### PR TITLE
In C mode, include <stdbool.h>

### DIFF
--- a/include/dll.h
+++ b/include/dll.h
@@ -24,6 +24,7 @@
   #define EXTERN_C extern "C"
 #else
   #define EXTERN_C
+  #include <stdbool.h> // make "bool" available
 #endif
 
 /* Version 2.9.0. Allowing for 2 digit minor versions */


### PR DESCRIPTION
When compiling with a C compiler, "bool" is not defined, so include
<stdbool.h> to make it available.