### PR TITLE
python: bind AnalysePlayPBN, AnalyseAllPlaysPBN, DealerPar, SetMaxThreads

### DIFF
--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -286,15 +286,15 @@ Batched form of `analyse_play_pbn` (wraps `AnalyseAllPlaysPBN`).
 
 Legacy thread-resource hook (wraps the **deprecated** `SetMaxThreads` C API).
 
-DDS 3.x removed internal batch parallelism: the legacy batch APIs
-(`solve_all_boards_*`, `analyse_all_plays_pbn`) run **single-threaded** regardless
-of this value, so calling it does **not** enable multi-threaded solving — it only
-sizes the single internal thread's memory and is kept for backward compatibility.
-`user_threads` must be `>= 0` (`0` = auto); values `> 1` are accepted but clamped
-to one thread. Raises `ValueError` for negative values.
+This does **not** control DDS's batch parallelism and is kept only for backward
+compatibility. `solve_all_boards_*` already parallelise across the machine's
+hardware threads automatically (via `solve_boards_n`) — the value passed here does
+not size that pool. `analyse_all_plays_pbn` currently runs sequentially.
+`user_threads` must be `>= 0` (`0` = auto); raises `ValueError` for negative values.
 
-For real concurrency, create one `SolverContext` per worker thread and pass it to
-`solve_board` / `solve_board_pbn` (which release the GIL during the search).
+For per-board concurrency from Python, create one `SolverContext` per worker thread
+and pass it to `solve_board` / `solve_board_pbn` (which release the GIL during the
+search).
 
 ## Card Representation
 

