### PR TITLE
Update makefiles for MSYS2/MinGW-w64

### DIFF
--- a/examples/Makefiles/Makefile_mingw
+++ b/examples/Makefiles/Makefile_mingw
@@ -16,13 +16,7 @@
 
 
 # If your exact compiler name is not given here, change it.
-# CC		= mingw32-g++
-CC		= i686-w64-mingw32-g++
-
-# Use this one to get Windows multi-threading
-# CC_FLAGS	= -O3 -flto -mtune=generic
-# Use this one to get OpenMP multi-threading
-CC_FLAGS	= -O3 -flto -fopenmp -mtune=generic
+# CXX	= g++
 
 # These flags are not turned on by default, but DDS should pass them.
 # Turn them on below.
@@ -51,22 +45,20 @@ WARN_FLAGS	= 		\
 	-Wno-long-long		\
 	-Wno-format
 
-# Here you can turn on warnings.
-# CC_FULL_FLAGS	= $(CC_FLAGS)
-CC_FULL_FLAGS	= $(CC_FLAGS) $(WARN_FLAGS)
+CXXFLAGS	= -O3 -mms-bitfields -flto -mtune=generic \
+	$(WARN_FLAGS) -I../include \
+	-DNDEBUG -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -D_CONSOLE -DWIN32CON -D_LIB
 
 DLLBASE		= dds
-DLL 		= $(DLLBASE).dll
-EXPORTER	= Exports.def
 
 COMMON_SOURCE_FILES 	=	\
 	hands.cpp
 
 ALL_EXAMPLE_FILES	=	\
-	AnalysePlayBin		\
-	AnalysePlayPBN		\
-	AnalyseAllPlaysBin	\
-	AnalyseAllPlaysPBN	\
+	AnalysePlayBin.cpp	\
+	AnalysePlayPBN.cpp	\
+	AnalyseAllPlaysBin.cpp	\
+	AnalyseAllPlaysPBN.cpp	\
 	CalcDDtable.cpp		\
 	CalcDDtablePBN.cpp	\
 	CalcAllTables.cpp	\
@@ -77,76 +69,34 @@ ALL_EXAMPLE_FILES	=	\
 	SolveBoardPBN.cpp	\
 	SolveAllBoards.cpp
 
-LD_FLAGS	= 		\
-	-Wl,--subsystem,windows \
-	-Wl,--output-def,$(DLLBASE).def	\
+LDFLAGS	= -s -mconsole -flto	\
 	-Wl,--dynamicbase 	\
 	-Wl,--nxcompat 		\
 	-Wl,--no-seh 		\
 	-Wl,--enable-stdcall-fixup
 
-LIB_FLAGS	= -L. -l$(DLLBASE)
+LDLIBS	= -static -L. -l$(DLLBASE)
 
 OBJ_FILES	= $(subst .cpp,.o,$(COMMON_SOURCE_FILES))
 EX_OBJ_FILES	= $(subst .cpp,.o,$(ALL_EXAMPLE_FILES))
 EX_EXE_FILES	= $(subst .cpp,.exe,$(ALL_EXAMPLE_FILES))
 
-AnalysePlayBin:	$(OBJ_FILES) AnalysePlayBin.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) AnalysePlayBin.o -o AnalysePlayBin
+.PHONY: all depend clean
 
-AnalysePlayPBN:	$(OBJ_FILES) AnalysePlayPBN.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) AnalysePlayPBN.o -o AnalysePlayPBN
+all: $(EX_EXE_FILES)
 
