### PR TITLE
Move UNUSED out of C++11-dependent #ifdef

### DIFF
--- a/src/portab.h
+++ b/src/portab.h
@@ -52,13 +52,15 @@
 #endif
 
 
-// In C++11 UNUSED(x) is explicitly provided
+// http://stackoverflow.com/a/4030983/211160
+// Use to indicate a variable is being intentionally not referred to (which
+// usually generates a compiler warning)
+#ifndef UNUSED
+#define UNUSED(x) ((void)(true ? 0 : ((x), void(), 0)))
+#endif
+
+
 #if __cplusplus <= 199711L
-  #if defined (_MSC_VER)
-    #define UNUSED(x) (void) (x);
-  #else
-    #define UNUSED(x) (void) (sizeof((x), 0))
-  #endif
   #ifndef __clang__
      #define nullptr NULL
   #endif


### PR DESCRIPTION
[The code says](https://github.com/dds-bridge/dds/pull/4/files#diff-f077def8d1d46ce3832e5ddabf7f524dL55):

```
// In C++11 UNUSED(x) is explicitly provided
```

But that isn't true.  **nullptr** is explicitly provided, however, in C++11.

What is true is that there are a bunch of codebases that define this exact macro somewhere.  But it should not be necessary to write it conditionally for MS compilers.

In a technical sense, the name USE may be better.  The reason is because UNUSED might end up being a lie--there's nothing stopping one from later adding a reference to the so-called UNUSED thing, no error will be caused.
