### PR TITLE
calc_tables: drop racing scheduler.RegisterRun call

### DIFF
--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -80,8 +80,6 @@ auto calc_all_boards_n(
   if (bop->no_of_boards > MAXNOOFBOARDS)
     return RETURN_TOO_MANY_BOARDS;
 
-  scheduler.RegisterRun(RunMode::DDS_RUN_CALC, * bop);
-
   for (int k = 0; k < MAXNOOFBOARDS; k++)
     solvedp->solved_board[k].cards = 0;
 


### PR DESCRIPTION
`calc_all_boards_n(ctx, ...)` still writes to the file-scope `Scheduler scheduler` global on entry, even though 9ebcac5 made the rest of the path thread-safe. With multiple `SolverContext`s driving `calc_dd_table` concurrently, all workers race on `scheduler.hands[]` / `numHands` / `threadGroup` and the heap corruption SIGSEGVs downstream.

The registered run data has no live consumer on the sequential execution path (the only reader, `Scheduler::GetNumber` in `calc_chunk_common`, is dead code; the surrounding `PrintTiming` call is `#ifdef DDS_SCHEDULER`-gated). Dropping the call is functionally a no-op in standard builds.

Removes one race. A deeper race in the TT/search path remains under sustained contention and is left for a separate PR.
