### PR TITLE
Drop -mtune=generic

### DIFF
--- a/examples/Makefiles/Makefile_linux
+++ b/examples/Makefiles/Makefile_linux
@@ -8,7 +8,7 @@
 # If your compiler name is not given here, change it.
 CC		= g++
 
-CC_FLAGS	= -O3 -flto -mtune=generic -fopenmp
+CC_FLAGS	= -O3 -flto -fopenmp
 
 # These flags are not turned on by default, but DDS should pass them.
 # Turn them on below.

--- a/src/Makefiles/Makefile_linux_shared
+++ b/src/Makefiles/Makefile_linux_shared
@@ -81,7 +81,7 @@ WARN_FLAGS	= 		\
 	-Wno-long-long		\
 	-Wno-format
 
-COMPILE_FLAGS	= -fPIC -O3 -flto -fopenmp -mtune=generic -std=c++11 \
+COMPILE_FLAGS	= -fPIC -O3 -flto -fopenmp -std=c++11 \
 		$(WARN_FLAGS) \
 		$(DDS_BEHAVIOR) $(THREAD_COMPILE) $(THREADING)
 

--- a/src/Makefiles/Makefile_linux_static
+++ b/src/Makefiles/Makefile_linux_static
@@ -86,7 +86,7 @@ WARN_FLAGS	= 		\
 	-Wno-long-long		\
 	-Wno-format
 
-COMPILE_FLAGS	= -O3 -flto -fopenmp -mtune=generic -std=c++11 \
+COMPILE_FLAGS	= -O3 -flto -fopenmp -std=c++11 \
 		$(WARN_FLAGS) \
 		$(DDS_BEHAVIOR) $(THREAD_COMPILE) $(THREADING)
 

--- a/test/Makefiles/Makefile_linux
+++ b/test/Makefiles/Makefile_linux
@@ -61,7 +61,7 @@ WARN_FLAGS	= 		\
         -Wno-odr                \
 	-Wno-format
 
-COMPILE_FLAGS	= -O3 -flto -fopenmp -mtune=generic \
+COMPILE_FLAGS	= -O3 -flto -fopenmp \
 		$(WARN_FLAGS)
 
 DLLBASE		= dds


### PR DESCRIPTION
"-mtune=generic" works on x86 only and fails on all other architectures.

Failing build logs: https://buildd.debian.org/status/logs.php?pkg=dds&ver=2.9.0-1