### PR TITLE
Add Coding Standards and AI Tool Advice.

### DIFF
--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -21,6 +21,6 @@ alwaysApply: false
 2. **Make changes** locally.  
 3. **Commit** with a clear message.  
 4. **Push** the branch.  
-5. **Open a PR** via the `github` command line interface.  
+5. **Open a PR** via the GitHub CLI (`gh`).
 
 ---

--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -21,6 +21,6 @@ alwaysApply: false
 2. **Make changes** locally.  
 3. **Commit** with a clear message.  
 4. **Push** the branch.  
-5. **Open a PR** via the `github` MCP server (see `github.instructions.md`).  
+5. **Open a PR** via the `github` command line interface.  
 
 ---

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -7,7 +7,6 @@ alwaysApply: false
 
 ## Overview
 This project uses GitHub as its primary version control and collaboration platform. All code contributions, fixes, and features must go through a pull request (PR) workflow.
-You have access to an MCP server named **`github`** (running `mcp-github`) which can create branches, push commits, and open PRs directly from the Continue.dev environment. See `.vscode/mcp.json` for configuration.
 
 ## Branching Strategy
 - **Default branch:** `main`
@@ -32,25 +31,14 @@ You have access to an MCP server named **`github`** (running `mcp-github`) which
 5. Small PRs are preferred — keep them focused on one logical change.
 
 ## Tooling
-Use the **`github`** MCP server (configured in `.vscode/mcp.json`) to:
+Use the github command line interface to:
    - Create branches
    - Commit and push changes
    - Open pull requests
    - Check PR status
-## Example MCP Server Commands
-You can instruct Continue.dev to:
-- `Use the github MCP server to create a new branch called fix/memory-leak`
-- `Push the current branch and open a pull request titled "Fix memory leak in cache manager"`
-- `List open pull requests for this repo`
-- `Merge PR #45 after approval`
 
 ## Automation
 - CI/CD runs automatically for all PRs.
 - Approved PRs can be merged by maintainers.
-- Use **squash merging** to keep history clean.
 
