### PR TITLE
Parallel Solve all Boards and Improved Thread Safety.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,9 @@ dump.txt
 
 # Generated documentation output
 doxygen_output/
+
+# CCE (code-context-engine)
+# CCE local cache (per-machine, not for version control)
+.cce/
+# Claude Code local settings written by cce init
+.claude/settings.local.json

--- a/library/src/api/dll.h
+++ b/library/src/api/dll.h
@@ -602,6 +602,14 @@ EXTERN_C DLLEXPORT auto STDCALL SolveAllBoardsBin(
   struct Boards const * bop,
   struct SolvedBoards * solvedp) -> int;
 
+EXTERN_C DLLEXPORT auto STDCALL SolveAllBoardsSeq(
+  struct BoardsPBN const * bop,
+  struct SolvedBoards * solvedp) -> int;
+
+EXTERN_C DLLEXPORT auto STDCALL SolveAllBoardsBinSeq(
+  struct Boards const * bop,
+  struct SolvedBoards * solvedp) -> int;
+
 EXTERN_C DLLEXPORT auto STDCALL SolveAllChunks(
   struct BoardsPBN const * bop,
   struct SolvedBoards * solvedp,

--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -19,7 +19,6 @@
 
 ParamType cparam;
 
-extern System sysdep;
 extern Memory memory;
 extern Scheduler scheduler;
 
@@ -28,27 +27,18 @@ auto calc_all_boards_n(
   Boards * bop,
   SolvedBoards * solvedp) -> int;
 
-// Legacy shim for system/threading infrastructure (not actively used)
-auto calc_single_common(
-  const int thrId,
-  const int bno) -> void;
+// Forward declaration for legacy shim
+auto calc_single_common(const int bno) -> void;
 
 
 auto calc_single_common_internal(
   SolverContext& ctx,
-  [[maybe_unused]] const int thrId,
   const int bno) -> void
 {
-  // Solves a single Deal and strain for all four declarers.
-
   FutureTricks fut{};
   Deal deal = cparam.bop->deals[bno];  // Make a local copy
   deal.first = 0;
 
-  // Use caller-provided SolverContext for DD table calculation.
-  // This allows transposition table reuse across multiple table calculations.
-
-  START_THREAD_TIMER(thrId);
   int res = solve_board(
                 ctx,
                 deal,
@@ -81,16 +71,12 @@ auto calc_single_common_internal(
     else
       cparam.error = res;
   }
-  END_THREAD_TIMER(thrId);
 }
 
-// Legacy shim for system/threading infrastructure (not actively used)
-auto calc_single_common(
-  const int thrId,
-  const int bno) -> void
+auto calc_single_common(const int bno) -> void
 {
   SolverContext ctx;
-  calc_single_common_internal(ctx, thrId, bno);
+  calc_single_common_internal(ctx, bno);
 }
 
 
@@ -101,48 +87,36 @@ auto copy_calc_single(const vector<int>& crossrefs) -> void
     if (crossrefs[i] == -1)
       continue;
 
-    START_THREAD_TIMER(thrId);
     for (int k = 0; k < DDS_HANDS; k++)
-      cparam.solvedp->solved_board[i].score[k] = 
+      cparam.solvedp->solved_board[i].score[k] =
         cparam.solvedp->solved_board[ crossrefs[i] ].score[k];
-    END_THREAD_TIMER(thrId);
   }
 }
 
 
-auto calc_chunk_common(
-  const int thrId) -> void
+auto calc_chunk_common() -> void
 {
-  // Solves each Deal and strain for all four declarers.
-  // NOTE: This function is legacy multi-threading infrastructure not actively used
-  // in current sequential execution mode.
-  
-  vector<FutureTricks> fut;
-  fut.resize(static_cast<unsigned>(cparam.no_of_boards));
-
   int index;
   schedType st;
 
   while (1)
   {
-    st = scheduler.GetNumber(thrId);
+    st = scheduler.GetNumber(0);
     index = st.number;
     if (index == -1)
       break;
 
     if (st.repeatOf != -1)
     {
-      START_THREAD_TIMER(thrId);
       for (int k = 0; k < DDS_HANDS; k++)
       {
         cparam.solvedp->solved_board[index].score[k] =
           cparam.solvedp->solved_board[ st.repeatOf ].score[k];
       }
-      END_THREAD_TIMER(thrId);
       continue;
     }
 
-    calc_single_common(thrId, index);
+    calc_single_common(index);
   }
 }
 
