### PR TITLE
Save build artifacts

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -31,3 +31,13 @@ jobs:
       # 6️⃣ Run all tests (including Python)
       - name: Run all tests
         run: bazel test --verbose_failures //...
+
+      # 7️⃣ Upload test logs
+      - name: Upload test logs - Linux
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-linux
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -30,3 +30,13 @@ jobs:
       # Run all tests (including Python)
       - name: Run all tests
         run: bazelisk test --verbose_failures //...
+
+      # Upload test logs
+      - name: Upload test logs - macOS
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-macos
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/ci_wasm.yml
+++ b/.github/workflows/ci_wasm.yml
@@ -30,3 +30,13 @@ jobs:
       # 4️⃣ Smoke test: run solve_board under Node.js — pass if it does not crash
       - name: Smoke test solve_board_wasm
         run: node bazel-bin/examples/wasm/solve_board.js
+
+      # 5️⃣ Upload test logs
+      - name: Upload test logs - WASM
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-wasm
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -26,3 +26,13 @@ jobs:
       # Run all tests (including Python)
       - name: Run all tests
         run: bazel test --verbose_failures //...
+
+      # Upload test logs
+      - name: Upload test logs - Windows
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-windows
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
The e2e tests fail sporadically on github, preventing merges. Adding artifacts will allow us to diagnose and hopefully prevent these failures.