### PR TITLE
Remove manual memory management to enhance memory safety

### DIFF
--- a/src/ABstats.cpp
+++ b/src/ABstats.cpp
@@ -24,11 +24,6 @@ ABstats::ABstats()
 }
 
 
-ABstats::~ABstats()
-{
-}
-
-
 void ABstats::Reset()
 {
   for (int depth = 0; depth < DDS_MAXDEPTH; depth++)

--- a/src/ABstats.h
+++ b/src/ABstats.h
@@ -106,7 +106,7 @@ class ABstats
 
     ABstats();
 
-    ~ABstats();
+    ~ABstats() = default;
 
     void Reset();
 

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -10,6 +10,7 @@
 #ifndef DDS_MEMORY_H
 #define DDS_MEMORY_H
 
+#include <memory>
 #include <vector>
 
 #include "TransTable.h"
@@ -78,7 +79,7 @@ struct ThreadData
   // 960 KB
   relRanksType rel[8192];
 
-  TransTable * transTable;
+  std::unique_ptr<TransTable> transTable;
 
   Moves moves;
 
@@ -116,15 +117,11 @@ class Memory
 {
   private:
 
-    vector<ThreadData *> memory;
+    vector<ThreadData> memory;
 
     vector<string> threadSizes;
 
   public:
-
-    Memory();
-
-    ~Memory();
 
     void ReturnThread(const unsigned thrId);
 

--- a/src/Moves.cpp
+++ b/src/Moves.cpp
@@ -97,11 +97,6 @@ Moves::Moves()
 }
 
 
-Moves::~Moves()
-{
-}
-
-
 void Moves::Init(
   const int tricks,
   const int relStartHand,

--- a/src/Moves.h
+++ b/src/Moves.h
@@ -176,7 +176,7 @@ class Moves
   public:
     Moves();
 
-    ~Moves();
+    ~Moves() = default;
 
     void Init(
       const int tricks,

--- a/src/Scheduler.cpp
+++ b/src/Scheduler.cpp
@@ -85,11 +85,6 @@ void Scheduler::InitTimes()
 #endif
 
 
-Scheduler::~Scheduler()
-{
-}
-
-
 void Scheduler::Reset()
 {
   for (int b = 0; b < MAXNOOFBOARDS; b++)

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -162,7 +162,7 @@ class Scheduler
 
     Scheduler();
 
-    ~Scheduler();
+    ~Scheduler() = default;
 
     void RegisterThreads(
       const int n);

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -83,11 +83,6 @@ System::System()
 }
 
 
-System::~System()
-{
-}
-
-
 void System::Reset()
 {
   runCat = DDS_RUN_SOLVE;
@@ -434,19 +429,16 @@ int System::RunThreadsGCD()
 int System::RunThreadsBoost()
 {
 #ifdef DDS_THREADS_BOOST
-  vector<boost::thread *> threads;
+  vector<boost::thread> threads;
 
   const unsigned nu = static_cast<unsigned>(numThreads);
-  threads.resize(nu);
+  threads.reserve(nu);
 
   for (unsigned k = 0; k < nu; k++)
-    threads[k] = new boost::thread(fptr, k);
+    threads.emplace_back(fptr, k);
 
-  for (unsigned k = 0; k < nu; k++)
-  {
-    threads[k]->join();
-    delete threads[k];
-  }
+  for (boost::thread & t : threads)
+    t.join();
 #endif
 
   return RETURN_NO_FAULT;
@@ -460,23 +452,20 @@ int System::RunThreadsBoost()
 int System::RunThreadsSTL()
 {
 #ifdef DDS_THREADS_STL
-  vector<thread *> threads;
+  vector<thread> threads;
 
   vector<int> uniques;
   vector<int> crossrefs;
   (* CallbackDuplList[runCat])(* bop, uniques, crossrefs);
 
   const unsigned nu = static_cast<unsigned>(numThreads);
-  threads.resize(nu);
+  threads.reserve(nu);
 
   for (unsigned k = 0; k < nu; k++)
-    threads[k] = new thread(fptr, k);
+    threads.emplace_back(fptr, k);
 
-  for (unsigned k = 0; k < nu; k++)
-  {
-    threads[k]->join();
-    delete threads[k];
-  }
+  for (thread & t : threads)
+    t.join();
 #endif
 
   return RETURN_NO_FAULT;
@@ -534,19 +523,16 @@ int System::RunThreadsSTLIMPL()
 int System::RunThreadsTBB()
 {
 #ifdef DDS_THREADS_TBB
-  vector<tbb::tbb_thread *> threads;
+  vector<tbb::tbb_thread> threads;
 
   const unsigned nu = static_cast<unsigned>(numThreads);
-  threads.resize(nu);
+  threads.reserve(nu);
 
   for (unsigned k = 0; k < nu; k++)
-    threads[k] = new tbb::tbb_thread(fptr, k);
+    threads.emplace_back(fptr, k);
 
-  for (unsigned k = 0; k < nu; k++)
-  {
-    threads[k]->join();
-    delete threads[k];
-  }
+  for (tbb::tbb_thread & t : threads)
+    t.join();
 #endif
 
   return RETURN_NO_FAULT;

--- a/src/System.h
+++ b/src/System.h
@@ -81,7 +81,7 @@ class System
   public:
     System();
 
-    ~System();
+    ~System() = default;
 
     void Reset();
 

--- a/src/ThreadMgr.cpp
+++ b/src/ThreadMgr.cpp
@@ -29,11 +29,6 @@ ThreadMgr::ThreadMgr()
 }
 
 
-ThreadMgr::~ThreadMgr()
-{
-}
-
-
 void ThreadMgr::Reset(const int nThreads)
 {
   const unsigned n = static_cast<unsigned>(nThreads);

--- a/src/ThreadMgr.h
+++ b/src/ThreadMgr.h
@@ -29,7 +29,7 @@ class ThreadMgr
 
     ThreadMgr();
 
-    ~ThreadMgr();
+    ~ThreadMgr() = default;
 
     void Reset(const int nThreads);
 

--- a/src/TimeStat.cpp
+++ b/src/TimeStat.cpp
@@ -22,11 +22,6 @@ TimeStat::TimeStat()
 }
 
 
-TimeStat::~TimeStat()
-{
-}
-
-
 void TimeStat::Reset()
 {
   number = 0;

--- a/src/TimeStat.h
+++ b/src/TimeStat.h
@@ -27,7 +27,7 @@ class TimeStat
 
     TimeStat();
 
-    ~TimeStat();
+    ~TimeStat() = default;
 
     void Reset();
 

--- a/src/TimeStatList.cpp
+++ b/src/TimeStatList.cpp
@@ -15,17 +15,6 @@
 #include "TimeStatList.h"
 
 
-TimeStatList::TimeStatList()
-{
-  TimeStatList::Reset();
-}
-
-
-TimeStatList::~TimeStatList()
-{
-}
-
-
 void TimeStatList::Reset()
 {
 }

--- a/src/TimeStatList.h
+++ b/src/TimeStatList.h
@@ -28,10 +28,6 @@ class TimeStatList
 
   public:
 
-    TimeStatList();
-
-    ~TimeStatList();
-
     void Reset();
 
     void Init(

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -24,11 +24,6 @@ Timer::Timer()
 }
 
 
-Timer::~Timer()
-{
-}
-
-
 void Timer::Reset()
 {
   name = "";

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -35,7 +35,7 @@ class Timer
 
     Timer();
 
-    ~Timer();
+    ~Timer() = default;
 
     void Reset();
 

--- a/src/TimerGroup.cpp
+++ b/src/TimerGroup.cpp
@@ -22,11 +22,6 @@ TimerGroup::TimerGroup()
 }
 
 
-TimerGroup::~TimerGroup()
-{
-}
-
-
 void TimerGroup::Reset()
 {
   timers.resize(TIMER_DEPTH);

--- a/src/TimerGroup.h
+++ b/src/TimerGroup.h
@@ -29,7 +29,7 @@ class TimerGroup
 
     TimerGroup();
 
-    ~TimerGroup();
+    ~TimerGroup() = default;
 
     void Reset();
 

--- a/src/TimerList.cpp
+++ b/src/TimerList.cpp
@@ -24,11 +24,6 @@ TimerList::TimerList()
 }
 
 
-TimerList::~TimerList()
-{
-}
-
-
 void TimerList::Reset()
 {
   timerGroups.resize(TIMER_NO_SIZE);

--- a/src/TimerList.h
+++ b/src/TimerList.h
@@ -87,7 +87,7 @@ class TimerList
   public:
     TimerList();
 
-    ~TimerList();
+    ~TimerList() = default;
 
     void Reset();
 

--- a/src/TransTable.h
+++ b/src/TransTable.h
@@ -64,9 +64,9 @@ struct nodeCardsType // 8 bytes
 class TransTable
 {
   public:
-    TransTable(){};
+    TransTable() = default;
 
-    virtual ~TransTable(){};
+    virtual ~TransTable() = default;
 
     virtual void Init(const int handLookup[][15]){};
 


### PR DESCRIPTION
1. Replace all instances of `delete` with automatic memory management
  a. Use automatic variables if possible
  b. Use `std::unique_ptr` if we must
2. Replace empty destructors with `default` ones to allow inlining