### PR TITLE
Move private structures into TransTable

### DIFF
--- a/src/TransTable.cpp
+++ b/src/TransTable.cpp
@@ -420,7 +420,7 @@ double TransTable::MemoryInUse()
 }
 
 
-winBlockType * TransTable::GetNextCardBlock()
+TransTable::winBlockType * TransTable::GetNextCardBlock()
 {
   /*
      Spaghetti code.  The basic idea is that there is a pool of
@@ -717,7 +717,7 @@ nodeCardsType * TransTable::Lookup(
 }
 
 
-winBlockType * TransTable::LookupSuit(
+TransTable::winBlockType * TransTable::LookupSuit(
   distHashType		* dp,
   long long 		key,
   bool			* empty)
@@ -1475,7 +1475,7 @@ void TransTable::PrintSummarySuitStats()
 }
 
 
-winBlockType * TransTable::FindMatchingDist(
+TransTable::winBlockType * TransTable::FindMatchingDist(
   int			trick,
   int			hand,
   int			handDistSought[DDS_HANDS])

--- a/src/TransTable.h
+++ b/src/TransTable.h
@@ -42,18 +42,20 @@
 #define HISTSIZE		100000
 
 
+// Also used in ABSearch
+struct nodeCardsType // 8 bytes
+{
+  char      ubound; // For N-S
+  char      lbound; // For N-S
+  char      bestMoveSuit;
+  char      bestMoveRank;
+  char      leastWin[DDS_SUITS];
+};
+
+
 class TransTable
 {
   private:
-
-    struct nodeCardsType // 8 bytes
-    {
-      char      ubound; // For N-S
-      char      lbound; // For N-S
-      char      bestMoveSuit;
-      char      bestMoveRank;
-      char      leastWin[DDS_SUITS];
-    };
 
     struct winMatchType // 52 bytes
     {


### PR DESCRIPTION
Note the tabs above that let you switch between the "Conversation", "Commits", and "Files changed".

I noticed there was a comment in the code that originally said:

```
// Not clear to me why I can't put the following structs in     
// the private part of the class as well.  But for some reason      
// compilation fails then.
```

I wouldn't be sure why it wouldn't work either...and in fact, I moved it in and it did compile.  So as a sample of starting a discussion in issues and pull requests (vs email) I thought I'd send this as a pull request.  You can add comments here, and we could have a feedback loop which would add more commits to this branch (that I called `private-struct-transtable`) if they were needed.

For now, this branch only exists in **hostilefork/dds** (and on my local machine which is where I pushed it from).  Ultimately what would happen is that these would be either rejected or accepted and pulled into the **dds-bridge/dds** repository.  If you wanted to, you could pull them into **sorenhein/dds** to work with yourself.
