### PR TITLE
Three tiny fixes to compile w/o warnings w/MSFT cl 19.24.28319

### DIFF
--- a/src/TimerGroup.cpp
+++ b/src/TimerGroup.cpp
@@ -86,7 +86,7 @@ void TimerGroup::Differentiate()
 {
   for (unsigned r = 0; r < timers.size()-1; r++)
   {
-    unsigned i = timers.size() - 1 - r;
+    size_t i = timers.size() - 1 - r;
     timers[i] -= timers[i-1];
   }
 }
@@ -149,7 +149,7 @@ string TimerGroup::TimerLines(const Timer& sumTotal) const
   string st = "";
   for (unsigned r = 0; r < timers.size(); r++)
   {
-    unsigned i = timers.size() - r - 1;
+    size_t i = timers.size() - r - 1;
     if (timers[i].Used())
       st += timers[i].SumLine(sumTotal);
   }

--- a/src/TransTableL.cpp
+++ b/src/TransTableL.cpp
@@ -1038,7 +1038,7 @@ string TransTableL::MakeHolding(
   const string& high,
   const unsigned len) const
 {
-  const unsigned l = high.size();
+  const size_t l = high.size();
   if (l == 0)
     return "-";
   else if (l == len)

--- a/test/parse.cpp
+++ b/test/parse.cpp
@@ -420,7 +420,7 @@ bool parse_DEALERPAR(
   const vector<string>& list,
   parResultsDealer * par)
 {
-  const unsigned l = list.size();
+  const size_t l = list.size();
   if (l < 3)
   {
     cout << "PAR2 list does not have 3+ elements: " << l << endl;
@@ -655,7 +655,7 @@ void splitIntoWords(
   bool isSpace = true;
 
   // It seems compilers have different ideas about files.
-  const unsigned tl = text.length();
+  const size_t tl = text.length();
   string ttext;
   if (text.back() == ' ')
     ttext = text.substr(0, tl-1);


### PR DESCRIPTION
Just 3 tiny s/unsigned/size_t/ necessary and sufficient to make w/o warnings on the latest CLI compiler from Microsoft Visual Studio.