### PR TITLE
Bug fix affecting solve with given moves

### DIFF
--- a/src/SolverIF.cpp
+++ b/src/SolverIF.cpp
@@ -238,7 +238,29 @@ int STDCALL SolveBoard(
   {
     mv.rank = dl.currentTrickRank[k];
     mv.suit = dl.currentTrickSuit[k];
-    mv.sequence = dl.currentTrickSuit[k];
+    mv.sequence = 0;
+
+    thrp->moves.Init(
+      trick,
+      k,
+      dl.currentTrickRank,
+      dl.currentTrickSuit,
+      thrp->lookAheadPos.rankInSuit,
+      thrp->trump,
+      thrp->lookAheadPos.first[iniDepth]);
+
+    if (k == 0)
+      thrp->moves.MoveGen0(
+        trick,
+        &thrp->lookAheadPos,
+        &thrp->bestMove[iniDepth],
+        &thrp->bestMoveTT[iniDepth],
+        thrp->rel);
+    else
+      thrp->moves.MoveGen123(
+        trick,
+        k,
+        &thrp->lookAheadPos);
 
     thrp->lookAheadPos.move[iniDepth + handRelFirst - k] = mv;
     thrp->moves.MakeSpecific(&mv, trick, k);


### PR DESCRIPTION
Actually two bugs, the first one with no known effect:  mv.sequence should of course
be 0 to begin with.

The move object was not being initialized prior to insertion of a given move.