-AnalyseAllPlaysBin:	$(OBJ_FILES) AnalyseAllPlaysBin.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) AnalyseAllPlaysBin.o -o AnalyseAllPlaysBin
-
-AnalyseAllPlaysPBN:	$(OBJ_FILES) AnalyseAllPlaysPBN.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) AnalyseAllPlaysPBN.o -o AnalyseAllPlaysPBN
-
-CalcDDtable:	$(OBJ_FILES) CalcDDtable.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) CalcDDtable.o -o CalcDDtable
-
-CalcDDtablePBN:	$(OBJ_FILES) CalcDDtablePBN.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) CalcDDtablePBN.o -o CalcDDtablePBN
-
-CalcAllTables:	$(OBJ_FILES) CalcAllTables.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) CalcAllTables.o -o CalcAllTables
-
-CalcAllTablesPBN:	$(OBJ_FILES) CalcAllTablesPBN.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) CalcAllTablesPBN.o -o CalcAllTablesPBN
-
-DealerPar:	$(OBJ_FILES) DealerPar.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) DealerPar.o -o DealerPar
-
-Par:	$(OBJ_FILES) Par.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) Par.o -o Par
-
-SolveBoard:	$(OBJ_FILES) SolveBoard.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) SolveBoard.o -o SolveBoard
-
-SolveBoardPBN:	$(OBJ_FILES) SolveBoardPBN.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) SolveBoardPBN.o -o SolveBoardPBN
-
-SolveAllBoards:	$(OBJ_FILES) SolveAllBoards.o
-	$(CC) $(CC_FULL_FLAGS) $(LD_FLAGS) $(LIB_FLAGS) $(OBJ_FILES) SolveAllBoards.o -o SolveAllBoards
+%.exe: $(OBJ_FILES) %.o
+	$(CXX) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 %.o:	%.cpp
-	$(CC) $(CC_FULL_FLAGS) -c $< -o $*.o
+	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 depend:
-	makedepend -Y -- $(cOMMON_SOURCE_FILES) $(ALL_EXAMPLE_FILES)
+	makedepend -Y -- $(COMMON_SOURCE_FILES) $(ALL_EXAMPLE_FILES)
 
 clean:
-	rm -f *.o *.exe $(DLL) $(DLLBASE).def
+	$(RM) *.exe *.o
 
 # DO NOT DELETE
+.PRECIOUS: $(OBJ_FILES) $(EX_OBJ_FILES)
 
-CalcDDtable.o: ../include/dll.h hands.h
-CalcDDtablePBN.o: ../include/dll.h hands.h
-CalcAllTables.o: ../include/dll.h hands.h
-CalcAllTablesPBN.o: ../include/dll.h hands.h
-DealerPar.o: ../include/dll.h hands.h
-Par.o: ../include/dll.h hands.h
-SolveBoard.o: ../include/dll.h hands.h
-SolveBoardPBN.o: ../include/dll.h hands.h
-SolveAllBoards.o: ../include/dll.h hands.h

--- a/src/Makefiles/Makefile_mingw
+++ b/src/Makefiles/Makefile_mingw
@@ -25,15 +25,13 @@ THR_OPENMP	= -DDDS_THREADS_OPENMP
 THR_WINAPI	= -DDDS_THREADS_WINAPI
 THR_STL		= -DDDS_THREADS_STL
 
-THREADING	= $(THR_BOOST) $(THR_OPENMP) $(THR_STL)
+THREADING	= $(THR_OPENMP) $(THR_WINAPI) $(THR_STL)
 
 # If you need to add something for a threading system, this is
 # the place.
 
-CC_BOOST_LINK	= -lboost_system -lboost_thread
-
 THREAD_COMPILE	= -fopenmp
-THREAD_LINK	= -lgomp $(CC_BOOST_LINK)
+THREAD_LINK	= -lgomp
 
 # 2. Debugging options.  (There are more granular options in debug.h.)
 
@@ -56,7 +54,7 @@ INCL_SOURCE	= Makefiles/sources.txt
 INCL_DEPENDS	= Makefiles/depends_obj.txt
 
 # If your compiler name is not given here, change it.
-CC		= g++
+# CXX	= g++
 WINDRES		= windres
 
 # We compile with aggressive warnings, but we have to turn off some
@@ -86,34 +84,44 @@ WARN_FLAGS	= 		\
 	-Wno-unknown-pragmas 	\
 	-Wno-long-long
 
-COMPILE_FLAGS	= -O3 -DBUILDING_EXAMPLE_DLL -fopenmp \
-		$(WARN_FLAGS) \
-		$(DDS_BEHAVIOR) $(THREAD_COMPILE) $(THREADING)
+CXXFLAGS	= -O3 -mms-bitfields -flto $(THREAD_COMPILE) \
+	$(WARN_FLAGS) -I../include	\
+	$(DDS_BEHAVIOR) $(THREADING)	\
+	-DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DWIN32CON -D_WINDOWS -D_USRDLL -D_WINDLL
 
