### PR TITLE
Make sure link time optimization sees same compiler flags

### DIFF
--- a/src/Makefiles/Makefile_linux_shared
+++ b/src/Makefiles/Makefile_linux_shared
@@ -94,7 +94,7 @@ O_FILES 	= $(subst .cpp,.o,$(SOURCE_FILES))
 
 LINK_FLAGS      =               \
         -shared                 \
-        -Wl,-O2                 \
+        ${COMPILE_FLAGS}        \
         -Wl,--sort-common       \
         -Wl,--as-needed         \
         -Wl,-z                  \


### PR DESCRIPTION
gcc prefers that link time optimization flags must be matching
for compile and link commands.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

"To use the link-time optimizer, -flto and optimization options
should be specified at compile time and during the final link."