@@ -168,10 +142,8 @@ auto calc_all_boards_n(
 
   START_BLOCK_TIMER;
   
-  // Sequential execution: calculate each board in order
-  // Thread ID 0 is used for all boards (single-threaded)
   for (int bno = 0; bno < bop->no_of_boards; bno++) {
-    calc_single_common_internal(ctx, 0, bno);
+    calc_single_common_internal(ctx, bno);
     if (cparam.error != 0)
       return cparam.error;
   }

--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -17,42 +17,39 @@
 #include <system/system.hpp>
 
 
-ParamType cparam;
-
 extern Memory memory;
 extern Scheduler scheduler;
 
-// Legacy overloads (create temporary context)
+// Legacy overload (creates temporary context)
 auto calc_all_boards_n(
   Boards * bop,
   SolvedBoards * solvedp) -> int;
 
-// Forward declaration for legacy shim
-auto calc_single_common(const int bno) -> void;
-
 
 auto calc_single_common_internal(
   SolverContext& ctx,
-  const int bno) -> void
+  Boards const& bds,
+  SolvedBoards& solved,
+  const int bno) -> int
 {
   FutureTricks fut{};
-  Deal deal = cparam.bop->deals[bno];  // Make a local copy
+  Deal deal = bds.deals[bno];  // Make a local copy
   deal.first = 0;
 
   int res = solve_board(
                 ctx,
                 deal,
-                cparam.bop->target[bno],
-                cparam.bop->solutions[bno],
-                cparam.bop->mode[bno],
+                bds.target[bno],
+                bds.solutions[bno],
+                bds.mode[bno],
                 &fut);
 
   // SH: I'm making a terrible use of the fut structure here.
 
   if (res == 1)
-    cparam.solvedp->solved_board[bno].score[0] = fut.score[0];
+    solved.solved_board[bno].score[0] = fut.score[0];
   else
-    cparam.error = res;
+    return res;
 
   // Reuse the same SolverContext (including ThreadData and TransTable)
   // for subsequent same-board solves to ensure all declarers on the same
@@ -67,57 +64,11 @@ auto calc_single_common_internal(
     res = solve_same_board(ctx, deal, &fut, hint);
 
     if (res == 1)
-      cparam.solvedp->solved_board[bno].score[k] = fut.score[0];
+      solved.solved_board[bno].score[k] = fut.score[0];
     else
-      cparam.error = res;
+      return res;
   }
-}
-
-auto calc_single_common(const int bno) -> void
-{
-  SolverContext ctx;
-  calc_single_common_internal(ctx, bno);
-}
-
-
-auto copy_calc_single(const vector<int>& crossrefs) -> void
-{
-  for (unsigned i = 0; i < crossrefs.size(); i++)
-  {
-    if (crossrefs[i] == -1)
-      continue;
-
-    for (int k = 0; k < DDS_HANDS; k++)
-      cparam.solvedp->solved_board[i].score[k] =
-        cparam.solvedp->solved_board[ crossrefs[i] ].score[k];
-  }
-}
-
-
-auto calc_chunk_common() -> void
-{
-  int index;
-  schedType st;
-
-  while (1)
-  {
-    st = scheduler.GetNumber(0);
-    index = st.number;
-    if (index == -1)
-      break;
-
-    if (st.repeatOf != -1)
-    {
-      for (int k = 0; k < DDS_HANDS; k++)
-      {
-        cparam.solvedp->solved_board[index].score[k] =
-          cparam.solvedp->solved_board[ st.repeatOf ].score[k];
-      }
-      continue;
-    }
-
-    calc_single_common(index);
-  }
+  return 1;
 }
 
 