-LINK1_FLAGS	= -shared
-LINK2_FLAGS	= 		\
-	$(THREAD_LINK)		\
-	-Wl,--out-implib,libdds.a \
-	-Wl,--no-undefined
+DLLBASE	= dds
+DLL 	= $(DLLBASE).dll
+IMPLIB	= lib$(DLLBASE).a
 
-DLLBASE		= dds
-DLL 		= $(DLLBASE).dll
-DLIB 		= $(DLLBASE).lib
-EXPORTER	= Exports.def
+LDFLAGS	= -s -fPIC -shared -flto -fwhole-program \
+	-Wl,--add-stdcall-alias		\
+	-Wl,--export-all-symbols	\
+	-Wl,--no-undefined		\
+	-Wl,--out-implib=$(IMPLIB)
+
+LDLIBS	= $(THREAD_LINK)
 
 VFILE		= ddsres
+
+ifeq "$(MSYSTEM)" "MINGW32"
+WINDRES_FLAG	= -F pe-i386
+else # MINGW64
 WINDRES_FLAG	= -F pe-x86-64
+endif
 
 include $(INCL_SOURCE)
 
 O_FILES 	= $(subst .cpp,.o,$(SOURCE_FILES)) $(VFILE).o
 
-mingw:	$(O_FILES)
-	$(CC) $(LINK1_FLAGS) $(O_FILES) \
-	-o $(DLL) $(LINK2_FLAGS)
+.PHONY: all depend clean install
+
+all:	$(DLL)
+
+$(DLL):	$(O_FILES)
+	$(CXX) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 %.o:	%.cpp
-	$(CC) $(COMPILE_FLAGS) -c $<
+	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 $(DLLBASE).res:	$(DLLBASE).rc
 	$(WINDRES) $(DLLBASE).rc $(DLLBASE).res
@@ -125,13 +133,12 @@ depend:
 	makedepend -Y -- $(SOURCE_FILES)
 
 clean:
-	rm -f $(O_FILES) $(DLL) $(DLLBASE).{lib,def,exp,res}
+	$(RM) $(DLL) $(IMPLIB) $(O_FILES)
 
-install:
-	test -d ../test || mkdir ../test
-	test -d ../examples || mkdir ../examples
-	cp $(DLL) $(DLLBASE).def ../test
-	cp $(DLL) $(DLLBASE).def ../examples
+install: $(DLL)
+	cp $(DLL) $(IMPLIB) ../test
+	cp $(DLL) $(IMPLIB) ../examples
+	cp $(DLL) ../hands
 
 # If you don't have a Linux-like setup, use "del" instead of "rm"
 # and "copy" instead of "cp".

--- a/test/Makefiles/Makefile_mingw
+++ b/test/Makefiles/Makefile_mingw
@@ -15,7 +15,7 @@
 # If you need to add something for the threading system, this is
 # the place.
 
-THREAD_LINK	= -lboost_system -lboost_thread -lgomp
+THREAD_LINK	= -lgomp
 
 # ----------------------- OFTEN OK    ------------------------------
 
@@ -28,7 +28,7 @@ INCL_OWN_SOURCE	= Makefiles/own_sources.txt
 INCL_DEPENDS	= Makefiles/depends_o.txt
 
 # If your compiler name is not given here, change it.
-CC		= g++
+# CXX	= g++
 
 # We compile with aggressive warnings, but we have to turn off some
 # of them as they appear in libraries in great numbers...
@@ -58,21 +58,18 @@ WARN_FLAGS	= 		\
 	-Wno-long-long		\
 	-Wno-format
 
-COMPILE_FLAGS	= -O3 $(WARN_FLAGS)
+CXXFLAGS	= -O3 -mms-bitfields -flto $(WARN_FLAGS) -I../include \
+	-DNDEBUG -DWIN32 -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -D_CONSOLE -DWIN32CON -D_LIB
 
 DLLBASE		= dds
-DLL 		= $(DLLBASE).dll
-DLIB 		= $(DLLBASE).lib
-EXPORTER	= Exports.def
 
-LINK1_FLAGS	= 
-LINK2_FLAGS	= 		\
+LDFLAGS	= -s -mconsole -flto	\
 	-Wl,--dynamicbase 	\
 	-Wl,--nxcompat 		\
 	-Wl,--no-seh 		\