-## Notes for Continue.dev
-- You are allowed to automate branch creation and PR submission using the `github` MCP server.
-- If multiple PRs are required, ensure each is isolated to its own branch.
-- You may request human review before merging.
 ```

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -31,7 +31,7 @@ This project uses GitHub as its primary version control and collaboration platfo
 5. Small PRs are preferred — keep them focused on one logical change.
 
 ## Tooling
-Use the github command line interface to:
+Use `git` for local version control, and the GitHub CLI (`gh`) for GitHub operations:
    - Create branches
    - Commit and push changes
    - Open pull requests

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -28,7 +28,7 @@ This project uses GitHub as its primary version control and collaboration platfo
    - CI build
    - All unit and integration tests
    - Any lint/format checks
-5. Small PRs are preferred — keep them focused on one logical change.
+5. Small PRs are preferred — keep each focused on one logical change.
 
 ## Tooling
 Use `git` for local version control, and the GitHub CLI (`gh`) for GitHub operations:
@@ -38,7 +38,7 @@ Use `git` for local version control, and the GitHub CLI (`gh`) for GitHub operat
    - Check PR status
 
 ## Automation
-- CI/CD runs automatically for all PRs.
+- CI runs automatically for all PRs.
 - Approved PRs can be merged by maintainers.
 
 ```

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,6 +93,11 @@ genrule(
     outs = ["doxygen_docs.zip"],
     cmd = """
       set -e
+      case "$$(uname -s)" in
+        Darwin)  PATH="/opt/homebrew/bin:/usr/local/bin:$$PATH" ;;
+        Linux)   PATH="/usr/local/bin:$$PATH" ;;
+        MINGW*|MSYS*|CYGWIN*) PATH="/usr/bin:/usr/local/bin:$$PATH" ;;
+      esac
       DOXYFILE_GEN="$(@D)/Doxyfile.generated"
       OUT_DIR="$(@D)/doxygen_output"
       OUT_ZIP="$$(pwd)/$@"

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -260,7 +260,7 @@
     },
     "@@emsdk+//:emscripten_deps.bzl%emscripten_deps": {
       "general": {
-        "bzlTransitiveDigest": "Dt5IF0PG0xjU5iMLeU6FQ1/xWvBqUgUognNk3r5pJXY=",
+        "bzlTransitiveDigest": "reX42Ca3PEP5mFXph0pqMqqqwHJbvykl5X4FHfXD6qg=",
         "usagesDigest": "lqS0hMGr6MqmX63BGZOskMFcqzqO53K0UlYFxuE3QSU=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -16,6 +16,8 @@ toolchain selection lives in `MODULE.bazel` and standard-language settings are
 primarily configured in `.bazelrc` (with a fallback default in
 `CPPVARIABLES.bzl`).
 
+MODULE.bazel.lock is checked in and version managed as per current bazel best practises.
+
 ### macOS SDK and Runtime Compatibility
 
 On macOS, binaries built against a newer SDK/runtime than the currently running
@@ -29,14 +31,13 @@ If you see runtime loader failures after a toolchain or OS change:
 
 
 ## Visual Studio and Rider Build
+
 The top-level `solution` folder contains a Visual Studio solution file `solution.slnx` and 
 project files for the dds and all the samples. It also contains a `Directory.Build.props` 
 file which defines the common properties for all the projects. 
 
 Note this line in the `Directory.Build.props` file: `<BuildDir>$(MSBuildThisFileDirectory)\..\Build\</BuildDir>` 
 defining the output directory for all the projects. 
-
-
 
 ## API Layers
 

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -1,51 +1,62 @@
 # Coding agents and coding standards
 
-Coding agents are becoming increasingly powerful and which tool and model that scores best in test changes if not by the week at least on a monthly basis. These recommendations and instructions for coding were collected in the first quarter of 2026 when the bulk of the work to modernise the codebase for release 3.0.0 was carried out.
+Coding agents are improving quickly, and the best tool or model for a task can change from one month to the next. This note collects the coding guidance and tooling recommendations that were assembled during the first quarter of 2026, when most of the modernisation work for release 3.0.0 was completed.
 
-Configurations for MCP (Model Content Protocol) servers are not included. MCP servers add a lot of power, but can also expose severe vulnerabilities. How they should be deployed is definitely not one size fits all.
+This document does not prescribe a specific MCP server setup. MCP servers can be powerful, but they also introduce security risks, so the right deployment strategy depends on the environment.
 
 ## Coding Standards
 
-Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`, which is where Github Copilot looks for its permanent instructions.
+Consistent style matters even more when both humans and coding agents are reading and editing the same code. The preferred conventions are documented in the `.github/instructions` directory, which is where GitHub Copilot looks for its persistent instructions.
 
 1. [C++](../.github/instructions/cpp.instructions.md)
 2. [Bazel](../.github/instructions/bazel.instructions.md)
 3. [Git](../.github/instructions/git.instructions.md)
 4. [GitHub](../.github/instructions/github.instructions.md)
 
-## Recommended tools for coding agents
+## Recommended Tools for Coding Agents
 
 ### clangd
+
 https://clangd.llvm.org
 
-Language servers are well known to most integrated development environments but coding agents are typically not able to interact with them directly. There are several MCP wrappers that can surface a language server to a coding agent. This is, however, serving raw JSON responses that the coding agent has to interpret and reason around. If - as is highly recommended - you run serena then prefer to let serena handle the integration with language servers.
+Language servers are familiar to most IDE users, but coding agents usually cannot interact with them directly. MCP wrappers can expose a language server to an agent, but they often do so by forwarding raw JSON responses that still need to be interpreted. If you also run Serena, prefer to let Serena handle the language-server integration.
 
 ### Serena
+
 https://github.com/oraios/serena
 
-Probably the most important tool at the time of writing. Serena provides semantic analysis and instructions to help coding agents stay on target. 
+Serena is the most useful tool in this workflow. It provides semantic analysis and retrieval features that help coding agents stay focused on the right parts of the codebase and understand the structure of the language they are working in.
 
 ### Code Context Engine
+
 https://github.com/elara-labs/code-context-engine
 
-Creates and maintains an index of the codebase. This means that a coding agent often can read only the relevant part of a file instead of searching all the content of several files. 
+Code Context Engine builds and maintains an index of the codebase, which lets a coding agent inspect the relevant parts of a file without scanning unrelated content across many files.
 
-As a side note, I find it interesting that vector embeddings were removed from Claude Code. My amatuer understanding is that Serena tells the agent what the code is doing and code context enginer where the interesting code. This differs from vector embeddnings which tells the coding agent which parts of the codebase looks similar. Knowing that calls to write to the database looks similar is not useful, but the information where they are and what they write is.
+One observation from this tooling landscape is that different systems solve different problems. Serena helps explain what the code is doing, while a code index helps locate where the interesting code lives. That is more useful than simply surfacing syntactically similar code, which is often not enough to guide a change.
 
-## Documentation and code completion
+## Documentation and Code Completion
 
-Code documentation for DDS3 is generated through doxygen, which extracts formatted comments from the source code. The
-build command
+Code documentation for DDS3 is generated with Doxygen, which extracts formatted comments from the source code. Run the following command to generate the local documentation:
 
 ```
 bazelisk build //:doxygen_docs
 ```
 
-generates a stack of local html pages. Open `doxygen_output/html/pages.html` to read the documentation.
+The generated HTML pages are available under `doxygen_output/html/`. Open `doxygen_output/html/pages.html` to read the documentation.
 
 ### Extracting compile_commands.json
 
-Language servers, such as clangd, rely on a file called `compile_commands.json` which contains information about how project artefacts are build. 
+Language servers such as clangd rely on a `compile_commands.json` file, which describes how the project is built.
+
+On macOS or Linux, the following command generates that file when the `bazel-compile-commands` utility is installed:
+
+```
+bazel-compile-commands //...
+```
+
 https://github.com/kiron1/bazel-compile-commands
+
+An alternative is Hedron Compile Commands, which can be integrated into the Bazel build. It appears to be less actively maintained, but it is still worth knowing about:
 
 https://github.com/hedronvision/bazel-compile-commands-extractor

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -14,13 +14,19 @@ Language servers are well known by most integrated development environments but 
 ### Serena
 https://github.com/oraios/serena
 
-Probably the most important tool at the time of writing.
+Probably the most important tool at the time of writing. Serena provides semantic analysis and instructions to help coding agents stay on target. 
 
 ### Code Context Engine
+https://github.com/elara-labs/code-context-engine
+
+Creates and maintains an index of the codebase. This means that a coding agent often can read only the relevant part of a file instead of searching all the content of several files. 
+
+As a side note, I find it interesting that vector embeddings were removed from Claude Code. My amatuer understanding is that Serena tells the agent what the code is doing and code context enginer where the interesting code. This differs from vector embeddnings which tells the coding agent which parts of the codebase looks similar. Knowing that calls to write to the database looks similar is not useful, but the information where they are and what they write is.
+
 
 ## Coding Standards
 
-Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`
+Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`, which is where Github Copilot looks for its permanent instructions.
 
 1. [C++](../.github/instructions/cpp.instructions.md)
 2. [Bazel](../.github/instructions/bazel.instructions.md)
@@ -28,6 +34,8 @@ Keeping a consistent coding style is more important than ever as it helps both h
 4. [GitHub](../.github/instructions/github.instructions.md)
 
 ## Documentation and code completion
+
+DDS3 
 
 ### Extracting compile_commands.json
 

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -2,14 +2,23 @@
 
 Coding agents are becoming increasingly powerful and which tool and model that scores best in test changes if not by the week at least on a monthly basis. These recommendations and instructions for coding were collected in the first quarter of 2026 when the bulk of the work to modernise the codebase for release 3.0.0 was carried out.
 
-Configurations for MCP servers are not included. MCP servers add a lot of power, but can also expose severe vulnerabilities. How they should be deployed is definitely not one size fits all.
+Configurations for MCP (Model Content Protocol) servers are not included. MCP servers add a lot of power, but can also expose severe vulnerabilities. How they should be deployed is definitely not one size fits all.
+
+## Coding Standards
+
+Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`, which is where Github Copilot looks for its permanent instructions.
+
+1. [C++](../.github/instructions/cpp.instructions.md)
+2. [Bazel](../.github/instructions/bazel.instructions.md)
+3. [Git](../.github/instructions/git.instructions.md)
+4. [GitHub](../.github/instructions/github.instructions.md)
 
 ## Recommended tools for coding agents
 
 ### clangd
 https://clangd.llvm.org
 
-Language servers are well known by most integrated development environments but coding agents are typically not able to interact with them directly. There are several MCP wrappers that can surface a language server to a coding agent. This is, however, surfacing raw JSON responses that the coding agent has to interpret and reason around. If - as is highly recommended - you run serena then prefer to let serena handle the integration with language servers.
+Language servers are well known to most integrated development environments but coding agents are typically not able to interact with them directly. There are several MCP wrappers that can surface a language server to a coding agent. This is, however, serving raw JSON responses that the coding agent has to interpret and reason around. If - as is highly recommended - you run serena then prefer to let serena handle the integration with language servers.
 
 ### Serena
 https://github.com/oraios/serena
@@ -23,22 +32,20 @@ Creates and maintains an index of the codebase. This means that a coding agent o
 
 As a side note, I find it interesting that vector embeddings were removed from Claude Code. My amatuer understanding is that Serena tells the agent what the code is doing and code context enginer where the interesting code. This differs from vector embeddnings which tells the coding agent which parts of the codebase looks similar. Knowing that calls to write to the database looks similar is not useful, but the information where they are and what they write is.
 
-
-## Coding Standards
-
-Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`, which is where Github Copilot looks for its permanent instructions.
-
-1. [C++](../.github/instructions/cpp.instructions.md)
-2. [Bazel](../.github/instructions/bazel.instructions.md)
-3. [Git](../.github/instructions/git.instructions.md)
-4. [GitHub](../.github/instructions/github.instructions.md)
-
 ## Documentation and code completion
 
-DDS3 
+Code documentation for DDS3 is generated through doxygen, which extracts formatted comments from the source code. The
+build command
+
+```
+bazelisk build //:doxygen_docs
+```
+
+generates a stack of local html pages. Open `doxygen_output/html/pages.html` to read the documentation.
 
 ### Extracting compile_commands.json
 
+Language servers, such as clangd, rely on a file called `compile_commands.json` which contains information about how project artefacts are build. 
 https://github.com/kiron1/bazel-compile-commands
 
 https://github.com/hedronvision/bazel-compile-commands-extractor

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -1,6 +1,6 @@
-# Coding agents and coding standards
+# Coding Agents and Coding Standards
 
-Coding agents are improving quickly, and the best tool or model for a task can change from one month to the next. This note collects the coding guidance and tooling recommendations that were assembled during the first quarter of 2026, when most of the modernisation work for release 3.0.0 was completed.
+Coding agents are improving quickly, and the best tool or model for a task can change from one month to the next. This note collects coding guidance and tooling recommendations assembled during the first quarter of 2026, when most of the modernisation work for release 3.0.0 was completed.
 
 This document does not prescribe a specific MCP server setup. MCP servers can be powerful, but they also introduce security risks, so the right deployment strategy depends on the environment.
 
@@ -19,7 +19,7 @@ Consistent style matters even more when both humans and coding agents are readin
 
 https://clangd.llvm.org
 
-Language servers are familiar to most IDE users, but coding agents usually cannot interact with them directly. MCP wrappers can expose a language server to an agent, but they often do so by forwarding raw JSON responses that still need to be interpreted. If you also run Serena, prefer to let Serena handle the language-server integration.
+Language servers are familiar to most IDE users, but coding agents usually cannot interact with them directly. MCP wrappers can expose a language server to an agent, but they often do so by forwarding raw JSON responses that still need interpretation. If you also run Serena, prefer to let Serena handle the language-server integration.
 
 ### Serena
 
@@ -31,7 +31,7 @@ Serena is the most useful tool in this workflow. It provides semantic analysis a
 
 https://github.com/elara-labs/code-context-engine
 
-Code Context Engine builds and maintains an index of the codebase, which lets a coding agent inspect the relevant parts of a file without scanning unrelated content across many files.
+Code Context Engine builds and maintains an index of the codebase, letting a coding agent inspect relevant parts of a file without scanning unrelated content across many files.
 
 One observation from this tooling landscape is that different systems solve different problems. Serena helps explain what the code is doing, while a code index helps locate where the interesting code lives. That is more useful than simply surfacing syntactically similar code, which is often not enough to guide a change.
 
@@ -55,6 +55,10 @@ bazel-compile-commands //...
 
 https://github.com/kiron1/bazel-compile-commands
 
-An alternative is Hedron Compile Commands, which can be integrated into the Bazel build. It appears to be less actively maintained, but it is still worth knowing about:
+An alternative is Hedron Compile Commands, which can be integrated into the Bazel build. It appears to be less actively maintained, but is still worth knowing about:
 
 https://github.com/hedronvision/bazel-compile-commands-extractor
+
+## Other Tooling
+
+We are not maintaining an official list of recommended tools for working with the DDS codebase. The CI scripts use `homebrew` or `apt-get` to install `doxygen`, so you may have to update `PATH` variables in build scripts if you install it using another method.

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -1,0 +1,36 @@
+# Coding agents and coding standards
+
+Coding agents are becoming increasingly powerful and which tool and model that scores best in test changes if not by the week at least on a monthly basis. These recommendations and instructions for coding were collected in the first quarter of 2026 when the bulk of the work to modernise the codebase for release 3.0.0 was carried out.
+
+Configurations for MCP servers are not included. MCP servers add a lot of power, but can also expose severe vulnerabilities. How they should be deployed is definitely not one size fits all.
+
+## Recommended tools for coding agents
+
+### clangd
+https://clangd.llvm.org
+
+Language servers are well known by most integrated development environments but coding agents are typically not able to interact with them directly. There are several MCP wrappers that can surface a language server to a coding agent. This is, however, surfacing raw JSON responses that the coding agent has to interpret and reason around. If - as is highly recommended - you run serena then prefer to let serena handle the integration with language servers.
+
+### Serena
+https://github.com/oraios/serena
+
+Probably the most important tool at the time of writing.
+
+### Code Context Engine
+
+## Coding Standards
+
+Keeping a consistent coding style is more important than ever as it helps both humans and coding agents. Preferred styles are document in the `.github/instructions directory`
+
+1. [C++](../.github/instructions/cpp.instructions.md)
+2. [Bazel](../.github/instructions/bazel.instructions.md)
+3. [Git](../.github/instructions/git.instructions.md)
+4. [GitHub](../.github/instructions/github.instructions.md)
+
+## Documentation and code completion
+
+### Extracting compile_commands.json
+
+https://github.com/kiron1/bazel-compile-commands
+
+https://github.com/hedronvision/bazel-compile-commands-extractor

--- a/docs/coding_standards_and_ai_advice.md
+++ b/docs/coding_standards_and_ai_advice.md
@@ -39,11 +39,9 @@ One observation from this tooling landscape is that different systems solve diff
 
 Code documentation for DDS3 is generated with Doxygen, which extracts formatted comments from the source code. Run the following command to generate the local documentation:
 
-```
-bazelisk build //:doxygen_docs
-```
+    bazelisk build //:doxygen_docs
 
-The generated HTML pages are available under `doxygen_output/html/`. Open `doxygen_output/html/pages.html` to read the documentation.
+The generated HTML pages are written under `bazel-bin/doxygen_output/html/` (and packaged as `bazel-bin/doxygen_docs.zip`). Open `bazel-bin/doxygen_output/html/index.html` to read the documentation.
 
 ### Extracting compile_commands.json
 


### PR DESCRIPTION
Adds a document about coding standards and AI tools. It is based on my experience from modernising the code base in the first quarter of 2026. I have also tidied up GitHub instructions, which define the coding standards and fixed the command to extract the documentation from Doxygen style comments.