### PR TITLE
Build on FreeBSD

### DIFF
--- a/examples/AnalyseAllPlaysBin.cpp
+++ b/examples/AnalyseAllPlaysBin.cpp
@@ -30,7 +30,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/AnalyseAllPlaysPBN.cpp
+++ b/examples/AnalyseAllPlaysPBN.cpp
@@ -30,7 +30,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/AnalysePlayBin.cpp
+++ b/examples/AnalysePlayBin.cpp
@@ -30,7 +30,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/AnalysePlayPBN.cpp
+++ b/examples/AnalysePlayPBN.cpp
@@ -28,7 +28,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/CalcAllTables.cpp
+++ b/examples/CalcAllTables.cpp
@@ -30,7 +30,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/CalcAllTablesPBN.cpp
+++ b/examples/CalcAllTablesPBN.cpp
@@ -30,7 +30,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/CalcDDtable.cpp
+++ b/examples/CalcDDtable.cpp
@@ -27,7 +27,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/CalcDDtablePBN.cpp
+++ b/examples/CalcDDtablePBN.cpp
@@ -27,7 +27,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/DealerPar.cpp
+++ b/examples/DealerPar.cpp
@@ -27,7 +27,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/Makefiles/Makefile_freebsd
+++ b/examples/Makefiles/Makefile_freebsd
@@ -1,5 +1,5 @@
 # This is a Makefile for the examples,
-# for Linux and the GNU g++ compiler.
+# for FreeBSD and the clang c++ compiler.
 
 # It does assume a Unix-like setup for some commands,
 # but if you only want to call "make" with the default target,