-	-Wl,--enable-stdcall-fixup \
-	$(THREAD_LINK) \
-	-L. -l$(DLLBASE)
+	-Wl,--enable-stdcall-fixup
+
+LDLIBS	= -static -L. -l$(DLLBASE)
 
 # This is in addition to $(DTEST).cpp
 
@@ -81,9 +78,6 @@ include $(INCL_OWN_SOURCE)
 DTEST_OBJ_FILES	= $(subst .cpp,.o,$(DTEST_SOURCE_FILES)) $(DTEST).o
 
 DTEST		= dtest
-ITEST		= itest
-
-# These are the files that we steal from the src directory.
 
 include $(INCL_DDS_SOURCE)
 
@@ -94,26 +88,27 @@ ITEST_SOURCE_FILES	=	\
 
 ITEST_OBJ_FILES	= $(subst .cpp,.o,$(ITEST_SOURCE_FILES))
 
-dtest:	$(DTEST_OBJ_FILES)
-	$(CC) $(COMPILE_FLAGS) $(LINK1_FLAGS) $(DTEST_OBJ_FILES) \
-	$(LINK2_FLAGS) -o $(DTEST)
+.PHONY: all depend clean install
 
-itest:	$(ITEST_OBJ_FILES)
-	$(CC) $(COMPILE_FLAGS) $(LINK1_FLAGS) $(ITEST_OBJ_FILES) \
-	$(LINK2_FLAGS) -o $(ITEST)
+all: dtest.exe itest.exe
+
+dtest.exe: $(DTEST_OBJ_FILES)
+	$(CXX) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+itest.exe: $(ITEST_OBJ_FILES)
+	$(CXX) $(LDFLAGS) $^ $(THREAD_LINK) -o $@
 
 %.o:	%.cpp
-	$(CC) $(COMPILE_FLAGS) -c $< -o $*.o
+	$(CXX) -c $(CXXFLAGS) $< -o $@
 
 depend:
 	makedepend -Y -- $(ITEST_SOURCE_FILES) $(DTEST).cpp
 
 clean:
-	rm -f *.o *.exe $(DLLBASE).def $(DLL)
+	$(RM) *.exe *.o
 
-# If you don't have a Linux-like setup, use "del" instead of "rm".
+install: dtest.exe itest.exe
+	cp $^ ../hands
 
 include $(INCL_DEPENDS)
-
-# DO NOT DELETE
 

--- a/test/Makefiles/dds_sources.txt
+++ b/test/Makefiles/dds_sources.txt
@@ -18,6 +18,7 @@ DDS_SOURCE_FILES    =           \
         ../src/SolveBoard.cpp   \
         ../src/SolverIF.cpp     \
         ../src/System.cpp       \
+        ../src/ThreadMgr.cpp    \
         ../src/Timer.cpp        \
         ../src/TimerGroup.cpp   \
         ../src/TimerList.cpp    \


### PR DESCRIPTION
Common changes:
- CXX, CXXFLAGS, LDFLAGS, RM, LDFLAGS and LDLIBS are common variables used in GNU make built-in rules.
CXX defaults to 'g++", which will be OK usually.
see GNU Make manual 10.3 Variables Used by Implicit Rules.
- Add -I../include, so the ugly #include statements can be rectified in the future.

src/Makefiles/Makefile_mingw:
- Add common macros for Windows DLLs.
- THREADING & THREAD_LINK: replace boost w/ winapi
	Boost may not be installed, while winapi is essential on MinGW.
- Add MINGW32 support.
- Add -flto -fwhole-program
FYI:
w/o -flto: DLL size 387,584 bytes
w/ -flto (-fuse-linker-plugin): DLL size 409,088 bytes
w/ -flto -fwhole-program: DLL size 296,960 bytes

test/Makefiles/Makefile_mingw:
- Add common macros for Windows exe.
- $(THREAD_LINK): replace boost w/ winapi
- Use .exe suffix for executales.
	MinGW is for building Windows app.
- Add -flto
- Add missing ThreadMgr.cpp to dds_sources.txt

examples/Makefiles/Makefile_mingw:
- Add common macros for Windows exe.
- Add missing .cpp suffix in $(ALL_EXAMPLE_FILES).
- Replace -Wl,--subsystem,windows w/ -mconsole.
- Optimize rules for executables.
- Use .PRECIOUS to preserve .o files.
See GNU Make manual 10.4 Chains of Implicit Rules.