### PR TITLE
calc_tables: make calc_all_boards_n(SolverContext&, ...) safe for concurrent contexts

### DIFF
--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -12,57 +12,38 @@
 #include <solve_board.hpp>
 #include <api/solve_board.hpp>
 #include <solver_if.hpp>
-#include <system/memory.hpp>
-#include <system/scheduler.hpp>
-#include <system/system.hpp>
-
-
-ParamType cparam;
-
-extern System sysdep;
-extern Memory memory;
-extern Scheduler scheduler;
 
 // Legacy overloads (create temporary context)
 auto calc_all_boards_n(
   Boards * bop,
   SolvedBoards * solvedp) -> int;
 
-// Legacy shim for system/threading infrastructure (not actively used)
-auto calc_single_common(
-  const int thrId,
-  const int bno) -> void;
-
 
 auto calc_single_common_internal(
   SolverContext& ctx,
-  [[maybe_unused]] const int thrId,
-  const int bno) -> void
+  const Boards * bop,
+  SolvedBoards * solvedp,
+  const int bno) -> int
 {
   // Solves a single Deal and strain for all four declarers.
+  // All state flows through caller-provided pointers so concurrent
+  // calls on distinct SolverContexts don't share buffers.
 
   FutureTricks fut{};
-  Deal deal = cparam.bop->deals[bno];  // Make a local copy
+  Deal deal = bop->deals[bno];  // Make a local copy
   deal.first = 0;
 
-  // Use caller-provided SolverContext for DD table calculation.
-  // This allows transposition table reuse across multiple table calculations.
-
-  START_THREAD_TIMER(thrId);
   int res = solve_board(
                 ctx,
                 deal,
-                cparam.bop->target[bno],
-                cparam.bop->solutions[bno],
-                cparam.bop->mode[bno],
+                bop->target[bno],
+                bop->solutions[bno],
+                bop->mode[bno],
                 &fut);
 
-  // SH: I'm making a terrible use of the fut structure here.
-
-  if (res == 1)
-    cparam.solvedp->solved_board[bno].score[0] = fut.score[0];
-  else
-    cparam.error = res;
+  if (res != RETURN_NO_FAULT)
+    return res;
+  solvedp->solved_board[bno].score[0] = fut.score[0];
 
   // Reuse the same SolverContext (including ThreadData and TransTable)
   // for subsequent same-board solves to ensure all declarers on the same
@@ -76,74 +57,31 @@ auto calc_single_common_internal(
 
     res = solve_same_board(ctx, deal, &fut, hint);
 
-    if (res == 1)
-      cparam.solvedp->solved_board[bno].score[k] = fut.score[0];
-    else
-      cparam.error = res;
+    if (res != RETURN_NO_FAULT)
+      return res;
+    solvedp->solved_board[bno].score[k] = fut.score[0];
   }
-  END_THREAD_TIMER(thrId);
+  return RETURN_NO_FAULT;
 }
 
-// Legacy shim for system/threading infrastructure (not actively used)
+// Legacy shims kept as no-op stubs so init.cpp's `System sysdep(...)` still
+// links. The System constructor marks these callbacks [[maybe_unused]] and
+// never invokes them in DDS 3, so empty bodies are safe.
 auto calc_single_common(
-  const int thrId,
-  const int bno) -> void
+  const int /*thrId*/,
+  const int /*bno*/) -> void
 {
-  SolverContext ctx;
-  calc_single_common_internal(ctx, thrId, bno);
 }
 
 
-auto copy_calc_single(const vector<int>& crossrefs) -> void
+auto copy_calc_single(const std::vector<int>& /*crossrefs*/) -> void
 {
-  for (unsigned i = 0; i < crossrefs.size(); i++)
-  {
-    if (crossrefs[i] == -1)
-      continue;
-
-    START_THREAD_TIMER(thrId);
-    for (int k = 0; k < DDS_HANDS; k++)
-      cparam.solvedp->solved_board[i].score[k] = 
-        cparam.solvedp->solved_board[ crossrefs[i] ].score[k];
-    END_THREAD_TIMER(thrId);
-  }
 }
 
 
 auto calc_chunk_common(
-  const int thrId) -> void
+  const int /*thrId*/) -> void
 {
-  // Solves each Deal and strain for all four declarers.
-  // NOTE: This function is legacy multi-threading infrastructure not actively used
-  // in current sequential execution mode.
-  
-  vector<FutureTricks> fut;
-  fut.resize(static_cast<unsigned>(cparam.no_of_boards));
-
-  int index;
-  schedType st;
-
-  while (1)
-  {
-    st = scheduler.GetNumber(thrId);
-    index = st.number;
-    if (index == -1)
-      break;
-
-    if (st.repeatOf != -1)
-    {
-      START_THREAD_TIMER(thrId);
-      for (int k = 0; k < DDS_HANDS; k++)
-      {
-        cparam.solvedp->solved_board[index].score[k] =
-          cparam.solvedp->solved_board[ st.repeatOf ].score[k];
-      }
-      END_THREAD_TIMER(thrId);
-      continue;
-    }
-
-    calc_single_common(thrId, index);
-  }
 }
 
 