--- a/examples/Makefiles/Makefile_freebsd
+++ b/examples/Makefiles/Makefile_freebsd
@@ -1,0 +1,117 @@
+# This is a Makefile for the examples,
+# for Linux and the GNU g++ compiler.
+
+# It does assume a Unix-like setup for some commands,
+# but if you only want to call "make" with the default target,
+# you should be OK.
+
+# If your compiler name is not given here, change it.
+CC		= c++
+
+CC_FLAGS	= -O3 -flto -fopenmp
+
+# These flags are not turned on by default, but DDS should pass them.
+# Turn them on below.
+WARN_FLAGS	= 		\
+	-Wshadow 		\
+	-Wsign-conversion 	\
+	-pedantic -Wall -Wextra  \
+	-Wcast-align -Wcast-qual \
+	-Wctor-dtor-privacy 	\
+	-Wdisabled-optimization \
+	-Winit-self 		\
+	-Wmissing-declarations 	\
+	-Wmissing-include-dirs 	\
+	-Wold-style-cast 	\
+	-Woverloaded-virtual 	\
+	-Wredundant-decls 	\
+	-Wsign-promo 		\
+	-Wstrict-overflow=1 	\
+	-Wswitch-default -Wundef \
+	-Werror 		\
+	-Wno-unused 		\
+	-Wno-unknown-pragmas 	\
+	-Wno-long-long		\
+	-Wno-format
+
+# Here you can turn on warnings.
+# CC_FULL_FLAGS	= $(CC_FLAGS)
+CC_FULL_FLAGS	= $(CC_FLAGS) $(WARN_FLAGS)
+
+DLLBASE		= dds
+STATIC_LIB	= lib$(DLLBASE).a
+
+COMMON_SOURCE_FILES 	=	\
+	hands.cpp
+
+ALL_EXAMPLE_FILES	=	\
+	AnalysePlayBin		\
+	AnalysePlayPBN		\
+	AnalyseAllPlaysBin	\
+	AnalyseAllPlaysPBN	\
+	CalcDDtable.cpp		\
+	CalcDDtablePBN.cpp	\
+	CalcAllTables.cpp	\
+	CalcAllTablesPBN.cpp	\
+	DealerPar.cpp		\
+	Par.cpp			\
+	SolveBoard.cpp		\
+	SolveBoardPBN.cpp	\
+	SolveAllBoards.cpp
+
+LIB_FLAGS	= -L. -l$(DLLBASE)
+
+LD_FLAGS	= 
+
+OBJ_FILES	= $(COMMON_SOURCE_FILES:S/.cpp/.o/)
+EX_OBJ_FILES	= $(ALL_EXAMPLE_FILES:S/.cpp/.o/)
+EX_EXE_FILES	= $(ALL_EXAMPLE_FILES:S/.cpp//)
+
+AnalysePlayBin:	$(OBJ_FILES) AnalysePlayBin.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) AnalysePlayBin.o $(LIB_FLAGS) -o AnalysePlayBin
+
+AnalysePlayPBN:	$(OBJ_FILES) AnalysePlayPBN.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) AnalysePlayPBN.o $(LIB_FLAGS) -o AnalysePlayPBN
+
+AnalyseAllPlaysBin:	$(OBJ_FILES) AnalyseAllPlaysBin.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) AnalyseAllPlaysBin.o $(LIB_FLAGS) -o AnalyseAllPlaysBin
+
+AnalyseAllPlaysPBN:	$(OBJ_FILES) AnalyseAllPlaysPBN.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) AnalyseAllPlaysPBN.o $(LIB_FLAGS) -o AnalyseAllPlaysPBN
+
+CalcDDtable:	$(OBJ_FILES) CalcDDtable.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) CalcDDtable.o $(LIB_FLAGS) -o CalcDDtable
+
+CalcDDtablePBN:	$(OBJ_FILES) CalcDDtablePBN.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) CalcDDtablePBN.o $(LIB_FLAGS) -o CalcDDtablePBN
+
+CalcAllTables:	$(OBJ_FILES) CalcAllTables.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) CalcAllTables.o $(LIB_FLAGS) -o CalcAllTables
+
+CalcAllTablesPBN:	$(OBJ_FILES) CalcAllTablesPBN.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) CalcAllTablesPBN.o $(LIB_FLAGS) -o CalcAllTablesPBN
+
+DealerPar:	$(OBJ_FILES) DealerPar.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) DealerPar.o $(LIB_FLAGS) -o DealerPar
+
+Par:	$(OBJ_FILES) Par.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) Par.o $(LIB_FLAGS) -o Par
+
+SolveBoard:	$(OBJ_FILES) SolveBoard.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) SolveBoard.o $(LIB_FLAGS) -o SolveBoard
+
+SolveBoardPBN:	$(OBJ_FILES) SolveBoardPBN.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) SolveBoardPBN.o $(LIB_FLAGS) -o SolveBoardPBN
+
+SolveAllBoards:	$(OBJ_FILES) SolveAllBoards.o
+	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(OBJ_FILES) SolveAllBoards.o $(LIB_FLAGS) -o SolveAllBoards
+
+.cpp.o:
+	$(CC) $(CC_FULL_FLAGS) -c $< -o $@
+
+depend:
+	makedepend -Y -- $(cOMMON_SOURCE_FILES) $(ALL_EXAMPLE_FILES)
+
+clean:
+	rm -f $(OBJ_FILES) $(EX_OBJ_FILES) $(EX_EXE_FILES) $(STATIC_LIB)
+

--- a/examples/Par.cpp
+++ b/examples/Par.cpp
@@ -27,7 +27,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/SolveAllBoards.cpp
+++ b/examples/SolveAllBoards.cpp
@@ -27,7 +27,7 @@ int main()
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/SolveBoard.cpp
+++ b/examples/SolveBoard.cpp
@@ -33,7 +33,7 @@ int main()
   bool match2;
   bool match3;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/SolveBoardPBN.cpp
+++ b/examples/SolveBoardPBN.cpp
@@ -33,7 +33,7 @@ int main()
   bool match2,
                 match3;
 
-#if defined(__linux) || defined(__APPLE__)
+#if defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__)
   SetMaxThreads(0);
 #endif
 

