### PR TITLE
Fix compiler warnings on platforms where char is unsigned

### DIFF
--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -531,7 +531,7 @@ void SetDealTables(
     for (int s = 0; s < DDS_SUITS; s++)
     {
       relp->absRank[1][s].hand =
-        static_cast<char>(handLookup[s][topBitNo]);
+        static_cast<signed char>(handLookup[s][topBitNo]);
       relp->absRank[1][s].rank = static_cast<char>(topBitNo);
     }
   }

--- a/src/TransTableL.cpp
+++ b/src/TransTableL.cpp
@@ -1025,8 +1025,8 @@ void TransTableL::PrintNodeValues(
     cardSuit[3] << cardRank[15-static_cast<int>(np.leastWin[3])] << "\n";
 
   fout << setw(16) << left << "Bounds" << 
-    to_string(np.lbound) << " to " <<
-    to_string(np.ubound) << " tricks\n";
+    to_string(static_cast<int>(np.lbound)) << " to " <<
+    to_string(static_cast<int>(np.ubound)) << " tricks\n";
 
   fout << setw(16) << left << "Best move" <<
     cardSuit[ static_cast<int>(np.bestMoveSuit) ] <<


### PR DESCRIPTION
If char is unsigned, there were two warnings that made the build fail
because of `-Werror=sign-promo`:

Init.cpp: In function 'void SetDealTables(ThreadData*)':
Init.cpp:534:9: error: conversion to 'signed char' from 'char' may change the sign of the result [-Werror=sign-conversion]
         static_cast<char>(handLookup[s][topBitNo]);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

TransTableL.cpp: In member function ‘void TransTableL::PrintNodeValues(std::ofstream&, const nodeCardsType&) const’:
TransTableL.cpp:1028:24: error: passing ‘char’ chooses ‘int’ over ‘unsigned int’ [-Werror=sign-promo]
     to_string(np.lbound) << " to " <<
                        ^

Seen on Debian's buildds: https://buildd.debian.org/status/fetch.php?pkg=dds&arch=ppc64el&ver=2.9.0-2&stamp=1537788660&raw=0