@@ -126,14 +77,8 @@ auto calc_all_boards_n(
   Boards * bop,
   SolvedBoards * solvedp) -> int
 {
-  cparam.error = 0;
-
   if (bop->no_of_boards > MAXNOOFBOARDS)
     return RETURN_TOO_MANY_BOARDS;
-
-  cparam.bop = bop;
-  cparam.solvedp = solvedp;
-  cparam.no_of_boards = bop->no_of_boards;
 
   scheduler.RegisterRun(RunMode::DDS_RUN_CALC, * bop);
 
@@ -141,18 +86,18 @@ auto calc_all_boards_n(
     solvedp->solved_board[k].cards = 0;
 
   START_BLOCK_TIMER;
-  
+
   for (int bno = 0; bno < bop->no_of_boards; bno++) {
-    calc_single_common_internal(ctx, bno);
-    if (cparam.error != 0)
-      return cparam.error;
+    const int err = calc_single_common_internal(ctx, *bop, *solvedp, bno);
+    if (err != 1)
+      return err;
   }
-  
+
   END_BLOCK_TIMER;
 
-  solvedp->no_of_boards = cparam.no_of_boards;
+  solvedp->no_of_boards = bop->no_of_boards;
 
-#ifdef DDS_SCHEDULER 
+#ifdef DDS_SCHEDULER
   scheduler.PrintTiming();
 #endif
 
@@ -367,4 +312,3 @@ void detect_calc_duplicates(
   // only looks at the cards.
   return detect_solve_duplicates(bds, uniques, crossrefs);
 }
-

--- a/library/src/calc_tables.hpp
+++ b/library/src/calc_tables.hpp
@@ -16,30 +16,15 @@
 
 
 /**
- * @brief Perform common single-board calculations (legacy threading interface).
- *
- * Creates temporary context per call. Used by legacy threading infrastructure.
- *
- * @param thrID Thread identifier for parallel execution.
- * @param bno Board number to analyze.
+ * @brief Solve a single board. Creates a temporary context per call.
  */
-auto calc_single_common(
-  const int thrID,
-  const int bno) -> void;
+auto calc_single_common(const int bno) -> void;
 
 /**
- * @brief Perform common single-board calculations with explicit solver context.
- *
- * Context-aware version that allows TT reuse across calculations.
- * Internal helper function.
- *
- * @param ctx Solver context for resource management
- * @param thrID Thread identifier for parallel execution.
- * @param bno Board number to analyze.
+ * @brief Solve a single board using an explicit solver context for TT reuse.
  */
 auto calc_single_common_internal(
   SolverContext& ctx,
-  const int thrID,
   const int bno) -> void;
 
 /**
@@ -68,14 +53,9 @@ auto copy_calc_single(
   const std::vector<int>& crossrefs) -> void;
 
 /**
- * @brief Perform common chunk calculations for a set of Boards.
- *
- * Computes results for a chunk (batch) of Boards using the specified thread ID.
- *
- * @param thrId Thread identifier for parallel execution.
+ * @brief Process all boards queued in the scheduler (sequential).
  */
-auto calc_chunk_common(
-  const int thrId) -> void;
+auto calc_chunk_common() -> void;
 
 /**
  * @brief Detect duplicate board calculations and build cross-reference maps.

--- a/library/src/calc_tables.hpp
+++ b/library/src/calc_tables.hpp
@@ -16,16 +16,15 @@
 
 
 /**
- * @brief Solve a single board. Creates a temporary context per call.
- */
-auto calc_single_common(const int bno) -> void;
-
-/**
  * @brief Solve a single board using an explicit solver context for TT reuse.
+ *
+ * @return 1 on success, error code otherwise
  */
 auto calc_single_common_internal(
   SolverContext& ctx,
-  const int bno) -> void;
+  Boards const& bds,
+  SolvedBoards& solved,
+  const int bno) -> int;
 
 /**
  * @brief Calculate all boards with explicit solver context.
@@ -41,21 +40,6 @@ auto calc_all_boards_n(
   SolverContext& ctx,
   Boards * bop,
   SolvedBoards * solvedp) -> int;
-
-/**
- * @brief Copy calculation results for single Boards based on cross-references.
- *
- * Copies results from previously computed Boards as indicated by the cross-reference vector.
- *
- * @param crossrefs Vector of cross-reference indices mapping Boards to be copied.
- */
-auto copy_calc_single(
-  const std::vector<int>& crossrefs) -> void;
-
-/**
- * @brief Process all boards queued in the scheduler (sequential).
- */
-auto calc_chunk_common() -> void;
 
 /**
  * @brief Detect duplicate board calculations and build cross-reference maps.

--- a/library/src/dealer_par.cpp
+++ b/library/src/dealer_par.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 
 /* First index: 0 nonvul, 1 vul. Second index: tricks down */
-int DOUBLED_SCORES[2][14] =
+const int DOUBLED_SCORES[2][14] =
 {
   {
     0   ,  100,  300,  500,  800, 1100, 1400, 1700,
@@ -33,7 +33,7 @@ int DOUBLED_SCORES[2][14] =
    0 is pass, 1 is 1C, ..., 35 is 7NT.
    Second index is 0 nonvul, 1 vul. */
 
-int SCORES[36][2] =
+const int SCORES[36][2] =
 {
   {    0,   0},
   {   70,  70}, {  70,   70}, {  80,   80}, {  80,   80}, {  90,   90},
@@ -48,7 +48,7 @@ int SCORES[36][2] =
 /* Second index is contract number, 0 .. 35.
    First index is vul: none, only defender, only declarer, both. */
 
-int DOWN_TARGET[36][4] =
+const int DOWN_TARGET[36][4] =
 {
   {0, 0, 0, 0},
   {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
@@ -60,7 +60,7 @@ int DOWN_TARGET[36][4] =
   {6, 5, 8, 7}, {6, 5, 8, 7}, {6, 5, 8, 7}, {6, 5, 8, 7}, {6, 5, 8, 7}
 };
 
-int FLOOR_CONTRACT[36] =
+const int FLOOR_CONTRACT[36] =
 {
    0,  1,  2,  3,  4,  5,  1,  2,  3,  4,  5,
        1,  2,  3,  4, 15,  1,  2, 18, 19, 15,
@@ -84,14 +84,14 @@ const vector<string> NUMBER_TO_PLAYER = { "N", "E", "S", "W" };
 
 /* First index is vul: none, both, NS, EW.
    Second index is vul (0, 1) for NS and then EW. */
-int VUL_LOOKUP[4][2] = { {0, 0}, {1, 1}, {1, 0}, {0, 1} };
+const int VUL_LOOKUP[4][2] = { {0, 0}, {1, 1}, {1, 0}, {0, 1} };
 
 /* First vul is declarer (not necessarily NS), second is defender. */
-int VUL_TO_NO[2][2] = { {0, 1}, {2, 3} };
+const int VUL_TO_NO[2][2] = { {0, 1}, {2, 3} };
 
 
 /* Maps DDS order (S, H, D, C, NT) to par order (C, D, H, S, NT). */
-int DENOM_ORDER[5] = { 3, 2, 1, 0, 4 };
+const int DENOM_ORDER[5] = { 3, 2, 1, 0, 4 };
 
 
 struct data_type

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -23,20 +23,7 @@
 #include <utility/constants.h>
 #include <utility/debug.h>
 
-System sysdep(
-    &solve_chunk_common,
-    &calc_chunk_common,
-    &play_chunk_common,
-    &detect_solve_duplicates,
-    &detect_calc_duplicates,
-    &detect_play_duplicates,
-    &solve_single_common,
-    &calc_single_common,
-    &play_single_common,
-    &copy_solve_single,
-    &copy_calc_single,
-    &copy_play_single
-);
+System sysdep;
 Memory memory;
 Scheduler scheduler;
 

--- a/library/src/par.cpp
+++ b/library/src/par.cpp
@@ -35,8 +35,6 @@ struct parContr2Type
   int denom;
 };
 
-int stat_contr[5] = {0, 0, 0, 0, 0};
-
 /* index 1: 0=NT, 1=Major, 2=Minor index 2: contract level 1-7 */
 const int max_low[3][8] = {
   {0, 0, 1, 0, 1, 2, 0, 0}, 

--- a/library/src/play_analyser.cpp
+++ b/library/src/play_analyser.cpp
@@ -11,7 +11,6 @@
 #include <solver_if.hpp>
 #include <pbn.hpp>
 #include <solver_context/solver_context.hpp>
-#include <system/memory.hpp>
 #include <system/scheduler.hpp>
 #include <system/system.hpp>
 
@@ -26,18 +25,6 @@ using namespace std;
   ofstream fout;
 #endif
 
-struct playparamType
-{
-  int no_of_boards;
-  PlayTracesBin const * plp;
-  SolvedPlays * solvedp;
-  int error;
-};
-
-ParamType playparam;
-playparamType traceparam;
-
-extern Memory memory;
 extern Scheduler scheduler;
 
 
@@ -289,71 +276,31 @@ int STDCALL AnalysePlayPBN(
 }
 
 
-void play_single_common(const int bno)
-{
-  SolvedPlay solved;
-
-  int res = AnalysePlayBin(
-    playparam.bop->deals[bno],
-    traceparam.plp->plays[bno],
-    &solved,
-    0);
-
-  // If there are multiple errors, this will catch one of them.
-  if (res == 1)
-    traceparam.solvedp->solved[bno] = solved;
-  else
-   playparam.error = res;
-}
-
-
-void play_chunk_common()
-{
-  int index;
-  schedType st;
-
-  while (1)
-  {
-    st = scheduler.GetNumber(0);
-    index = st.number;
-    if (index == -1)
-      break;
-
-    play_single_common(index);
-  }
-}
-
-
 int STDCALL AnalyseAllPlaysBin(
   Boards const * bop,
   PlayTracesBin const * plp,
   SolvedPlays * solvedp,
   [[maybe_unused]] int chunkSize)
 {
-  playparam.error = 0;
-
   if (bop->no_of_boards > MAXNOOFBOARDS)
     return RETURN_TOO_MANY_BOARDS;
 
   if (bop->no_of_boards != plp->no_of_boards)
     return RETURN_UNKNOWN_FAULT;
 
-  playparam.bop = bop;
-  traceparam.plp = plp;
-  playparam.no_of_boards = bop->no_of_boards;
-  traceparam.no_of_boards = bop->no_of_boards;
-  traceparam.solvedp = solvedp;
-
   scheduler.RegisterRun(RunMode::DDS_RUN_TRACE, * bop, * plp);
 
   START_BLOCK_TIMER;
-  
+
   for (int bno = 0; bno < bop->no_of_boards; bno++) {
-    play_single_common(bno);
-    if (playparam.error != 0)
-      return playparam.error;
+    SolvedPlay solved;
+    const int res = AnalysePlayBin(bop->deals[bno], plp->plays[bno], &solved, 0);
+    if (res == 1)
+      solvedp->solved[bno] = solved;
+    else
+      return res;
   }
-  
+
   END_BLOCK_TIMER;
 
   solvedp->no_of_boards = bop->no_of_boards;
@@ -432,6 +379,4 @@ void detect_play_duplicates(
 }
 
 
-void copy_play_single([[maybe_unused]] const vector<int>& crossrefs)
-{ }
 

--- a/library/src/play_analyser.cpp
+++ b/library/src/play_analyser.cpp
@@ -37,7 +37,6 @@ struct playparamType
 ParamType playparam;
 playparamType traceparam;
 
-extern System sysdep;
 extern Memory memory;
 extern Scheduler scheduler;
 
@@ -58,11 +57,8 @@ int STDCALL AnalysePlayBin(
   Deal dl,
   PlayTraceBin play,
   SolvedPlay * solvedp,
-  int thrId)
+  [[maybe_unused]] int thrId)
 {
-  if (! sysdep.thread_ok(thrId))
-    return RETURN_THREAD_INDEX;
-
   // Create an owned context for this analysis and obtain its ThreadData.
   SolverContext outer_ctx;
   auto thrp = outer_ctx.thread();
@@ -293,9 +289,7 @@ int STDCALL AnalysePlayPBN(
 }
 
 
-void play_single_common(
-  const int thrId,
-  const int bno)
+void play_single_common(const int bno)
 {
   SolvedPlay solved;
 
@@ -303,7 +297,7 @@ void play_single_common(
     playparam.bop->deals[bno],
     traceparam.plp->plays[bno],
     &solved,
-    thrId);
+    0);
 
   // If there are multiple errors, this will catch one of them.
   if (res == 1)
@@ -313,19 +307,19 @@ void play_single_common(
 }
 
 
-void play_chunk_common(const int thrId)
+void play_chunk_common()
 {
   int index;
   schedType st;
 
   while (1)
   {
-    st = scheduler.GetNumber(thrId);
+    st = scheduler.GetNumber(0);
     index = st.number;
     if (index == -1)
       break;
 
-    play_single_common(thrId, index);
+    play_single_common(index);
   }
 }
 
@@ -354,10 +348,8 @@ int STDCALL AnalyseAllPlaysBin(
 
   START_BLOCK_TIMER;
   
-  // Sequential execution: analyze each play in order
-  // Thread ID 0 is used for all plays (single-threaded)
   for (int bno = 0; bno < bop->no_of_boards; bno++) {
-    play_single_common(0, bno);
+    play_single_common(bno);
     if (playparam.error != 0)
       return playparam.error;
   }

--- a/library/src/play_analyser.hpp
+++ b/library/src/play_analyser.hpp
@@ -14,14 +14,7 @@
 #include <api/dll.h>
 
 
-void play_single_common(const int bno);
-
-void play_chunk_common();
-
 void detect_play_duplicates(
   const Boards& bds,
   std::vector<int>& uniques,
   std::vector<int>& crossrefs);
-
-void copy_play_single(
-  const std::vector<int>& crossrefs);

--- a/library/src/play_analyser.hpp
+++ b/library/src/play_analyser.hpp
@@ -14,12 +14,9 @@
 #include <api/dll.h>
 
 
-void play_single_common(
-  const int thrId,
-  const int bno);
+void play_single_common(const int bno);
 
-void play_chunk_common(
-  const int thrId);
+void play_chunk_common();
 
 void detect_play_duplicates(
   const Boards& bds,

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -20,7 +20,6 @@
 
 ParamType param;
 
-extern System sysdep;
 extern Memory memory;
 extern Scheduler scheduler;
 
@@ -34,16 +33,10 @@ auto same_board(
   const unsigned index2) -> bool;
 
 
-auto solve_single_common(
-  const int thrId,
-  const int bno) -> void
+auto solve_single_common(const int bno) -> void
 {
   FutureTricks fut;
 
-  // Fallback timing: measure per-board elapsed time (ms) even when
-  // DDS_SCHEDULER isn't enabled at compile time. This allows the
-  // dtest -r/--report option to print per-board timings.
-  START_THREAD_TIMER(thrId);
   auto t0 = std::chrono::steady_clock::now();
   int res = SolveBoard(
               param.bop->deals[bno],
@@ -51,9 +44,8 @@ auto solve_single_common(
               param.bop->solutions[bno],
               param.bop->mode[bno],
               &fut,
-              thrId);
+              0);
   auto t1 = std::chrono::steady_clock::now();
-  END_THREAD_TIMER(thrId);
 
   // Compute elapsed milliseconds and publish to scheduler as a
   // lightweight fallback. Scheduler will ignore or use this value
@@ -76,23 +68,20 @@ auto copy_solve_single(const vector<int>& crossrefs) -> void
     if (crossrefs[i] == -1)
       continue;
 
-    START_THREAD_TIMER(thrId);
-    param.solvedp->solved_board[i] = 
+    param.solvedp->solved_board[i] =
       param.solvedp->solved_board[crossrefs[i]];
-    END_THREAD_TIMER(thrId);
   }
 }
 
 
-auto solve_chunk_common(
-  const int thrId) -> void
+auto solve_chunk_common() -> void
 {
   int index;
   schedType st;
 
   while (1)
   {
-    st = scheduler.GetNumber(thrId);
+    st = scheduler.GetNumber(0);
     index = st.number;
     if (index == -1)
       break;
@@ -106,15 +95,13 @@ auto solve_chunk_common(
         param.bop->deals[index ].first ==
         param.bop->deals[st.repeatOf].first)
     {
-      START_THREAD_TIMER(thrId);
-      param.solvedp->solved_board[index] = 
+      param.solvedp->solved_board[index] =
         param.solvedp->solved_board[st.repeatOf];
-      END_THREAD_TIMER(thrId);
       continue;
     }
     else
     {
-      solve_single_common(thrId, index);
+      solve_single_common(index);
     }
   }
 }
@@ -139,11 +126,9 @@ auto solve_all_boards_n(
     solved.solved_board[k].cards = 0;
 
   START_BLOCK_TIMER;
-  
-  // Sequential execution: solve each board in order
-  // Thread ID 0 is used for all boards (single-threaded)
+
   for (int bno = 0; bno < bds.no_of_boards; bno++) {
-    solve_single_common(0, bno);
+    solve_single_common(bno);
     if (param.error != 0)
       return param.error;
   }

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -178,6 +178,46 @@ int STDCALL SolveAllBoardsBin(
 }
 
 
+int STDCALL SolveAllBoardsSeq(
+  BoardsPBN const * bop,
+  SolvedBoards * solvedp)
+{
+  Boards bo;
+  bo.no_of_boards = bop->no_of_boards;
+  if (bo.no_of_boards > MAXNOOFBOARDS)
+    return RETURN_TOO_MANY_BOARDS;
+
+  for (int k = 0; k < bop->no_of_boards; k++)
+  {
+    bo.mode[k] = bop->mode[k];
+    bo.solutions[k] = bop->solutions[k];
+    bo.target[k] = bop->target[k];
+    bo.deals[k].first = bop->deals[k].first;
+    bo.deals[k].trump = bop->deals[k].trump;
+
+    for (int i = 0; i <= 2; i++)
+    {
+      bo.deals[k].currentTrickSuit[i] = bop->deals[k].currentTrickSuit[i];
+      bo.deals[k].currentTrickRank[i] = bop->deals[k].currentTrickRank[i];
+    }
+
+    if (convert_from_pbn(bop->deals[k].remainCards, bo.deals[k].remainCards)
+        != 1)
+      return RETURN_PBN_FAULT;
+  }
+
+  return solve_all_boards_n_seq(bo, * solvedp);
+}
+
+
+int STDCALL SolveAllBoardsBinSeq(
+  Boards const * bop,
+  SolvedBoards * solvedp)
+{
+  return solve_all_boards_n_seq(* bop, * solvedp);
+}
+
+
 int STDCALL SolveAllChunksPBN(
   BoardsPBN const * bop,
   SolvedBoards * solvedp,

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -7,7 +7,11 @@
    See LICENSE and README.
 */
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <thread>
+#include <vector>
 
 #include "solve_board.hpp"
 #include <solver_if.hpp>
@@ -18,14 +22,8 @@
 #include <utility/debug.h>
 
 
-ParamType param;
-
 extern Memory memory;
 extern Scheduler scheduler;
-
-auto solve_all_boards_n(
-  Boards const & bds,
-  SolvedBoards& solved) -> int;
 
 auto same_board(
   const Boards& bds,
@@ -33,111 +31,66 @@ auto same_board(
   const unsigned index2) -> bool;
 
 
-auto solve_single_common(const int bno) -> void
-{
-  FutureTricks fut;
-
-  auto t0 = std::chrono::steady_clock::now();
-  int res = SolveBoard(
-              param.bop->deals[bno],
-              param.bop->target[bno],
-              param.bop->solutions[bno],
-              param.bop->mode[bno],
-              &fut,
-              0);
-  auto t1 = std::chrono::steady_clock::now();
-
-  // Compute elapsed milliseconds and publish to scheduler as a
-  // lightweight fallback. Scheduler will ignore or use this value
-  // when reporting if full DDS_SCHEDULER timing is not active.
-  auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
-  if (dur < 0) dur = 0;
-  scheduler.SetBoardTime(bno, static_cast<int>(dur));
-
-  if (res == 1)
-    param.solvedp->solved_board[bno] = fut;
-  else
-    param.error = res;
-}
-
-
-auto copy_solve_single(const vector<int>& crossrefs) -> void
-{
-  for (unsigned i = 0; i < crossrefs.size(); i++)
-  {
-    if (crossrefs[i] == -1)
-      continue;
-
-    param.solvedp->solved_board[i] =
-      param.solvedp->solved_board[crossrefs[i]];
-  }
-}
-
-
-auto solve_chunk_common() -> void
-{
-  int index;
-  schedType st;
-
-  while (1)
-  {
-    st = scheduler.GetNumber(0);
-    index = st.number;
-    if (index == -1)
-      break;
-
-    // This is not a perfect repeat detector, as the hands in
-    // a group might have declarers N, S, N, N. Then the second
-    // N would not reuse the first N. However, must reuses are
-    // reasonably adjacent, and this is just an optimization anyway.
-
-    if (st.repeatOf != -1 &&
-        param.bop->deals[index ].first ==
-        param.bop->deals[st.repeatOf].first)
-    {
-      param.solvedp->solved_board[index] =
-        param.solvedp->solved_board[st.repeatOf];
-      continue;
-    }
-    else
-    {
-      solve_single_common(index);
-    }
-  }
-}
-
-
 auto solve_all_boards_n(
-  Boards const & bds,
+  Boards const& bds,
   SolvedBoards& solved) -> int
 {
-  param.error = 0;
-
-  if (bds.no_of_boards > MAXNOOFBOARDS)
+  const int n = bds.no_of_boards;
+  if (n > MAXNOOFBOARDS)
     return RETURN_TOO_MANY_BOARDS;
-
-  param.bop = &bds;
-  param.solvedp = &solved;
-  param.no_of_boards = bds.no_of_boards;
-
-  scheduler.RegisterRun(RunMode::DDS_RUN_SOLVE, bds);
 
   for (int k = 0; k < MAXNOOFBOARDS; k++)
     solved.solved_board[k].cards = 0;
 
-  START_BLOCK_TIMER;
+  scheduler.RegisterRun(RunMode::DDS_RUN_SOLVE, bds);
 
-  for (int bno = 0; bno < bds.no_of_boards; bno++) {
-    solve_single_common(bno);
-    if (param.error != 0)
-      return param.error;
+  const int nthreads = std::max(1,
+    std::min(static_cast<int>(std::thread::hardware_concurrency()), n));
+
+  std::atomic<int> next_board{0};
+  std::atomic<int> first_error{0};
+
+  auto worker = [&] {
+    for (;;) {
+      const int bno = next_board.fetch_add(1, std::memory_order_relaxed);
+      if (bno >= n || first_error.load(std::memory_order_relaxed) != 0)
+        break;
+
+      FutureTricks fut;
+      const auto t0 = std::chrono::steady_clock::now();
+      const int res = SolveBoard(
+        bds.deals[bno], bds.target[bno], bds.solutions[bno],
+        bds.mode[bno], &fut, 0);
+      auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+      if (dur < 0) dur = 0;
+      scheduler.SetBoardTime(bno, static_cast<int>(dur));
+
+      if (res == 1)
+        solved.solved_board[bno] = fut;
+      else {
+        int expected = 0;
+        first_error.compare_exchange_strong(
+          expected, res, std::memory_order_relaxed);
+      }
+    }
+  };
+
+  START_BLOCK_TIMER;
+  {
+    std::vector<std::jthread> threads;
+    threads.reserve(static_cast<unsigned>(nthreads));
+    for (int i = 0; i < nthreads; ++i)
+      threads.emplace_back(worker);
   }
-  
   END_BLOCK_TIMER;
 
-  solved.no_of_boards = param.no_of_boards;
+  if (const int err = first_error.load(); err != 0)
+    return err;
 
-#ifdef DDS_SCHEDULER 
+  solved.no_of_boards = n;
+
+#ifdef DDS_SCHEDULER
   scheduler.PrintTiming();
 #endif
 

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -217,6 +217,53 @@ int STDCALL SolveAllChunksBin(
 }
 
 
+auto solve_all_boards_n_seq(
+  Boards const& bds,
+  SolvedBoards& solved) -> int
+{
+  const int n = bds.no_of_boards;
+  if (n > MAXNOOFBOARDS)
+    return RETURN_TOO_MANY_BOARDS;
+
+  for (int k = 0; k < MAXNOOFBOARDS; k++)
+    solved.solved_board[k].cards = 0;
+
+  scheduler.RegisterRun(RunMode::DDS_RUN_SOLVE, bds);
+
+  int error = 0;
+
+  START_BLOCK_TIMER;
+  for (int bno = 0; bno < n && error == 0; bno++) {
+    FutureTricks fut;
+    const auto t0 = std::chrono::steady_clock::now();
+    const int res = SolveBoard(
+      bds.deals[bno], bds.target[bno], bds.solutions[bno],
+      bds.mode[bno], &fut, 0);
+    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - t0).count();
+    if (dur < 0) dur = 0;
+    scheduler.SetBoardTime(bno, static_cast<int>(dur));
+
+    if (res == 1)
+      solved.solved_board[bno] = fut;
+    else
+      error = res;
+  }
+  END_BLOCK_TIMER;
+
+  if (error != 0)
+    return error;
+
+  solved.no_of_boards = n;
+
+#ifdef DDS_SCHEDULER
+  scheduler.PrintTiming();
+#endif
+
+  return RETURN_NO_FAULT;
+}
+
+
 auto detect_solve_duplicates(
   const Boards& bds,
   vector<int>& uniques,

--- a/library/src/solve_board.hpp
+++ b/library/src/solve_board.hpp
@@ -14,12 +14,6 @@
 #include <api/dll.h>
 
 
-auto solve_single_common(const int bno) -> void;
-
-auto copy_solve_single(const std::vector<int>& crossrefs) -> void;
-
-auto solve_chunk_common() -> void;
-
 auto detect_solve_duplicates(
   const Boards& bds,
   std::vector<int>& uniques,

--- a/library/src/solve_board.hpp
+++ b/library/src/solve_board.hpp
@@ -14,6 +14,10 @@
 #include <api/dll.h>
 
 
+auto solve_all_boards_n_seq(
+  Boards const& bds,
+  SolvedBoards& solved) -> int;
+
 auto detect_solve_duplicates(
   const Boards& bds,
   std::vector<int>& uniques,

--- a/library/src/solve_board.hpp
+++ b/library/src/solve_board.hpp
@@ -14,15 +14,11 @@
 #include <api/dll.h>
 
 
-auto solve_single_common(
-  const int thrId,
-  const int bno) -> void;
+auto solve_single_common(const int bno) -> void;
 
-auto copy_solve_single(
-  const std::vector<int>& crossrefs) -> void;
+auto copy_solve_single(const std::vector<int>& crossrefs) -> void;
 
-auto solve_chunk_common(
-  const int thrId) -> void;
+auto solve_chunk_common() -> void;
 
 auto detect_solve_duplicates(
   const Boards& bds,

--- a/library/src/solver_if.cpp
+++ b/library/src/solver_if.cpp
@@ -19,7 +19,6 @@
 #include <system/timer_list.hpp>
 #include <trans_table/trans_table.hpp>
 
-extern System sysdep;
 extern Memory memory;
 extern Scheduler scheduler;
 
@@ -73,12 +72,8 @@ int STDCALL SolveBoard(
   int solutions,
   int mode,
   FutureTricks * futp,
-  int thrId)
+  [[maybe_unused]] int thrId)
 {
-  if (! sysdep.thread_ok(thrId))
-    return RETURN_THREAD_INDEX;
-
-  // Create an owned context for this call and delegate to the C++ overload.
   SolverContext outer_ctx;
   return solve_board(outer_ctx, dl, target, solutions, mode, futp);
 }

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -133,23 +133,8 @@ const vector<string> DDS_SYSTEM_THREADING =
 #define DDS_SYSTEM_THREAD_SIZE 9
 
 
-System::System(
-    [[maybe_unused]] FptrType solve_chunk_common,
-    [[maybe_unused]] FptrType calc_chunk_common,
-    [[maybe_unused]] FptrType play_chunk_common,
-    [[maybe_unused]] FduplType detect_solve_duplicates,
-    [[maybe_unused]] FduplType detect_calc_duplicates,
-    [[maybe_unused]] FduplType detect_play_duplicates,
-    [[maybe_unused]] FsingleType solve_single_common,
-    [[maybe_unused]] FsingleType calc_single_common,
-    [[maybe_unused]] FsingleType play_single_common,
-    [[maybe_unused]] FcopyType copy_solve_single,
-    [[maybe_unused]] FcopyType copy_calc_single,
-    [[maybe_unused]] FcopyType copy_play_single
-)
+System::System()
 {
-  // Threading infrastructure removed: callbacks no longer registered.
-  // System now only provides hardware detection and configuration.
   System::reset();
 }
 
@@ -284,12 +269,6 @@ int System::register_params(
   num_threads_ = n_threads;
   sys_mem_mb_ = mem_usable_mb;
   return RETURN_NO_FAULT;
-}
-
-
-bool System::thread_ok(const int thread_id) const
-{
-  return (thread_id >= 0 && thread_id < num_threads_);
 }
 
 

--- a/library/src/system/system.hpp
+++ b/library/src/system/system.hpp
@@ -22,10 +22,8 @@
 
 using namespace std;
 
-typedef void (*FptrType)(const int thread_id);
 typedef void (*FduplType)(
   const Boards& bds, vector<int>& uniques, vector<int>& crossrefs);
-typedef void (*FsingleType)(const int thread_id, const int board_number);
 typedef void (*FcopyType)(const vector<int>& crossrefs);
 
 
@@ -66,23 +64,9 @@ class System
     /**
      * @brief Construct a new System object.
      *
-     * Initializes system-dependent state, threading, and memory management for
-     * the double dummy solver.
+     * Initializes system-dependent state and hardware detection for the solver.
      */
-    System(
-      FptrType solve_chunk_common,
-      FptrType calc_chunk_common,
-      FptrType play_chunk_common,
-      FduplType detect_solve_duplicates,
-      FduplType detect_calc_duplicates,
-      FduplType detect_play_duplicates,
-      FsingleType solve_single_common,
-      FsingleType calc_single_common,
-      FsingleType play_single_common,
-      FcopyType copy_solve_single,
-      FcopyType copy_calc_single,
-      FcopyType copy_play_single
-    );
+    System();
 
     /**
      * @brief Destroy the System object and clean up resources.
@@ -96,8 +80,6 @@ class System
     int register_params(
       const int n_threads,
       const int mem_usable_mb);
-
-    bool thread_ok(const int thread_id) const;
 
     void get_hardware(
       int& core_count,


### PR DESCRIPTION
Parallel processing of a batch of boards had been removed as the code to chunk about static memory in per thread allocations had become quite fragile, and frequently caused crashes on macOS. Introducing a per call SolverContext, with the option for the calling code to supply one for re-use, should make it easier to implement a parallel version.

There were, however, a couple of lingering pieces of statically allocated memory. This did not prevent creating a parallel version of SolveAllBoards, but was dangerous when library functions were called from several threads simultaneously.

Big thanks and kudos to [jdh8](https://github.com/jdh8) for identifying the problem.