### PR TITLE
Bug fix: Scheduler wrongly found some hands to be identical

### DIFF
--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -72,6 +72,7 @@ class Scheduler
     {
       int next;
       int spareKey;
+      unsigned remainCards[DDS_HANDS][DDS_SUITS];
       int NTflag;
       int first;
       int strain;
@@ -137,6 +138,10 @@ class Scheduler
       boards * bop);
 
     void FinetuneGroups();
+
+    bool SameHand(
+      int hno1,
+      int hno2);
 
     void SortSolve(),
          SortCalc(),


### PR DESCRIPTION
The old test was rather heuristic and adequate for random distributions
in a batch.  But it was not good enough for distributions that are explicitly
generated to be similar, such as distributions with two given hands
(dummy and a defender) and other hands consistent with the bidding.

The heuristic test is now better, and it is followed by a rigorous test
among the remaining candidates.
