### PR TITLE
Fix crash when unloading the library

### DIFF
--- a/src/Memory.h
+++ b/src/Memory.h
@@ -10,6 +10,7 @@
 #ifndef DDS_MEMORY_H
 #define DDS_MEMORY_H
 
+#include <memory>
 #include <vector>
 
 #include "TransTable.h"
@@ -78,7 +79,7 @@ struct ThreadData
   // 960 KB
   relRanksType rel[8192];
 
-  TransTable * transTable;
+  std::unique_ptr<TransTable> transTable;
 
   Moves moves;
 
@@ -116,7 +117,7 @@ class Memory
 {
   private:
 
-    vector<ThreadData *> memory;
+    vector<ThreadData> memory;
     unsigned nThreads;
 
     vector<string> threadSizes;

--- a/src/dds.cpp
+++ b/src/dds.cpp
@@ -33,8 +33,6 @@ extern "C" BOOL APIENTRY DllMain(
     SetMaxThreads(0);
   else if (ul_reason_for_call == DLL_PROCESS_DETACH)
   {
-    CloseDebugFiles();
-    FreeMemory();
 #ifdef DDS_MEMORY_LEAKS_WIN32
     _CrtDumpMemoryLeaks();
 #endif
@@ -58,8 +56,6 @@ void DDSInitialize(void)
 
 void DDSFinalize(void) 
 {
-  CloseDebugFiles();
-  FreeMemory();
 }
 
 #elif defined(USES_CONSTRUCTOR)
@@ -72,8 +68,6 @@ static void __attribute__ ((constructor)) libInit(void)
 
 static void __attribute__ ((destructor)) libEnd(void)
 {
-  CloseDebugFiles();
-  FreeMemory();
 }
 
 #endif


### PR DESCRIPTION
I noticed dds was causing crash in exit because libEnd was called after memory::~memory(). Static destructor are executed in unspecified order. To avoid order issues I decided to make changes which moves all memory cleanup code to automatically generated destructors using stl and std::unique_ptr memory management.

I noticed there is pull request #90. But it seems to have issues still so I decided to provide alternative attempt at fixing same issue.

