### PR TITLE
Remove unnecessary, WASM-specific code and configurations

### DIFF
--- a/CPPVARIABLES.bzl
+++ b/CPPVARIABLES.bzl
@@ -72,7 +72,7 @@ DDS_LOCAL_DEFINES = select({
     "//:debug_build_macos": [],
     "//:build_linux": [],
     "//:debug_build_linux": [],
-    "//:build_wasm": ["__WASM__"],
+    "//:build_wasm": [],
     "//conditions:default": [],
 }) + select({
     "//:debug_all": ["DDS_DEBUG_ALL"],

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -136,8 +136,6 @@ The MVP link flags include `-sENVIRONMENT=web,node` so the same `.js` / `.wasm` 
 
 ## Development notes
 
-- The `__WASM__` preprocessor constant is defined for WASM builds (`CPPVARIABLES.bzl`). It was added to work around platform-specific code paths; revisit whether it can be narrowed or removed as WASM support matures.
-- Some threading and platform-specific features are disabled or stubbed when `__WASM__` is set.
 - A reusable `cc_library` WASM artifact (not only example binaries) is not yet provided; today only `wasm_cc_binary` example targets are wired up.
 - The browser MVP lives under `web/`; see **Web browser (DDS MVP)** above and `//web:web_system_tests`.
 

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -98,7 +98,6 @@ For other experiments, copy built `.js` / `.wasm` files from `bazel-bin/examples
 | `-O3` | Aggressive optimization |
 | `-flto` | Link-time optimization |
 | `-fexceptions` | Enable C++ exceptions |
-| `-D__WASM__` | Preprocessor constant for WASM builds |
 | `-sWASM=1` | Emscripten WASM output (link flag) |
 | `-sALLOW_MEMORY_GROWTH=1` | Allow heap growth at runtime |
 | `-sINITIAL_MEMORY=268435456` | 256MB initial memory |

--- a/examples/analyse_all_plays_bin.cpp
+++ b/examples/analyse_all_plays_bin.cpp
@@ -30,10 +30,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   bo.no_of_boards = 3;
   DDplays.no_of_boards = 3;
 

--- a/examples/analyse_all_plays_pbn.cpp
+++ b/examples/analyse_all_plays_pbn.cpp
@@ -30,10 +30,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   bo.no_of_boards = 3;
   DDplays.no_of_boards = 3;
 

--- a/examples/analyse_play_bin.cpp
+++ b/examples/analyse_play_bin.cpp
@@ -30,7 +30,7 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__) || defined(__WASM__)
+#if defined(__APPLE__)
   SetMaxThreads(0);
 #endif
 
@@ -62,12 +62,7 @@ auto main() -> int
 
     if (res != RETURN_NO_FAULT)
     {
- #ifdef __WASM__
-      // For WASM, we can't use ErrorMessage, so we'll just print the error code
-      snprintf(line, sizeof(line), "error code %d", res);
- #else
       ErrorMessage(res, line);
- #endif
       printf("DDS error: %s\n", line);
     }
 

--- a/examples/analyse_play_bin.cpp
+++ b/examples/analyse_play_bin.cpp
@@ -30,10 +30,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     dl.trump = trump_suit_[handno];

--- a/examples/analyse_play_pbn.cpp
+++ b/examples/analyse_play_pbn.cpp
@@ -28,10 +28,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     dlPBN.trump = trump_suit_[handno];

--- a/examples/calc_all_tables.cpp
+++ b/examples/calc_all_tables.cpp
@@ -30,10 +30,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   DDdeals.no_of_tables = 3;
 
   for (int handno = 0; handno < 3; handno++)

--- a/examples/calc_all_tables_pbn.cpp
+++ b/examples/calc_all_tables_pbn.cpp
@@ -30,10 +30,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   DDdealsPBN.no_of_tables = 3;
 
   for (int handno = 0; handno < 3; handno++)

--- a/examples/calc_dd_table.cpp
+++ b/examples/calc_dd_table.cpp
@@ -27,10 +27,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
 

--- a/examples/calc_dd_table_pbn.cpp
+++ b/examples/calc_dd_table_pbn.cpp
@@ -27,7 +27,7 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__) || defined(__WASM__)
+#if defined(__APPLE__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/calc_dd_table_pbn.cpp
+++ b/examples/calc_dd_table_pbn.cpp
@@ -27,10 +27,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     strcpy(tableDealPBN.cards, pbn_hands_[handno]);

--- a/examples/calc_par_context_example.cpp
+++ b/examples/calc_par_context_example.cpp
@@ -170,10 +170,6 @@ auto main() -> int
   printf("DDS Examples: Par Calculation with SolverContext\n");
   printf("================================================\n");
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   // Run examples
   example_without_context();
   example_with_context();

--- a/examples/dealer_par.cpp
+++ b/examples/dealer_par.cpp
@@ -27,10 +27,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     set_table(&DDtable, handno);

--- a/examples/par.cpp
+++ b/examples/par.cpp
@@ -27,10 +27,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     set_table(&DDtable, handno);

--- a/examples/solve_all_boards.cpp
+++ b/examples/solve_all_boards.cpp
@@ -27,10 +27,6 @@ auto main() -> int
   char line[80];
   bool match;
 
-#if defined(__linux) || defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   bo.no_of_boards = 3;
   for (int handno = 0; handno < 3; handno++)
   {

--- a/examples/solve_board.cpp
+++ b/examples/solve_board.cpp
@@ -33,10 +33,6 @@ auto main() -> int
   bool match2;
   bool match3;
 
-#if defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     dl.trump = trump_suit_[handno];

--- a/examples/solve_board.cpp
+++ b/examples/solve_board.cpp
@@ -33,7 +33,7 @@ auto main() -> int
   bool match2;
   bool match3;
 
-#if defined(__linux) || defined(__APPLE__)  || defined(__WASM__)
+#if defined(__APPLE__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/solve_board_pbn.cpp
+++ b/examples/solve_board_pbn.cpp
@@ -32,7 +32,7 @@ auto main() -> int
   bool match2,
                 match3;
 
-#if defined(__linux) || defined(__APPLE__) || defined(__WASM__)
+#if defined(__APPLE__)
   SetMaxThreads(0);
 #endif
 

--- a/examples/solve_board_pbn.cpp
+++ b/examples/solve_board_pbn.cpp
@@ -32,10 +32,6 @@ auto main() -> int
   bool match2,
                 match3;
 
-#if defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
-
   for (int handno = 0; handno < 3; handno++)
   {
     dlPBN.trump = trump_suit_[handno];

--- a/examples/wasm/calc_dd_table_pbn_test.cpp
+++ b/examples/wasm/calc_dd_table_pbn_test.cpp
@@ -13,9 +13,6 @@
 #include "hands.hpp"
 
 TEST(CalcDdTablePbnWasmTest, MatchesReferenceTables) {
-#if defined(__APPLE__)
-  SetMaxThreads(0);
-#endif
 
   for (int handno = 0; handno < 3; ++handno) {
     DdTableDealPBN deal{};

--- a/examples/wasm/calc_dd_table_pbn_test.cpp
+++ b/examples/wasm/calc_dd_table_pbn_test.cpp
@@ -13,7 +13,7 @@
 #include "hands.hpp"
 
 TEST(CalcDdTablePbnWasmTest, MatchesReferenceTables) {
-#if defined(__linux) || defined(__APPLE__) || defined(__WASM__)
+#if defined(__APPLE__)
   SetMaxThreads(0);
 #endif
 

--- a/library/tests/heuristic_sorting/minimal_weight_test.cpp
+++ b/library/tests/heuristic_sorting/minimal_weight_test.cpp
@@ -17,12 +17,6 @@
  */
 class MinimalWeightTest : public ::testing::Test
 {
-protected:
-    void SetUp() override
-    {
-        // Initialize the DDS system
-        SetMaxThreads(0);
-    }
 };
 
 TEST_F(MinimalWeightTest, BasicWeightAllocCall) {

--- a/library/tests/solve_board/analyse_play_consistency.cpp
+++ b/library/tests/solve_board/analyse_play_consistency.cpp
@@ -251,8 +251,6 @@ auto hand_from_holdings(const std::array<std::string, 4>& suits) -> std::vector<
 
 class AnalysePlayConsistency : public ::testing::Test
 {
-protected:
-  void SetUp() override { SetMaxThreads(0); }
 };
 
 // The exact deal from dds-bridge/dds issue #156.

--- a/library/tests/solve_board/trick_three_bug.cpp
+++ b/library/tests/solve_board/trick_three_bug.cpp
@@ -35,8 +35,6 @@ inline auto dds_max(FutureTricks const & fut) -> size_t
 /// @details Reproduces the original bug scenario and validates the fix.
 TEST_F(TrickThreeBugTests, test_declarer_makes_nine_tricks)
 {
-    SetMaxThreads(0);
-
     const int target = 0;
     const int solutions = 3;
     const int mode = 0;


### PR DESCRIPTION
See https://github.com/dds-bridge/dds/issues/168 for further details.

```
The (SetMaxThreads) call is no longer necessary in 3.0.0 and can be removed from all examples, tests, etc.

I only removed it for __linux__ and  __WASM__ flags as I'm not able to test on __APPLE__, but I suspect this call can be removed for all platforms.
```