--- a/include/portab.h
+++ b/include/portab.h
@@ -32,7 +32,7 @@
 
   #define USES_DLLMAIN
 
-#elif defined (__linux)
+#elif defined (__linux) || defined(__FreeBSD__)
   #include <unistd.h>
   #if !defined(DDS_NO_STATIC_INIT)
   #define USES_CONSTRUCTOR

--- a/src/Makefiles/Makefile_freebsd_shared
+++ b/src/Makefiles/Makefile_freebsd_shared
@@ -72,6 +72,7 @@ WARN_FLAGS	= 		\
 	-Wsign-promo 		\
 	-Wstrict-overflow=1 	\
 	-Wswitch-default -Wundef \
+	-Werror			\
 	-Wno-unused 		\
 	-Wno-unknown-pragmas 	\
 	-Wno-long-long		\

--- a/src/Makefiles/Makefile_freebsd_shared
+++ b/src/Makefiles/Makefile_freebsd_shared
@@ -1,0 +1,124 @@
+# --------------------- INFORMATION --------------------------------
+
+# This the DDS Makefile for Linux and the GNU g++ compiler.
+# It creates a dynamically linked (shared) library, libdds.so.
+
+# --------------------- CONFIGURATION ------------------------------
+
+# You can configure the following:
+
+# 1. The threading systems that you want in the library.
+# You will always get single-threading.  If you have multiple
+# threading systems, the default will be the multi-threading one
+# with the lowest number (see System.cpp).  All that matters is
+# CC_THREADING.
+
+# GCD and WINAPI don't work on Windows.
+THR_BOOST	= -DDDS_THREADS_BOOST
+THR_GCD		= -DDDS_THREADS_GCD
+THR_OPENMP	= -DDDS_THREADS_OPENMP
+THR_WINAPI	= -DDDS_THREADS_WINAPI
+THR_STL		= -DDDS_THREADS_STL
+
+THREADING	= $(THR_BOOST) $(THR_OPENMP) $(THR_STL)
+
+# If you need to add something for a threading system, this is
+# the place.
+
+CC_BOOST_LINK	= -lboost_system -lboost_thread
+
+THREAD_COMPILE	= -fopenmp
+THREAD_LINK	= -fopenmp $(CC_BOOST_LINK)
+
+# 2. Debugging options.  (There are more granular options in debug.h.)
+
+DEBUG_ALL	= -DDDS_DEBUG_ALL 
+TIMING		= -DDDS_TIMING
+SCHEDULER	= -DDDS_SCHEDULER
+
+# All that matters from no. 2 and no. 3 is the following.  Here you
+# can add $(SMALL_MEMORY) etc.
+
+DDS_BEHAVIOR	=
+
+# ----------------------- OFTEN OK    ------------------------------
+
+# From here on you you don't have to change anything to CONFIGURE
+# the compilation.  But you may well have to change something to 
+# get it to compile.
+
+INCL_SOURCE	= Makefiles/sources.txt
+INCL_DEPENDS	= Makefiles/depends_o.txt
+
+# If your compiler name is not given here, change it.
+CC		= c++
+
+# We compile with aggressive warnings, but we have to turn off some
+# of them as they appear in libraries in great numbers...
+
+WARN_FLAGS	= 		\
+	-Wshadow 		\
+	-Wsign-conversion 	\
+	-pedantic -Wall -Wextra  \
+	-Wcast-align -Wcast-qual \
+	-Wctor-dtor-privacy 	\
+	-Wdisabled-optimization \
+	-Winit-self 		\
+	-Wmissing-declarations 	\
+	-Wmissing-include-dirs 	\
+	-Wold-style-cast 	\
+	-Woverloaded-virtual 	\
+	-Wredundant-decls 	\
+	-Wsign-promo 		\
+	-Wstrict-overflow=1 	\
+	-Wswitch-default -Wundef \
+	-Wno-unused 		\
+	-Wno-unknown-pragmas 	\
+	-Wno-long-long		\
+	-Wno-format
+
+IFLAGS = -I/usr/local/include
+COMPILE_FLAGS	= -fPIC -O3 -flto -fopenmp -std=c++11 \
+		$(WARN_FLAGS) $(IFLAGS) \
+		$(DDS_BEHAVIOR) $(THREAD_COMPILE) $(THREADING)
+
+DLLBASE		= dds
+SHARED_LIB	= lib$(DLLBASE).so
+
+include $(INCL_SOURCE)
+
+O_FILES 	= $(SOURCE_FILES:S/cpp/o/)
+
+LINK_FLAGS      =               \
+        -shared                 \
+        ${COMPILE_FLAGS}        \
+        -Wl,--sort-common       \
+        -Wl,--as-needed         \
+        -Wl,-z                  \
+        -Wl,relro               \
+        $(THREAD_LINK)          \
+	-L/usr/local/lib        \
+        -fPIC
+
+
+linux:	$(O_FILES)
+	$(CC) \
+        -o $(SHARED_LIB) $(O_FILES) $(LINK_FLAGS)
+
+.cpp.o:
+	$(CC) $(COMPILE_FLAGS) -c $< -o $@
+
+depend:
+	makedepend -Y -- $(SOURCE_FILES)
+
+clean:
+	rm -f $(O_FILES) $(SHARED_LIB)
+
+install:
+	test -d ../test || mkdir ../test
+	test -d ../examples || mkdir ../examples
+	cp $(SHARED_LIB) ../test
+	cp $(SHARED_LIB) ../examples
+
+include $(INCL_DEPENDS)
+

