### PR TITLE
Fix CalcDdTable error message naming in SolverContext.

### DIFF
--- a/dotnet/DDS_Core/DataModel/SolverContext.cs
+++ b/dotnet/DDS_Core/DataModel/SolverContext.cs
@@ -70,7 +70,7 @@ public sealed class SolverContext : IDisposable
                                                 , in table_deal
                                                 , out table_results);
 
-                ThrowIfError(rc, nameof(SolveBoard));
+                ThrowIfError(rc, nameof(CalcDdTable));
                 return rc;
             }
 


### PR DESCRIPTION
Use nameof(CalcDdTable) instead of nameof(SolveBoard) so DEBUG exceptions identify the failing method correctly.