### PR TITLE
New DDS_NO_DUMP_ON_ERROR flag to skip dump.txt generation

### DIFF
--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -269,6 +269,7 @@ int DumpInput(
   const int solutions, 
   const int mode)
 {
+#ifndef DDS_NO_DUMP_ON_ERROR
   ofstream fout;
   fout.open("dump.txt");
 
@@ -307,6 +308,7 @@ int DumpInput(
   fout << PrintDeal(ranks, 8);
 
   fout.close();
+#endif
   return 0;
 }
 


### PR DESCRIPTION
It's not always useful to produce these files, so allow disabling their generation at compile time. This is a `NO` flag to avoid changing default behaviour.