--- a/src/Makefiles/Makefile_freebsd_shared
+++ b/src/Makefiles/Makefile_freebsd_shared
@@ -1,6 +1,6 @@
 # --------------------- INFORMATION --------------------------------
 
-# This the DDS Makefile for Linux and the GNU g++ compiler.
+# This the DDS Makefile for FreeBSD and the clang c++ compiler.
 # It creates a dynamically linked (shared) library, libdds.so.
 
 # --------------------- CONFIGURATION ------------------------------

--- a/src/Makefiles/Makefile_freebsd_static
+++ b/src/Makefiles/Makefile_freebsd_static
@@ -77,6 +77,7 @@ WARN_FLAGS	= 		\
 	-Wsign-promo 		\
 	-Wstrict-overflow=1 	\
 	-Wswitch-default -Wundef \
+	-Werror			\
 	-Wno-unused 		\
 	-Wno-unknown-pragmas 	\
 	-Wno-long-long		\

--- a/src/Makefiles/Makefile_freebsd_static
+++ b/src/Makefiles/Makefile_freebsd_static
@@ -1,0 +1,117 @@
+# --------------------- INFORMATION --------------------------------
+
+# This the DDS Makefile for Linux and the GNU g++ compiler.
+# It creates a statically linked library, libdds.a.
+
+# --------------------- CONFIGURATION ------------------------------
+
+# You can configure the following:
+
+# 1. The threading systems that you want in the library.
+# You will always get single-threading.  If you have multiple
+# threading systems, the default will be the multi-threading one
+# with the lowest number (see System.cpp).  All that matters is
+# CC_THREADING.
+
+# GCD and WINAPI don't work on Windows.
+THR_BOOST	= -DDDS_THREADS_BOOST
+THR_GCD		= -DDDS_THREADS_GCD
+THR_OPENMP	= -DDDS_THREADS_OPENMP
+THR_WINAPI	= -DDDS_THREADS_WINAPI
+THR_STL		= -DDDS_THREADS_STL
+
+THREADING	= $(THR_BOOST) $(THR_OPENMP) $(THR_STL)
+
+# If you need to add something for a threading system, this is
+# the place.
+
+CC_BOOST_LINK	= -lboost_system -lboost_thread
+
+THREAD_COMPILE	= -fopenmp
+THREAD_LINK	= $(CC_BOOST_LINK)
+
+# 2. The small memory option, which causes DDS to consume a lot less
+# memory and to run somewhat more slowly.
+
+SMALL_MEMORY	= -DSMALL_MEMORY_OPTION
+
+# 3. Debugging options.  (There are more granular options in debug.h.)
+
+DEBUG_ALL	= -DDDS_DEBUG_ALL 
+TIMING		= -DDDS_TIMING
+SCHEDULER	= -DDDS_SCHEDULER
+
+# All that matters from no. 2 and no. 3 is the following.  Here you
+# can add $(SMALL_MEMORY) etc.
+
+DDS_BEHAVIOR	=
+
+# ----------------------- OFTEN OK    ------------------------------
+
+# From here on you you don't have to change anything to CONFIGURE
+# the compilation.  But you may well have to change something to 
+# get it to compile.
+
+INCL_SOURCE	= Makefiles/sources.txt
+INCL_DEPENDS	= Makefiles/depends_o.txt
+
+# If your compiler name is not given here, change it.
+CC		= c++
+
+# We compile with aggressive warnings, but we have to turn off some
+# of them as they appear in libraries in great numbers...
+
+WARN_FLAGS	= 		\
+	-Wshadow 		\
+	-Wsign-conversion 	\
+	-pedantic -Wall -Wextra  \
+	-Wcast-align -Wcast-qual \
+	-Wctor-dtor-privacy 	\
+	-Wdisabled-optimization \
+	-Winit-self 		\
+	-Wmissing-declarations 	\
+	-Wmissing-include-dirs 	\
+	-Wold-style-cast 	\
+	-Woverloaded-virtual 	\
+	-Wredundant-decls 	\
+	-Wsign-promo 		\
+	-Wstrict-overflow=1 	\
+	-Wswitch-default -Wundef \
+	-Wno-unused 		\
+	-Wno-unknown-pragmas 	\
+	-Wno-long-long		\
+	-Wno-format
+
+IFLAGS = -I/usr/local/include
+COMPILE_FLAGS	= -O3 -flto -fopenmp -std=c++11 \
+		$(WARN_FLAGS) \
+		$(DDS_BEHAVIOR) $(THREAD_COMPILE) $(THREADING) $(IFLAGS)
+
+DLLBASE		= dds
+STATIC_LIB	= lib$(DLLBASE).a
+
+include $(INCL_SOURCE)
+
+O_FILES 	= $(SOURCE_FILES:S/.cpp/.o/)
+
+
+linux:	$(O_FILES)
+	ar rcs $(STATIC_LIB) $(O_FILES)
+
+.cpp.o:
+	$(CC) $(COMPILE_FLAGS) -c $<
+
+depend:
+	makedepend -Y -- $(SOURCE_FILES)
+
+clean:
+	rm -f $(O_FILES) $(STATIC_LIB)
+
+install:
+	test -d ../test || mkdir ../test
+	test -d ../examples || mkdir ../examples
+	cp $(STATIC_LIB) ../test
+	cp $(STATIC_LIB) ../examples
+
+include $(INCL_DEPENDS)
+