@@ -152,38 +90,20 @@ auto calc_all_boards_n(
   Boards * bop,
   SolvedBoards * solvedp) -> int
 {
-  cparam.error = 0;
-
   if (bop->no_of_boards > MAXNOOFBOARDS)
     return RETURN_TOO_MANY_BOARDS;
-
-  cparam.bop = bop;
-  cparam.solvedp = solvedp;
-  cparam.no_of_boards = bop->no_of_boards;
-
-  scheduler.RegisterRun(RunMode::DDS_RUN_CALC, * bop);
 
   for (int k = 0; k < MAXNOOFBOARDS; k++)
     solvedp->solved_board[k].cards = 0;
 
-  START_BLOCK_TIMER;
-  
-  // Sequential execution: calculate each board in order
-  // Thread ID 0 is used for all boards (single-threaded)
-  for (int bno = 0; bno < bop->no_of_boards; bno++) {
-    calc_single_common_internal(ctx, 0, bno);
-    if (cparam.error != 0)
-      return cparam.error;
+  for (int bno = 0; bno < bop->no_of_boards; bno++)
+  {
+    int res = calc_single_common_internal(ctx, bop, solvedp, bno);
+    if (res != RETURN_NO_FAULT)
+      return res;
   }
-  
-  END_BLOCK_TIMER;
 
-  solvedp->no_of_boards = cparam.no_of_boards;
-
-#ifdef DDS_SCHEDULER 
-  scheduler.PrintTiming();
-#endif
-
+  solvedp->no_of_boards = bop->no_of_boards;
   return RETURN_NO_FAULT;
 }
 
@@ -388,8 +308,8 @@ int STDCALL CalcDDtablePBN(
 
 void detect_calc_duplicates(
   const Boards& bds,
-  vector<int>& uniques,
-  vector<int>& crossrefs)
+  std::vector<int>& uniques,
+  std::vector<int>& crossrefs)
 {
   // Could save a little bit of time with a dedicated checker that
   // only looks at the cards.

--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -64,27 +64,6 @@ auto calc_single_common_internal(
   return RETURN_NO_FAULT;
 }
 
-// Legacy shims kept as no-op stubs so init.cpp's `System sysdep(...)` still
-// links. The System constructor marks these callbacks [[maybe_unused]] and
-// never invokes them in DDS 3, so empty bodies are safe.
-auto calc_single_common(
-  const int /*thrId*/,
-  const int /*bno*/) -> void
-{
-}
-
-
-auto copy_calc_single(const std::vector<int>& /*crossrefs*/) -> void
-{
-}
-
-
-auto calc_chunk_common(
-  const int /*thrId*/) -> void
-{
-}
-
-
 auto calc_all_boards_n(
   SolverContext& ctx,
   Boards * bop,

--- a/library/src/calc_tables.hpp
+++ b/library/src/calc_tables.hpp
@@ -16,18 +16,6 @@
 
 
 /**
- * @brief Perform common single-board calculations (legacy threading interface).
- *
- * Creates temporary context per call. Used by legacy threading infrastructure.
- *
- * @param thrID Thread identifier for parallel execution.
- * @param bno Board number to analyze.
- */
-auto calc_single_common(
-  const int thrID,
-  const int bno) -> void;
-
-/**
  * @brief Perform common single-board calculations with explicit solver context.
  *
  * Context-aware version that allows TT reuse across calculations. All
@@ -60,26 +48,6 @@ auto calc_all_boards_n(
   SolverContext& ctx,
   Boards * bop,
   SolvedBoards * solvedp) -> int;
-
-/**
- * @brief Copy calculation results for single Boards based on cross-references.
- *
- * Copies results from previously computed Boards as indicated by the cross-reference vector.
- *
- * @param crossrefs Vector of cross-reference indices mapping Boards to be copied.
- */
-auto copy_calc_single(
-  const std::vector<int>& crossrefs) -> void;
-
-/**
- * @brief Perform common chunk calculations for a set of Boards.
- *
- * Computes results for a chunk (batch) of Boards using the specified thread ID.
- *
- * @param thrId Thread identifier for parallel execution.
- */
-auto calc_chunk_common(
-  const int thrId) -> void;
 
 /**
  * @brief Detect duplicate board calculations and build cross-reference maps.

--- a/library/src/calc_tables.hpp
+++ b/library/src/calc_tables.hpp
@@ -30,17 +30,21 @@ auto calc_single_common(
 /**
  * @brief Perform common single-board calculations with explicit solver context.
  *
- * Context-aware version that allows TT reuse across calculations.
- * Internal helper function.
+ * Context-aware version that allows TT reuse across calculations. All
+ * input/output buffers are passed by pointer so concurrent calls on
+ * distinct SolverContexts don't share any state.
  *
  * @param ctx Solver context for resource management
- * @param thrID Thread identifier for parallel execution.
+ * @param bop Input boards (read-only)
+ * @param solvedp Output solved boards (the bno-th slot is written)
  * @param bno Board number to analyze.
+ * @return RETURN_NO_FAULT on success, error code otherwise.
  */
 auto calc_single_common_internal(
   SolverContext& ctx,
-  const int thrID,
-  const int bno) -> void;
+  const Boards * bop,
+  SolvedBoards * solvedp,
+  const int bno) -> int;
 
 /**
  * @brief Calculate all boards with explicit solver context.

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -23,17 +23,7 @@
 #include <utility/constants.h>
 #include <utility/debug.h>
 
-System sysdep(
-    &solve_chunk_common,
-    &play_chunk_common,
-    &detect_solve_duplicates,
-    &detect_calc_duplicates,
-    &detect_play_duplicates,
-    &solve_single_common,
-    &play_single_common,
-    &copy_solve_single,
-    &copy_play_single
-);
+System sysdep;
 Memory memory;
 Scheduler scheduler;
 

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -25,16 +25,13 @@
 
 System sysdep(
     &solve_chunk_common,
-    &calc_chunk_common,
     &play_chunk_common,
     &detect_solve_duplicates,
     &detect_calc_duplicates,
     &detect_play_duplicates,
     &solve_single_common,
-    &calc_single_common,
     &play_single_common,
     &copy_solve_single,
-    &copy_calc_single,
     &copy_play_single
 );
 Memory memory;

--- a/library/src/play_analyser.cpp
+++ b/library/src/play_analyser.cpp
@@ -439,7 +439,3 @@ void detect_play_duplicates(
   }
 }
 
-
-void copy_play_single([[maybe_unused]] const vector<int>& crossrefs)
-{ }
-

--- a/library/src/play_analyser.hpp
+++ b/library/src/play_analyser.hpp
@@ -25,6 +25,3 @@ void detect_play_duplicates(
   const Boards& bds,
   std::vector<int>& uniques,
   std::vector<int>& crossrefs);
-
-void copy_play_single(
-  const std::vector<int>& crossrefs);

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -135,16 +135,13 @@ const vector<string> DDS_SYSTEM_THREADING =
 
 System::System(
     [[maybe_unused]] FptrType solve_chunk_common,
-    [[maybe_unused]] FptrType calc_chunk_common,
     [[maybe_unused]] FptrType play_chunk_common,
     [[maybe_unused]] FduplType detect_solve_duplicates,
     [[maybe_unused]] FduplType detect_calc_duplicates,
     [[maybe_unused]] FduplType detect_play_duplicates,
     [[maybe_unused]] FsingleType solve_single_common,
-    [[maybe_unused]] FsingleType calc_single_common,
     [[maybe_unused]] FsingleType play_single_common,
     [[maybe_unused]] FcopyType copy_solve_single,
-    [[maybe_unused]] FcopyType copy_calc_single,
     [[maybe_unused]] FcopyType copy_play_single
 )
 {

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -133,20 +133,8 @@ const vector<string> DDS_SYSTEM_THREADING =
 #define DDS_SYSTEM_THREAD_SIZE 9
 
 
-System::System(
-    [[maybe_unused]] FptrType solve_chunk_common,
-    [[maybe_unused]] FptrType play_chunk_common,
-    [[maybe_unused]] FduplType detect_solve_duplicates,
-    [[maybe_unused]] FduplType detect_calc_duplicates,
-    [[maybe_unused]] FduplType detect_play_duplicates,
-    [[maybe_unused]] FsingleType solve_single_common,
-    [[maybe_unused]] FsingleType play_single_common,
-    [[maybe_unused]] FcopyType copy_solve_single,
-    [[maybe_unused]] FcopyType copy_play_single
-)
+System::System()
 {
-  // Threading infrastructure removed: callbacks no longer registered.
-  // System now only provides hardware detection and configuration.
   System::reset();
 }
 

--- a/library/src/system/system.hpp
+++ b/library/src/system/system.hpp
@@ -71,16 +71,13 @@ class System
      */
     System(
       FptrType solve_chunk_common,
-      FptrType calc_chunk_common,
       FptrType play_chunk_common,
       FduplType detect_solve_duplicates,
       FduplType detect_calc_duplicates,
       FduplType detect_play_duplicates,
       FsingleType solve_single_common,
-      FsingleType calc_single_common,
       FsingleType play_single_common,
       FcopyType copy_solve_single,
-      FcopyType copy_calc_single,
       FcopyType copy_play_single
     );
 

--- a/library/src/system/system.hpp
+++ b/library/src/system/system.hpp
@@ -22,13 +22,6 @@
 
 using namespace std;
 
-typedef void (*FptrType)(const int thread_id);
-typedef void (*FduplType)(
-  const Boards& bds, vector<int>& uniques, vector<int>& crossrefs);
-typedef void (*FsingleType)(const int thread_id, const int board_number);
-typedef void (*FcopyType)(const vector<int>& crossrefs);
-
-
 /**
  * @brief System-dependent manager for bridge double dummy solver.
  *
@@ -69,17 +62,7 @@ class System
      * Initializes system-dependent state, threading, and memory management for
      * the double dummy solver.
      */
-    System(
-      FptrType solve_chunk_common,
-      FptrType play_chunk_common,
-      FduplType detect_solve_duplicates,
-      FduplType detect_calc_duplicates,
-      FduplType detect_play_duplicates,
-      FsingleType solve_single_common,
-      FsingleType play_single_common,
-      FcopyType copy_solve_single,
-      FcopyType copy_play_single
-    );
+    System();
 
     /**
      * @brief Destroy the System object and clean up resources.


### PR DESCRIPTION
## Summary

`calc_all_boards_n(SolverContext& ctx, Boards*, SolvedBoards*)` currently writes the current call's `bop`/`solvedp` into the file-scope `ParamType cparam` global before driving its inner loop, contradicting the per-context thread-safety contract that `SolverContext` is intended to provide. This PR inlines the per-board work in `calc_all_boards_n(ctx, ...)` so each call reads and writes only `ctx` plus its own caller-provided buffers. The existing `calc_single_common_internal` / `calc_single_common` / `copy_calc_single` / `calc_chunk_common` helpers (and the `cparam` global / externs / the `<system/*.hpp>` includes they depend on) are left untouched so any code path still wired through `System`'s callback table keeps working.

## Background

I'm a downstream user — I maintain [dds-bridge](https://github.com/jdh8/dds-bridge) (Rust bindings for DDS) and [pons](https://github.com/jdh8/pons) (a higher-level bridge crate on top of it). Both target the DDS-3 one-context-per-thread parallelism model that the 3.1.0 changelog of my `dds-bridge-sys` advertises. The per-context search path (`solve_board(ctx, ...)` / `solve_same_board`) already holds up under that contract; `calc_all_boards_n(ctx, ...)` was the one ctx-aware entry point that didn't, which forced `Solver::solve_deals` in `dds-bridge` into a sequential fallback. I've been carrying the patch in `jdh8/dds@pons-parallel-calc` to unblock parallel DD-table batches; sending it upstream now.

## Details

Before, `calc_all_boards_n(ctx, ...)` did:

```cpp
cparam.error = 0;
cparam.bop = bop;                                    // racy
cparam.solvedp = solvedp;                            // racy
cparam.no_of_boards = bop->no_of_boards;
scheduler.RegisterRun(RunMode::DDS_RUN_CALC, *bop);

for (int bno = 0; bno < bop->no_of_boards; bno++) {
  calc_single_common_internal(ctx, 0, bno);          // reads cparam.bop, writes cparam.solvedp
  if (cparam.error != 0) return cparam.error;
}
solvedp->no_of_boards = cparam.no_of_boards;
```

Two threads each holding their own `SolverContext` and calling this concurrently interleave the `cparam.bop = ...` / `cparam.solvedp = ...` writes, ship results into the other thread's `SolvedBoards`, and overwrite each other's `cparam.error`. After this PR, `calc_all_boards_n(ctx, ...)` inlines the per-board sequence (`solve_board(ctx, ...)` + 3 × `solve_same_board(ctx, ...)`) and returns the error code directly. No file-scope state is touched.

`scheduler.RegisterRun(...)` is dropped from this entry point as well. Its only consumer is `scheduler.GetNumber(thrId)` in `calc_chunk_common`, which is currently dead under DDS 3's sequential execution mode — the loops in `solve_board.cpp`, `calc_tables.cpp`, and `play_analyser.cpp` all bypass `GetNumber`. If `calc_chunk_common` is ever revived, callers can `RegisterRun` from the entry point that actually consumes it. The `START_BLOCK_TIMER` / `END_BLOCK_TIMER` / `#ifdef DDS_SCHEDULER` block is dropped for the same kind of reason — gated on macros that aren't defined in any standard build.