### PR TITLE
Add a .gitignore file to avoid seeing or checking in binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+!.gitignore
+*.o
+*.a
+*.dll
+*.obj
+*.exe
+src/[Mm]akefile
+test/[Mm]akefile
+test/dtest
+test/itest


### PR DESCRIPTION
Here's a helpful little thing to do, which is to exclude certain file types and filenames that we never want to see make it into version control.

The first line starts with an exclamation point because we don't want to ignore the .gitignore file.  That is to say--when we come up with new ways of filtering the files seen by version control, we want to be able to check those new ways in so others will get them. (Files beginning with periods are ignored by default, and hidden in directory listings by the OS also.)

Then we say don't track .o or .a files, or when someone has copied a Makefile into the src or test directory, or the test executables.  Should be a little bit of a help, feel free to add some more if you notice files that should-not-be-checked-in on other platform builds.