--- a/src/Makefiles/Makefile_freebsd_static
+++ b/src/Makefiles/Makefile_freebsd_static
@@ -1,6 +1,6 @@
 # --------------------- INFORMATION --------------------------------
 
-# This the DDS Makefile for Linux and the GNU g++ compiler.
+# This the DDS Makefile for FreeBSD and clang c++ compiler.
 # It creates a statically linked library, libdds.a.
 
 # --------------------- CONFIGURATION ------------------------------

--- a/src/Par.cpp
+++ b/src/Par.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <string.h>
+#include <stdio.h>
 
 #include "dds.h"
 #include "PBN.h"

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -33,7 +33,8 @@ const vector<string> DDS_SYSTEM_PLATFORM =
   "Windows",
   "Cygwin",
   "Linux",
-  "Apple"
+  "Apple",
+  "FreeBSD"
 };
 
 const vector<string> DDS_SYSTEM_COMPILER =
@@ -222,7 +223,7 @@ void System::GetHardware(
   return;
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
   // Use half of the physical memory
   long pages = sysconf (_SC_PHYS_PAGES);
   long pagesize = sysconf (_SC_PAGESIZE);
@@ -645,6 +646,8 @@ string System::GetSystem(int& sys) const
   sys = 3;
 #elif defined(__APPLE__)
   sys = 4;
+#elif defined(__FreeBSD__)
+  sys = 5;
 #else
   sys = 0;
 #endif

--- a/src/TransTable.h
+++ b/src/TransTable.h
@@ -51,7 +51,7 @@ struct nodeCardsType // 8 bytes
   #pragma warning(disable: 4100)
 #endif
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || (defined(__FreeBSD__) && defined (__clang__))
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
@@ -154,7 +154,7 @@ class TransTable
   #pragma warning(pop)
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || (defined(__FreeBSD__) && defined(__clang__))
   #pragma clang diagnostic pop
 #endif
 

--- a/src/TransTable.h
+++ b/src/TransTable.h
@@ -51,7 +51,7 @@ struct nodeCardsType // 8 bytes
   #pragma warning(disable: 4100)
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunused-parameter"
 #endif

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -13,15 +13,23 @@
 // Boost: Disable some header warnings.
 
 #ifdef DDS_THREADS_BOOST
-  #ifdef _MSC_VER
+  #if defined(_MSC_VER)
     #pragma warning(push)
     #pragma warning(disable: 4061 4191 4619 4623 5031)
+  #elif defined(__clang__) && defined(__FreeBSD__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wold-style-cast"
+    #pragma clang diagnostic ignored "-Wsign-conversion"
+    #pragma clang diagnostic ignored "-Wundef"
+    #pragma clang diagnostic ignored "-Wc11-extensions"
   #endif
 
   #include <boost/thread.hpp>
 
-  #ifdef _MSC_VER
+  #if defined(_MSC_VER)
     #pragma warning(pop)
+  #elif defined(__clang__) && defined(__FreeBSD__)
+    #pragma clang diagnostic pop
   #endif
 #endif
 

--- a/test/Makefiles/Makefile_freebsd
+++ b/test/Makefiles/Makefile_freebsd
@@ -1,0 +1,116 @@
+# --------------------- INFORMATION --------------------------------
+
+# This the test Makefile for Linux and the GNU g++ compiler.
+# It assumes a Unix-like setup for some commands.
+
+# The dtest program itself does not use multi-threading, 
+# but the library might, depending on how it was compiled.
+
+# The Makefile also allows an "un-official" and ugly, but
+# sometimes practical compilation of a directly integrated
+# executable (i.e. not using the DLL).  For this the Makefile
+# uses the source and object files in the src directory...
+# Use "make itest" at your own risk.
+
+# If you need to add something for the threading system, this is
+# the place.
+
+CC_BOOST_LINK	= -lboost_system -lboost_thread
+
+THREAD_LINK	= $(CC_BOOST_LINK)
+
+# ----------------------- OFTEN OK    ------------------------------
+
+# From here on you you don't have to change anything to CONFIGURE
+# the compilation.  But you may well have to change something to 
+# get it to compile.
+
+INCL_DDS_SOURCE	= Makefiles/dds_sources.txt
+INCL_OWN_SOURCE	= Makefiles/own_sources.txt
+INCL_DEPENDS	= Makefiles/depends_o.txt
+
+# If your compiler name is not given here, change it.
+CC		= c++
+
+# We compile with aggressive warnings, but we have to turn off some
+# of them as they appear in libraries in great numbers...
+
+WARN_FLAGS	= 		\
+	-Wshadow 		\
+	-Wsign-conversion 	\
+	-pedantic -Wall -Wextra  \
+	-Wcast-align -Wcast-qual \
+	-Wctor-dtor-privacy 	\
+	-Wdisabled-optimization \
+	-Winit-self 		\
+	-Wmissing-declarations 	\
+	-Wmissing-include-dirs 	\
+	-Wold-style-cast 	\
+	-Woverloaded-virtual 	\
+	-Wredundant-decls 	\
+	-Wsign-promo 		\
+	-Wstrict-overflow=1 	\
+	-Wswitch-default -Wundef \
+	-Werror 		\
+	-Wno-unused 		\
+	-Wno-unknown-pragmas 	\
+	-Wno-long-long		\
+        -Wno-odr                \
+	-Wno-format
+
+IFLAGS		= -I/usr/local/include
+COMPILE_FLAGS	= -O3 -flto -fopenmp \
+		$(WARN_FLAGS) $(IFLAGS)
+
+DLLBASE		= dds
+STATIC_LIB	= lib$(DLLBASE).a
+DLIB 		= $(DLLBASE).lib
+
+LFLAGS		= -L/usr/local/lib
+LINK1_FLAGS	= $(LFLAGS)
+LINK2_FLAGS	= -Wl,-rpath=. 	\
+		$(THREAD_LINK) $(LFLAGS) \
+		-L. -l$(DLLBASE)
+LINK3_FLAGS	= -Wl,-rpath=. 	\
+		$(THREAD_LINK) $(LFLAGS)
+
+# This is in addition to $(DTEST).cpp
+
+include $(INCL_OWN_SOURCE)
+
+DTEST_OBJ_FILES	= $(DTEST_SOURCE_FILES:S/cpp/o/) $(DTEST).o
+
+DTEST		= dtest
+ITEST		= itest
+
+# These are the files that we steal from the src directory.
+
+include $(INCL_DDS_SOURCE)
+
+ITEST_SOURCE_FILES	=	\
+	$(DDS_SOURCE_FILES)	\
+	$(DTEST_SOURCE_FILES)	\
+	itest.cpp
+
+ITEST_OBJ_FILES	= $(ITEST_SOURCE_FILES:S/cpp/o/)
+
+dtest:	$(DTEST_OBJ_FILES)
+	$(CC) $(COMPILE_FLAGS) $(LINK1_FLAGS) $(DTEST_OBJ_FILES) \
+	$(LINK2_FLAGS) -o $(DTEST)
+
+itest:	$(ITEST_OBJ_FILES)
+	$(CC) $(COMPILE_FLAGS) $(LINK1_FLAGS) $(ITEST_OBJ_FILES) \
+	$(LINK3_FLAGS) -o $(ITEST)
+
+.cpp.o:
+	$(CC) $(COMPILE_FLAGS) -c $< -o $*.o
+
+depend:
+	makedepend -Y -- $(ITEST_SOURCE_FILES) $(DTEST).cpp
+
+clean:
+	rm -f $(ITEST_OBJ_FILES) $(DTEST).o \
+	$(DTEST) $(ITEST) $(STATIC_LIB)
+
+include $(INCL_DEPENDS)
+

--- a/test/Makefiles/Makefile_freebsd
+++ b/test/Makefiles/Makefile_freebsd
@@ -1,6 +1,6 @@
 # --------------------- INFORMATION --------------------------------
 
-# This the test Makefile for Linux and the GNU g++ compiler.
+# This the test Makefile for FreeBSD and the clang c++ compiler.
 # It assumes a Unix-like setup for some commands.
 
 # The dtest program itself does not use multi-threading, 


### PR DESCRIPTION
Hi! Thanks for creating this library. I found myself needing to compile it on FreeBSD (with clang and BSD make which are the default on that platform) so I thought I'd share the changes I had to make:

* added makefiles for the main library (static & shared), test and examples
* added `stdio.h` to `Par.cpp` for `snprintf`
* remove the `-Wlogical-op`, `-Wnoexcept` and `Wstrict-null-sentinel` flags because clang 10 on FreeBSD doesn't recognise them
* turn off some more warnings in `System.cpp` caused by clang with boost
* added checks for the `__FreeBSD__` compiler macro where appropriate