### PR TITLE
Avoid OOB memory access + shrink Memory members

### DIFF
--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -28,8 +28,6 @@ void InitConstants();
 
 void InitDebugFiles();
 
-void FreeThreadMem();
-
 
 int lho[DDS_HANDS] = { 1, 2, 3, 0 };
 int rho[DDS_HANDS] = { 3, 0, 1, 2 };
@@ -594,13 +592,6 @@ void ResetBestMoves(
 void STDCALL GetDDSInfo(DDSInfo * info)
 {
   (void) sysdep.str(info);
-}
-
-
-void FreeThreadMem()
-{
-  for (unsigned thrId = 0; thrId < sysdep.NumThreads(); thrId++)
-    memory.ResetThread(thrId);
 }
 
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -350,7 +350,7 @@ void InitConstants()
 
 void InitDebugFiles()
 {
-  for (unsigned thrId = 0; thrId < sysdep.NumThreads(); thrId++)
+  for (unsigned thrId = 0; thrId < memory.NumThreads(); thrId++)
   {
     ThreadData * thrp = memory.GetPtr(thrId);
     UNUSED(thrp); // To avoid compile errors
@@ -390,7 +390,7 @@ void InitDebugFiles()
 
 void CloseDebugFiles()
 {
-  for (unsigned thrId = 0; thrId < sysdep.NumThreads(); thrId++)
+  for (unsigned thrId = 0; thrId < memory.NumThreads(); thrId++)
   {
     ThreadData * thrp = memory.GetPtr(thrId);
     UNUSED(thrp); // To avoid compiler warning
@@ -597,7 +597,7 @@ void STDCALL GetDDSInfo(DDSInfo * info)
 
 void STDCALL FreeMemory()
 {
-  for (unsigned thrId = 0; thrId < sysdep.NumThreads(); thrId++)
+  for (unsigned thrId = 0; thrId < memory.NumThreads(); thrId++)
     memory.ReturnThread(thrId);
 }
 

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -28,13 +28,6 @@ void Memory::Reset()
 }
 
 
-void Memory::ResetThread(const unsigned thrId)
-{
-  memory[thrId]->transTable->ResetMemory(TT_RESET_FREE_MEMORY);
-  memory[thrId]->memUsed = Memory::MemoryInUseMB(thrId);
-}
-
-
 void Memory::ReturnThread(const unsigned thrId)
 {
   memory[thrId]->transTable->ReturnAllMemory();

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -42,7 +42,6 @@ void Memory::Resize(
     // Downsize.
     for (unsigned i = n; i < memory.size(); i++)
     {
-      memory[i]->transTable->ReturnAllMemory();
       delete memory[i]->transTable;
       delete memory[i];
     }

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -13,18 +13,11 @@
 
 Memory::Memory()
 {
-  Memory::Reset();
 }
 
 
 Memory::~Memory()
 {
-}
-
-
-void Memory::Reset()
-{
-  nThreads = 0;
 }
 
 
@@ -41,13 +34,13 @@ void Memory::Resize(
   const int memDefault_MB,
   const int memMaximum_MB)
 {
-  if (nThreads == n)
+  if (memory.size() == n)
     return;
 
-  if (nThreads > n)
+  if (memory.size() > n)
   {
     // Downsize.
-    for (unsigned i = n; i < nThreads; i++)
+    for (unsigned i = n; i < memory.size(); i++)
     {
       memory[i]->transTable->ReturnAllMemory();
       delete memory[i]->transTable;
@@ -59,9 +52,10 @@ void Memory::Resize(
   else
   {
     // Upsize.
+    unsigned oldSize = memory.size();
     memory.resize(n);
     threadSizes.resize(n);
-    for (unsigned i = nThreads; i < n; i++)
+    for (unsigned i = oldSize; i < n; i++)
     {
       memory[i] = new ThreadData;
       if (flag == DDS_TT_SMALL)
@@ -81,22 +75,20 @@ void Memory::Resize(
       memory[i]->transTable->MakeTT();
     }
   }
-
-  nThreads = n;
 }
 
 
-int Memory::NumThreads() const
+unsigned Memory::NumThreads() const
 {
-  return static_cast<int>(nThreads);
+  return static_cast<unsigned>(memory.size());
 }
 
 
 ThreadData * Memory::GetPtr(const unsigned thrId)
 {
-  if (thrId >= nThreads)
+  if (thrId >= memory.size())
   {
-    cout << "Memory::GetPtr: " << thrId << " vs. " << nThreads << endl;
+    cout << "Memory::GetPtr: " << thrId << " vs. " << memory.size() << endl;
     exit(1);
   }
   return memory[thrId];

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -18,6 +18,7 @@ Memory::Memory()
 
 Memory::~Memory()
 {
+  Memory::Resize(0, DDS_TT_SMALL, 0, 0);
 }
 
 

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -117,12 +117,6 @@ double Memory::MemoryInUseMB(const unsigned thrId) const
 }
 
 
-void Memory::ReturnAllMemory()
-{
-  Memory::Resize(0, DDS_TT_SMALL, 0, 0);
-}
-
-
 string Memory::ThreadSize(const unsigned thrId) const
 {
   return threadSizes[thrId];

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -145,8 +145,6 @@ class Memory
 
     double MemoryInUseMB(const unsigned thrId) const;
 
-    void ReturnAllMemory();
-
     string ThreadSize(const unsigned thrId) const;
 };
 

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -117,7 +117,6 @@ class Memory
   private:
 
     vector<ThreadData *> memory;
-    unsigned nThreads;
 
     vector<string> threadSizes;
 
@@ -127,8 +126,6 @@ class Memory
 
     ~Memory();
 
-    void Reset();
-
     void ReturnThread(const unsigned thrId);
 
     void Resize(
@@ -137,7 +134,7 @@ class Memory
       const int memDefault_MB,
       const int memMaximum_MB);
 
-    int NumThreads() const;
+    unsigned NumThreads() const;
 
     ThreadData * GetPtr(const unsigned thrId);
 

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -129,8 +129,6 @@ class Memory
 
     void Reset();
 
-    void ResetThread(const unsigned thrId);
-
     void ReturnThread(const unsigned thrId);
 
     void Resize(

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -274,12 +274,6 @@ bool System::IsIMPL() const
 }
 
 
-unsigned System::NumThreads() const
-{
-  return static_cast<unsigned>(numThreads);
-}
-
-
 bool System::ThreadOK(const int thrId) const
 {
   return (thrId >= 0 && thrId < numThreads);

--- a/src/System.h
+++ b/src/System.h
@@ -97,8 +97,6 @@ class System
 
     bool IsIMPL() const;
 
-    unsigned NumThreads() const;
-
     bool ThreadOK(const int thrId) const;
 
     void GetHardware(

--- a/src/dds.cpp
+++ b/src/dds.cpp
@@ -73,7 +73,6 @@ static void __attribute__ ((constructor)) libInit(void)
 static void __attribute__ ((destructor)) libEnd(void)
 {
   CloseDebugFiles();
-  FreeMemory();
 }
 
 #endif


### PR DESCRIPTION
Includes some defensive tweaks I applied while tracking down the cause of a segfault.

Fixes #91. Fixes the root cause of #89.