### PR TITLE
Avoid nullptr access

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -37,7 +37,7 @@ void Memory::ResetThread(const unsigned thrId)
 
 void Memory::ReturnThread(const unsigned thrId)
 {
-  if(memory[thrId] == nullptr) return;
+  if(memory[thrId] == nullptr || memory[thrId]->transTable == nullptr) return;
   memory[thrId]->transTable->ReturnAllMemory();
   memory[thrId]->memUsed = Memory::MemoryInUseMB(thrId);
 }

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -37,6 +37,7 @@ void Memory::ResetThread(const unsigned thrId)
 
 void Memory::ReturnThread(const unsigned thrId)
 {
+  if(memory[thrId] == nullptr) return;
   memory[thrId]->transTable->ReturnAllMemory();
   memory[thrId]->memUsed = Memory::MemoryInUseMB(thrId);
 }


### PR DESCRIPTION
Merely loading libdds.so on Ubuntu crashes the parent program on exit. To repro, run the following python command:

    python -c 'from ctypes import *; dll = CDLL("libdds.so");'

I chased it down to trying to release memory on exit. It looks like the logic behind freeing the memory is broken, when the thread count is less than what's in the array. One might argue that this fix fixes the symptom, but it's better to avoid accessing pointers blindly.

This fix fixes the problem only on 18.04. On 16.04 it seems we are hitting the following line from Memory.cpp:

    cout << "Memory::GetPtr: " << thrId << " vs. " << nThreads << endl;

From a quick inspection of the code, I expect to be similar issue. Haven't spent the time debugging it yet.