### PR TITLE
Fix examples/Makefiles/Makefile_linux

### DIFF
--- a/examples/Makefiles/Makefile_linux
+++ b/examples/Makefiles/Makefile_linux
@@ -62,7 +62,8 @@ ALL_EXAMPLE_FILES	=	\
 	SolveBoardPBN.cpp	\
 	SolveAllBoards.cpp
 
-LIB_FLAGS	= -L. -l$(DLLBASE)
+LIB_FLAGS	= -Wl,-rpath=. \
+               -L. -l$(DLLBASE)
 
 LD_FLAGS	= 
 


### PR DESCRIPTION
Compiled examples reports: "error while loading shared libraries: libdds.so: cannot open shared object file: No such file or directory". This PR fixes it.