--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -228,6 +228,66 @@ print(f"Par: {par_result['par_score']}")
 print(f"Contract: {par_result['par_contracts_string']}")
 ```
 
+#### `dealer_par(table_results, dealer, vulnerable=0)`
+
+Calculates par contracts and score from the dealer's perspective (wraps `DealerPar`).
+
+**Parameters:**
+- `table_results` (dict): DD table result with key `res_table` (e.g. from `calc_dd_table`)
+- `dealer` (int): Dealer seat (0=N, 1=E, 2=S, 3=W)
+- `vulnerable` (int, default=0): Vulnerability (0=none, 1=both, 2=NS, 3=EW)
+
+**Returns:**
+- dict with keys: `score` (int), `number` (int), `contracts` (list[str], length `number`)
+
+```python
+from dds3 import calc_dd_table, dealer_par
+
+dd_result = calc_dd_table(table_deal)
+result = dealer_par(dd_result, dealer=0, vulnerable=0)
+print(result["score"], result["contracts"])
+```
+
+#### `analyse_play_pbn(remain_cards, play, trump=4, first=0, current_trick_suit=(0,0,0), current_trick_rank=(0,0,0), thread_index=0)`
+
+Returns the double-dummy trick count after each card of a played hand (wraps `AnalysePlayPBN`).
+
+**Parameters:**
+- `remain_cards` (str): Full deal in PBN format before any card of `play`
+- `play` (str): Cards played, 2 characters each (suit+rank), e.g. `"SAHK..."`
+- `trump` (int, default=4): Trump suit (0=♠, 1=♥, 2=♦, 3=♣, 4=NT)
+- `first` (int, default=0): Seat that leads (0=N, 1=E, 2=S, 3=W)
+- `current_trick_suit` / `current_trick_rank` (seq, default=(0,0,0)): Cards already in the trick
+- `thread_index` (int, default=0): Thread id
+
+**Returns:**
+- dict with keys: `number` (int), `tricks` (list[int]) — `tricks[i]` is the trick count for the side to play after `i` cards.
+
+```python
+from dds3 import analyse_play_pbn
+
+deal = "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3"
+result = analyse_play_pbn(deal, play="S6", trump=4, first=0)
+print(result["tricks"])
+```
+
+#### `analyse_all_plays_pbn(deals)`
+
+Batched form of `analyse_play_pbn` (wraps `AnalyseAllPlaysPBN`).
+
+**Parameters:**
+- `deals` (list[dict]): Up to 200 dicts, each with `remain_cards` (str, required), `play`
+  (str, required), and optional `trump`, `first`, `current_trick_suit`, `current_trick_rank`.
+
+**Returns:**
+- list[dict]: one `{number, tricks}` dict per deal (same shape as `analyse_play_pbn`).
+
+#### `set_max_threads(user_threads=0)`
+
+Sets the maximum number of threads DDS uses for the batch APIs (`solve_all_boards_*`,
+`analyse_all_plays_pbn`). `0` auto-configures from CPU/memory. Per-board
+`solve_board` / `solve_board_pbn` calls use `SolverContext` for concurrency instead.
+
 ## Card Representation
 
 ### Binary Format (remain_cards)

--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -284,9 +284,17 @@ Batched form of `analyse_play_pbn` (wraps `AnalyseAllPlaysPBN`).
 
 #### `set_max_threads(user_threads=0)`
 
-Sets the maximum number of threads DDS uses for the batch APIs (`solve_all_boards_*`,
-`analyse_all_plays_pbn`). `0` auto-configures from CPU/memory. Per-board
-`solve_board` / `solve_board_pbn` calls use `SolverContext` for concurrency instead.
+Legacy thread-resource hook (wraps the **deprecated** `SetMaxThreads` C API).
+
+DDS 3.x removed internal batch parallelism: the legacy batch APIs
+(`solve_all_boards_*`, `analyse_all_plays_pbn`) run **single-threaded** regardless
+of this value, so calling it does **not** enable multi-threaded solving — it only
+sizes the single internal thread's memory and is kept for backward compatibility.
+`user_threads` must be `>= 0` (`0` = auto); values `> 1` are accepted but clamped
+to one thread. Raises `ValueError` for negative values.
+
+For real concurrency, create one `SolverContext` per worker thread and pass it to
+`solve_board` / `solve_board_pbn` (which release the GIL during the search).
 
 ## Card Representation
 

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -121,6 +121,14 @@ py_test(
 )
 
 py_test(
+    name = "analyse_test",
+    size = "small",
+    main = "tests/test_analyse.py",
+    srcs = ["tests/test_analyse.py"],
+    deps = [":dds3_lib"],
+)
+
+py_test(
     name = "type_conversions_test",
     size = "small",
     main = "tests/test_type_conversions.py",

--- a/python/dds3/__init__.py
+++ b/python/dds3/__init__.py
@@ -1,11 +1,15 @@
 try:
+    from ._dds3 import analyse_all_plays_pbn
+    from ._dds3 import analyse_play_pbn
     from ._dds3 import api_root
     from ._dds3 import calc_all_tables_pbn
     from ._dds3 import calc_dd_table
     from ._dds3 import calc_par
     from ._dds3 import calc_par_from_table
+    from ._dds3 import dealer_par
     from ._dds3 import module_name
     from ._dds3 import par
+    from ._dds3 import set_max_threads
     from ._dds3 import SolverContext
     from ._dds3 import solve_all_boards_bin
     from ._dds3 import solve_all_boards_pbn
@@ -13,13 +17,17 @@ try:
     from ._dds3 import solve_board_pbn
 except ImportError:
     # Fallback for environments where _dds3 is available as a top-level module
+    from _dds3 import analyse_all_plays_pbn
+    from _dds3 import analyse_play_pbn
     from _dds3 import api_root
     from _dds3 import calc_all_tables_pbn
     from _dds3 import calc_dd_table
     from _dds3 import calc_par
     from _dds3 import calc_par_from_table
+    from _dds3 import dealer_par
     from _dds3 import module_name
     from _dds3 import par
+    from _dds3 import set_max_threads
     from _dds3 import SolverContext
     from _dds3 import solve_all_boards_bin
     from _dds3 import solve_all_boards_pbn
@@ -27,13 +35,17 @@ except ImportError:
     from _dds3 import solve_board_pbn
 
 __all__ = [
+    "analyse_all_plays_pbn",
+    "analyse_play_pbn",
     "api_root",
     "calc_all_tables_pbn",
     "calc_dd_table",
     "calc_par",
     "calc_par_from_table",
+    "dealer_par",
     "module_name",
     "par",
+    "set_max_threads",
     "SolverContext",
     "solve_all_boards_bin",
     "solve_all_boards_pbn",

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -612,14 +612,14 @@ auto register_analysis_bindings(py::module_& module) -> void
         },
         py::arg("user_threads") = 0,
         "Legacy thread-resource hook (wraps the deprecated SetMaxThreads C API).\n\n"
-        "DDS 3.x removed internal batch parallelism: the legacy batch APIs run\n"
-        "single-threaded regardless of this value, so calling this does NOT enable\n"
-        "multi-threaded solving. It only sizes the (single) internal thread's memory\n"
-        "and is retained for backward compatibility. For concurrency, create one\n"
+        "This does NOT control DDS's batch parallelism and is retained only for\n"
+        "backward compatibility. solve_all_boards_* already parallelise across the\n"
+        "machine's hardware threads automatically (see solve_boards_n); the value\n"
+        "passed here does not size that pool. analyse_all_plays_pbn currently runs\n"
+        "sequentially. For per-board concurrency from Python, create one\n"
         "SolverContext per worker thread and pass it to solve_board / solve_board_pbn.\n\n"
         "Args:\n"
-        "    user_threads (int, optional): Must be >= 0; 0 = auto. Values > 1 are\n"
-        "        accepted but clamped to a single internal thread. Default: 0\n\n"
+        "    user_threads (int, optional): Must be >= 0; 0 = auto. Default: 0\n\n"
         "Raises:\n"
         "    ValueError: If user_threads < 0.");
 
@@ -749,8 +749,8 @@ auto register_analysis_bindings(py::module_& module) -> void
         },
         py::arg("deals"),
         "Analyse multiple played deals in one batched call.\n\n"
-        "Wraps the DDS AnalyseAllPlaysPBN C API. Note: DDS 3.x runs the legacy\n"
-        "batch APIs single-threaded (internal parallelism was removed).\n\n"
+        "Wraps the DDS AnalyseAllPlaysPBN C API. Note: this batch entry point\n"
+        "currently solves the deals sequentially (one board at a time).\n\n"
         "Args:\n"
         "    deals (list[dict]): Up to 200 dicts, each with:\n"
         "        'remain_cards' (str, required): full deal in PBN format.\n"

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -594,6 +595,216 @@ auto register_calc_par_bindings(py::module_& module) -> void
         "    ValueError: If input validation fails (invalid table or vulnerability).\n"
         "    RuntimeError: If DDS solver returns error code.");
 }
+
+auto register_analysis_bindings(py::module_& module) -> void
+{
+    // set_max_threads: configure the worker-thread count used by the batch
+    // APIs (solve_all_boards_*, analyse_all_plays_pbn). 0 = auto-configure.
+    module.def(
+        "set_max_threads",
+        [](const int user_threads) { SetMaxThreads(user_threads); },
+        py::arg("user_threads") = 0,
+        "Set the maximum number of threads DDS uses for batch solving.\n\n"
+        "Args:\n"
+        "    user_threads (int, optional): Thread count; 0 = auto-configure. Default: 0\n\n"
+        "Notes:\n"
+        "    Affects the batch APIs (solve_all_boards_*, analyse_all_plays_pbn).\n"
+        "    Per-board solve_board / solve_board_pbn calls use SolverContext instead.");
+
+    // analyse_play_pbn: double-dummy trick count after each card of a played hand.
+    module.def(
+        "analyse_play_pbn",
+        [](const std::string& remain_cards,
+           const std::string& play,
+           const int trump,
+           const int first,
+           const py::sequence& current_trick_suit,
+           const py::sequence& current_trick_rank,
+           const int thread_index) {
+            const DealPBN native_deal = dds3_python::pbn_to_deal(
+                remain_cards, trump, first, current_trick_suit, current_trick_rank);
+
+            constexpr std::size_t max_play = sizeof(PlayTracePBN::cards) - 1U;
+            if (play.size() > max_play) {
+                throw py::value_error(
+                    "play string is too long (" + std::to_string(play.size()) +
+                    " chars, maximum " + std::to_string(max_play) + ")");
+            }
+            if (play.size() % 2U != 0U) {
+                throw py::value_error(
+                    "play string length must be even (2 characters per card)");
+            }
+
+            PlayTracePBN trace{};
+            trace.number = static_cast<int>(play.size() / 2U);
+            play.copy(trace.cards, play.size());
+
+            SolvedPlay solved{};
+            int code = RETURN_NO_FAULT;
+            {
+                py::gil_scoped_release release;
+                code = AnalysePlayPBN(native_deal, trace, &solved, thread_index);
+            }
+            throw_on_dds_error(code);
+            return dds3_python::solved_play_to_dict(solved);
+        },
+        py::arg("remain_cards"),
+        py::arg("play"),
+        py::arg("trump") = 4,
+        py::arg("first") = 0,
+        py::arg("current_trick_suit") = py::make_tuple(0, 0, 0),
+        py::arg("current_trick_rank") = py::make_tuple(0, 0, 0),
+        py::arg("thread_index") = 0,
+        "Analyse a played deal: double-dummy trick count after each card played.\n\n"
+        "Wraps the DDS AnalysePlayPBN C API.\n\n"
+        "Args:\n"
+        "    remain_cards (str): Full deal in PBN format before any card of 'play'.\n"
+        "    play (str): Cards played, 2 chars each (suit+rank), e.g. 'SAHK...'.\n"
+        "    trump (int, optional): Trump suit (0=♠,1=♥,2=♦,3=♣,4=NT). Default: 4\n"
+        "    first (int, optional): Seat that leads (0=N,1=E,2=S,3=W). Default: 0\n"
+        "    current_trick_suit (seq, optional): Suits already in the trick. Default: (0,0,0)\n"
+        "    current_trick_rank (seq, optional): Ranks already in the trick. Default: (0,0,0)\n"
+        "    thread_index (int, optional): Thread id. Default: 0\n\n"
+        "Returns:\n"
+        "    dict: {'number': int, 'tricks': list[int]} -- tricks[i] is the\n"
+        "          double-dummy trick count for the side to play after i cards.\n\n"
+        "Raises:\n"
+        "    ValueError: If PBN or play format is invalid.\n"
+        "    RuntimeError: If DDS solver returns error code.");
+
+    // analyse_all_plays_pbn: batched play analysis.
+    module.def(
+        "analyse_all_plays_pbn",
+        [](const py::list& deals) {
+            const auto count = static_cast<std::size_t>(deals.size());
+            if (count > static_cast<std::size_t>(MAXNOOFBOARDS)) {
+                throw py::value_error(
+                    "analyse_all_plays_pbn: too many boards (" + std::to_string(count) +
+                    ", maximum " + std::to_string(MAXNOOFBOARDS) + ")");
+            }
+
+            auto boards = std::make_unique<BoardsPBN>();
+            auto traces = std::make_unique<PlayTracesPBN>();
+            auto solved = std::make_unique<SolvedPlays>();
+            boards->no_of_boards = static_cast<int>(count);
+            traces->no_of_boards = static_cast<int>(count);
+
+            constexpr std::size_t max_play = sizeof(PlayTracePBN::cards) - 1U;
+            const auto default_trick = py::make_tuple(0, 0, 0);
+            for (std::size_t i = 0; i < count; ++i) {
+                const auto deal = py::cast<py::dict>(deals[i]);
+
+                const auto remain_cards = py::cast<std::string>(deal["remain_cards"]);
+                const auto play = py::cast<std::string>(deal["play"]);
+                const int trump = deal.contains("trump") ? py::cast<int>(deal["trump"]) : 4;
+                const int first = deal.contains("first") ? py::cast<int>(deal["first"]) : 0;
+                const py::sequence trick_suit = deal.contains("current_trick_suit")
+                    ? py::cast<py::sequence>(deal["current_trick_suit"])
+                    : py::cast<py::sequence>(default_trick);
+                const py::sequence trick_rank = deal.contains("current_trick_rank")
+                    ? py::cast<py::sequence>(deal["current_trick_rank"])
+                    : py::cast<py::sequence>(default_trick);
+
+                boards->deals[i] = dds3_python::pbn_to_deal(
+                    remain_cards, trump, first, trick_suit, trick_rank);
+                boards->target[i] = -1;
+                boards->solutions[i] = 3;
+                boards->mode[i] = 0;
+
+                if (play.size() > max_play || play.size() % 2U != 0U) {
+                    throw py::value_error(
+                        "play string at index " + std::to_string(i) +
+                        " is invalid (even length, at most " + std::to_string(max_play) +
+                        " chars)");
+                }
+                traces->plays[i].number = static_cast<int>(play.size() / 2U);
+                play.copy(traces->plays[i].cards, play.size());
+            }
+
+            int code = RETURN_NO_FAULT;
+            {
+                py::gil_scoped_release release;
+                // chunkSize is forced to 1 internally by DDS; the value is irrelevant.
+                code = AnalyseAllPlaysPBN(boards.get(), traces.get(), solved.get(), 1);
+            }
+            throw_on_dds_error(code);
+
+            py::list results;
+            for (int i = 0; i < solved->no_of_boards; ++i) {
+                results.append(dds3_python::solved_play_to_dict(solved->solved[i]));
+            }
+            return results;
+        },
+        py::arg("deals"),
+        "Analyse multiple played deals in one batched, multi-threaded call.\n\n"
+        "Wraps the DDS AnalyseAllPlaysPBN C API.\n\n"
+        "Args:\n"
+        "    deals (list[dict]): Up to 200 dicts, each with:\n"
+        "        'remain_cards' (str, required): full deal in PBN format.\n"
+        "        'play' (str, required): cards played, 2 chars each (suit+rank).\n"
+        "        'trump' (int, optional): 0-4. Default: 4\n"
+        "        'first' (int, optional): 0-3. Default: 0\n"
+        "        'current_trick_suit'/'current_trick_rank' (seq, optional): default (0,0,0)\n\n"
+        "Returns:\n"
+        "    list[dict]: one {'number', 'tricks'} dict per deal (see analyse_play_pbn).\n\n"
+        "Raises:\n"
+        "    ValueError: If more than 200 boards, or PBN/play format is invalid.\n"
+        "    KeyError: If a deal dict is missing 'remain_cards' or 'play'.\n"
+        "    RuntimeError: If DDS solver returns error code.");
+
+    // dealer_par: par contracts from the dealer's perspective.
+    module.def(
+        "dealer_par",
+        [](const py::dict& table_results, const int dealer, const int vulnerable) {
+            if (dealer < 0 || dealer > 3) {
+                throw py::value_error(
+                    "dealer has invalid value " + std::to_string(dealer) +
+                    " (expected 0=N, 1=E, 2=S, 3=W)");
+            }
+            if (vulnerable < 0 || vulnerable > 3) {
+                throw py::value_error(
+                    "vulnerable has invalid value " + std::to_string(vulnerable) +
+                    " (expected 0=none, 1=both, 2=NS, 3=EW)");
+            }
+
+            const DdTableResults native_table =
+                dds3_python::dict_to_dd_table_results(table_results);
+            ParResultsDealer par_results{};
+            int code = RETURN_NO_FAULT;
+            {
+                py::gil_scoped_release release;
+                code = DealerPar(&native_table, &par_results, dealer, vulnerable);
+            }
+            throw_on_dds_error(code);
+
+            py::list contracts;
+            const int contract_count = std::max(0, std::min(par_results.number, 10));
+            for (int i = 0; i < contract_count; ++i) {
+                contracts.append(std::string(par_results.contracts[i]));
+            }
+            py::dict result;
+            result["score"] = par_results.score;
+            result["number"] = par_results.number;
+            result["contracts"] = contracts;
+            return result;
+        },
+        py::arg("table_results"),
+        py::arg("dealer"),
+        py::arg("vulnerable") = 0,
+        "Calculate par contracts from the dealer's perspective.\n\n"
+        "Wraps the DDS DealerPar C API.\n\n"
+        "Args:\n"
+        "    table_results (dict): DD table dict with key 'res_table' (5x4 nested list),\n"
+        "        e.g. the result of calc_dd_table.\n"
+        "    dealer (int): Dealer seat (0=N, 1=E, 2=S, 3=W).\n"
+        "    vulnerable (int, optional): Vulnerability (0=none, 1=both, 2=NS, 3=EW). Default: 0\n\n"
+        "Returns:\n"
+        "    dict: {'score': int, 'number': int, 'contracts': list[str]} -- 'number'\n"
+        "          par contract strings; 'score' is signed from the dealer's side view.\n\n"
+        "Raises:\n"
+        "    ValueError: If dealer/vulnerable out of range or table is invalid.\n"
+        "    RuntimeError: If DDS solver returns error code.");
+}
 }  // namespace
 
 PYBIND11_MODULE(_dds3, module)
@@ -617,6 +828,7 @@ PYBIND11_MODULE(_dds3, module)
     register_table_bindings(module);
     register_par_bindings(module);
     register_calc_par_bindings(module);
+    register_analysis_bindings(module);
 
     module.def("api_root", []() {
         return "dds.hpp";

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -602,14 +602,26 @@ auto register_analysis_bindings(py::module_& module) -> void
     // APIs (solve_all_boards_*, analyse_all_plays_pbn). 0 = auto-configure.
     module.def(
         "set_max_threads",
-        [](const int user_threads) { SetMaxThreads(user_threads); },
+        [](const int user_threads) {
+            if (user_threads < 0) {
+                throw py::value_error(
+                    "user_threads has invalid value " + std::to_string(user_threads) +
+                    " (expected >= 0; 0 = auto)");
+            }
+            SetMaxThreads(user_threads);
+        },
         py::arg("user_threads") = 0,
-        "Set the maximum number of threads DDS uses for batch solving.\n\n"
+        "Legacy thread-resource hook (wraps the deprecated SetMaxThreads C API).\n\n"
+        "DDS 3.x removed internal batch parallelism: the legacy batch APIs run\n"
+        "single-threaded regardless of this value, so calling this does NOT enable\n"
+        "multi-threaded solving. It only sizes the (single) internal thread's memory\n"
+        "and is retained for backward compatibility. For concurrency, create one\n"
+        "SolverContext per worker thread and pass it to solve_board / solve_board_pbn.\n\n"
         "Args:\n"
-        "    user_threads (int, optional): Thread count; 0 = auto-configure. Default: 0\n\n"
-        "Notes:\n"
-        "    Affects the batch APIs (solve_all_boards_*, analyse_all_plays_pbn).\n"
-        "    Per-board solve_board / solve_board_pbn calls use SolverContext instead.");
+        "    user_threads (int, optional): Must be >= 0; 0 = auto. Values > 1 are\n"
+        "        accepted but clamped to a single internal thread. Default: 0\n\n"
+        "Raises:\n"
+        "    ValueError: If user_threads < 0.");
 
     // analyse_play_pbn: double-dummy trick count after each card of a played hand.
     module.def(
@@ -736,8 +748,9 @@ auto register_analysis_bindings(py::module_& module) -> void
             return results;
         },
         py::arg("deals"),
-        "Analyse multiple played deals in one batched, multi-threaded call.\n\n"
-        "Wraps the DDS AnalyseAllPlaysPBN C API.\n\n"
+        "Analyse multiple played deals in one batched call.\n\n"
+        "Wraps the DDS AnalyseAllPlaysPBN C API. Note: DDS 3.x runs the legacy\n"
+        "batch APIs single-threaded (internal parallelism was removed).\n\n"
         "Args:\n"
         "    deals (list[dict]): Up to 200 dicts, each with:\n"
         "        'remain_cards' (str, required): full deal in PBN format.\n"
@@ -784,7 +797,9 @@ auto register_analysis_bindings(py::module_& module) -> void
             }
             py::dict result;
             result["score"] = par_results.score;
-            result["number"] = par_results.number;
+            // Report the count actually returned so len(contracts) == number
+            // always holds, even if DDS yields an out-of-range number.
+            result["number"] = contract_count;
             result["contracts"] = contracts;
             return result;
         },

--- a/python/src/converters.cpp
+++ b/python/src/converters.cpp
@@ -303,7 +303,9 @@ auto solved_play_to_dict(const SolvedPlay& solved_play) -> py::dict
     }
 
     py::dict result;
-    result["number"] = solved_play.number;
+    // Report the count actually returned so len(tricks) == number always holds,
+    // even if DDS ever yields an out-of-range solved_play.number.
+    result["number"] = count;
     result["tricks"] = tricks;
     return result;
 }

--- a/python/src/converters.cpp
+++ b/python/src/converters.cpp
@@ -294,6 +294,20 @@ auto par_results_to_dict(const ParResults& par_results) -> py::dict
     return result;
 }
 
+auto solved_play_to_dict(const SolvedPlay& solved_play) -> py::dict
+{
+    py::list tricks;
+    const int count = std::max(0, std::min(solved_play.number, 53));
+    for (int i = 0; i < count; ++i) {
+        tricks.append(solved_play.tricks[i]);
+    }
+
+    py::dict result;
+    result["number"] = solved_play.number;
+    result["tricks"] = tricks;
+    return result;
+}
+
 auto list_to_dd_table_deals_pbn(
     const py::list& deals_pbn,
     const std::size_t max_tables) -> DdTableDealsPBN

--- a/python/src/converters.hpp
+++ b/python/src/converters.hpp
@@ -35,6 +35,7 @@ auto dict_to_dd_table_results(const pybind11::dict& table_input) -> DdTableResul
 auto future_tricks_to_dict(const FutureTricks& future_tricks) -> pybind11::dict;
 auto dd_table_results_to_dict(const DdTableResults& table_results) -> pybind11::dict;
 auto par_results_to_dict(const ParResults& par_results) -> pybind11::dict;
+auto solved_play_to_dict(const SolvedPlay& solved_play) -> pybind11::dict;
 
 auto list_to_dd_table_deals_pbn(
     const pybind11::list& deals_pbn,

--- a/python/tests/test_analyse.py
+++ b/python/tests/test_analyse.py
@@ -1,0 +1,96 @@
+"""Tests for analyse_play_pbn, analyse_all_plays_pbn and dealer_par."""
+
+import unittest
+
+from dds3 import (
+    analyse_all_plays_pbn,
+    analyse_play_pbn,
+    calc_dd_table,
+    dealer_par,
+    set_max_threads,
+)
+
+# A full 52-card deal in PBN (from docs/python_interface.md).
+DEAL = "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3"
+
+# Rank bitmask constants.
+R2, R3, R4, R5, R6, R7, R8 = 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100
+R9, RT, RJ, RQ, RK, RA = 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000
+
+# Test hand 0 from examples/hands.cpp (cards[hand][suit]).
+HAND0 = {
+    "cards": [
+        [RQ | RJ | R6, RK | R6 | R5 | R2, RJ | R8 | R5, RT | R9 | R8],
+        [R8 | R7 | R3, RJ | R9 | R7, RA | RT | R7 | R6 | R4, RQ | R4],
+        [RK | R5, RT | R8 | R3, RK | RQ | R9, RA | R7 | R6 | R5 | R2],
+        [RA | RT | R9 | R4 | R2, RA | RQ | R4, R3 | R2, RK | RJ | R3],
+    ]
+}
+
+
+class TestAnalysePlay(unittest.TestCase):
+    """Tests for analyse_play_pbn / analyse_all_plays_pbn."""
+
+    def setUp(self) -> None:
+        set_max_threads(0)
+
+    def test_analyse_play_pbn_basic(self) -> None:
+        # North leads the spade 6 in NT.
+        result = analyse_play_pbn(DEAL, play="S6", trump=4, first=0)
+        self.assertIn("number", result)
+        self.assertIn("tricks", result)
+        self.assertIsInstance(result["tricks"], list)
+        self.assertEqual(len(result["tricks"]), result["number"])
+
+    def test_analyse_play_pbn_odd_length(self) -> None:
+        with self.assertRaises(ValueError):
+            analyse_play_pbn(DEAL, play="S6S", trump=4, first=0)
+
+    def test_analyse_all_plays_pbn(self) -> None:
+        deals = [
+            {"remain_cards": DEAL, "play": "S6", "trump": 4, "first": 0},
+            {"remain_cards": DEAL, "play": "S6", "trump": 1, "first": 0},
+        ]
+        results = analyse_all_plays_pbn(deals)
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertIn("tricks", result)
+            self.assertIsInstance(result["tricks"], list)
+
+    def test_analyse_all_plays_missing_play(self) -> None:
+        with self.assertRaises(KeyError):
+            analyse_all_plays_pbn([{"remain_cards": DEAL}])
+
+
+class TestDealerPar(unittest.TestCase):
+    """Tests for dealer_par."""
+
+    def test_dealer_par_basic(self) -> None:
+        dd_table = calc_dd_table(HAND0)
+        result = dealer_par(dd_table, dealer=0, vulnerable=0)
+        self.assertIn("score", result)
+        self.assertIn("number", result)
+        self.assertIn("contracts", result)
+        self.assertIsInstance(result["score"], int)
+        self.assertIsInstance(result["contracts"], list)
+        self.assertEqual(len(result["contracts"]), result["number"])
+
+    def test_dealer_par_all_dealers(self) -> None:
+        dd_table = calc_dd_table(HAND0)
+        for dealer in range(4):
+            result = dealer_par(dd_table, dealer=dealer, vulnerable=0)
+            self.assertIsInstance(result["score"], int)
+
+    def test_dealer_par_invalid_dealer(self) -> None:
+        dd_table = calc_dd_table(HAND0)
+        with self.assertRaises(ValueError):
+            dealer_par(dd_table, dealer=4, vulnerable=0)
+
+    def test_dealer_par_invalid_vulnerability(self) -> None:
+        dd_table = calc_dd_table(HAND0)
+        with self.assertRaises(ValueError):
+            dealer_par(dd_table, dealer=0, vulnerable=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_analyse.py
+++ b/python/tests/test_analyse.py
@@ -61,6 +61,11 @@ class TestAnalysePlay(unittest.TestCase):
         with self.assertRaises(KeyError):
             analyse_all_plays_pbn([{"remain_cards": DEAL}])
 
+    def test_set_max_threads_rejects_negative(self) -> None:
+        with self.assertRaises(ValueError):
+            set_max_threads(-1)
+        set_max_threads(0)  # 0 is valid (auto)
+
 
 class TestDealerPar(unittest.TestCase):
     """Tests for dealer_par."""


### PR DESCRIPTION
Add Python bindings for four DDS C-API functions that had no dds3 wrapper:

- analyse_play_pbn / analyse_all_plays_pbn -> AnalysePlayPBN / AnalyseAllPlaysPBN, returning {number, tricks} per deal. New solved_play_to_dict converter.
- dealer_par -> DealerPar, returning {score, number, contracts} from a calc_dd_table result.
- set_max_threads -> SetMaxThreads, to size the batch-solver thread pool.

All released the GIL around the C call, validate inputs (play length/parity, seat/vulnerability ranges, board count <= MAXNOOFBOARDS), and reuse the existing pbn_to_deal / dict_to_dd_table_results helpers. Exposed via dds3.__init__, documented in docs/python_interface.md, and covered by python/tests/test_analyse.py (//python:analyse_test). Full suite: 11/11 pass.