### PR TITLE
Avoid per-node shared_ptr churn in the search hot path

### DIFF
--- a/library/src/ab_search.cpp
+++ b/library/src/ab_search.cpp
@@ -90,7 +90,7 @@ bool ab_search(
      the value of the subtree is returned.
      This is a specialized AB function for hand_rel_first == 0. */
 
-  auto thrp = ctx.thread();
+  ThreadData* thrp = ctx.thread_ptr();
   int hand = posPoint->first[depth];
   int tricks = depth >> 2;
   bool success = (ctx.search().node_type_store(hand) == MAXNODE ? true : false);
@@ -192,7 +192,7 @@ static bool ab_search_0_ctx(
      the value of the subtree is returned.
      This is a specialized AB function for hand_rel_first == 0. */
 
-  auto thrp = ctx.thread();
+  ThreadData* thrp = ctx.thread_ptr();
   int trump = thrp->trump;
   int hand = posPoint->first[depth];
   int tricks = depth >> 2;
@@ -493,7 +493,7 @@ static bool ab_search_1_ctx(
   const int depth,
   SolverContext& ctx)
 {
-  auto thrp = ctx.thread();
+  ThreadData* thrp = ctx.thread_ptr();
   int trump = thrp->trump;
   int hand = HAND_ID(posPoint->first[depth], 1);
   bool success = (ctx.search().node_type_store(hand) == MAXNODE ? true : false);
@@ -589,7 +589,9 @@ static bool ab_search_2_ctx(
   const int depth,
   SolverContext& ctx)
 {
-  auto thrp = ctx.thread();
+#ifdef DDS_AB_STATS
+  ThreadData* thrp = ctx.thread_ptr();
+#endif
   int hand = HAND_ID(posPoint->first[depth], 2);
   bool success = (ctx.search().node_type_store(hand) == MAXNODE ? true : false);
   bool value = ! success;
@@ -680,7 +682,9 @@ static bool ab_search_3_ctx(
 
   unsigned short int makeWinRank[DDS_SUITS];
 
-  auto thrp = ctx.thread();
+#ifdef DDS_AB_STATS
+  ThreadData* thrp = ctx.thread_ptr();
+#endif
   int hand = HAND_ID(posPoint->first[depth], 3);
   bool success = (ctx.search().node_type_store(hand) == MAXNODE ? true : false);
   bool value = ! success;
@@ -826,7 +830,7 @@ void make_3(
   MoveType const * mply,
   SolverContext& ctx)
 {
-  auto thrp = ctx.thread();
+  ThreadData* thrp = ctx.thread_ptr();
   int firstHand = posPoint->first[depth];
 
   const TrickDataType& data = ctx.move_gen().get_trick_data((depth + 3) >> 2);
@@ -892,7 +896,7 @@ static void make_3_ctx(
   MoveType const * mply,
   SolverContext& ctx)
 {
-  auto thrp = ctx.thread();
+  ThreadData* thrp = ctx.thread_ptr();
   int firstHand = posPoint->first[depth];
 
   const TrickDataType& data = ctx.move_gen().get_trick_data((depth + 3) >> 2);
@@ -1111,7 +1115,6 @@ EvalType evaluate_with_context(
   const int trump,
   SolverContext& ctx)
 {
-  auto thrp = ctx.thread();
   int s, h, hmax = 0, count = 0, k = 0;
   unsigned short rmax = 0;
   EvalType eval;

--- a/library/src/later_tricks.cpp
+++ b/library/src/later_tricks.cpp
@@ -163,7 +163,7 @@ bool LaterTricksMIN(
         fprintf(stderr, "LaterTricksMIN: invalid aggr=%u (depth=%d)", aggr, depth);
         return true; // conservative fallback
       }
-      int h = ctx.thread()->rel[aggr].abs_rank[3][trump].hand;
+      int h = ctx.thread_ptr()->rel[aggr].abs_rank[3][trump].hand;
       if (h == -1)
         return true;
 
@@ -176,7 +176,7 @@ bool LaterTricksMIN(
         for (int ss = 0; ss < DDS_SUITS; ss++)
           if (depth_ok) tpos.win_ranks[depth][ss] = 0;
         if (depth_ok) tpos.win_ranks[depth][trump] = bit_map_rank[
-          static_cast<int>(static_cast<unsigned char>(ctx.thread()->rel[aggr].abs_rank[3][trump].rank)) ];
+          static_cast<int>(static_cast<unsigned char>(ctx.thread_ptr()->rel[aggr].abs_rank[3][trump].rank)) ];
         return false;
       }
     }
@@ -338,7 +338,7 @@ bool LaterTricksMAX(
         fprintf(stderr, "LaterTricksMAX: invalid aggr=%u (depth=%d)\n", aggr, depth);
         return false; // conservative fallback for MAX
       }
-      int h = ctx.thread()->rel[aggr].abs_rank[3][trump].hand;
+      int h = ctx.thread_ptr()->rel[aggr].abs_rank[3][trump].hand;
       if (h == -1)
         return false;
 
@@ -351,7 +351,7 @@ bool LaterTricksMAX(
         for (int ss = 0; ss < DDS_SUITS; ss++)
           if (depth_ok) tpos.win_ranks[depth][ss] = 0;
         if (depth_ok) tpos.win_ranks[depth][trump] = bit_map_rank[
-          static_cast<int>(static_cast<unsigned char>(ctx.thread()->rel[aggr].abs_rank[3][trump].rank)) ];
+          static_cast<int>(static_cast<unsigned char>(ctx.thread_ptr()->rel[aggr].abs_rank[3][trump].rank)) ];
         return true;
       }
     }

--- a/library/src/quick_tricks.cpp
+++ b/library/src/quick_tricks.cpp
@@ -997,10 +997,10 @@ int QuickTricksPartnerHandTrump(
     for (int h = 0; h < DDS_HANDS; h++)
       ranks |= tpos.rank_in_suit[h][suit];
 
-    if (ctx.thread()->rel[ranks].abs_rank[3][suit].hand == partner[hand])
+    if (ctx.thread_ptr()->rel[ranks].abs_rank[3][suit].hand == partner[hand])
     {
       tpos.win_ranks[depth][suit] |= bit_map_rank[
-        static_cast<int>(static_cast<unsigned char>(ctx.thread()->rel[ranks].abs_rank[3][suit].rank)) ];
+        static_cast<int>(static_cast<unsigned char>(ctx.thread_ptr()->rel[ranks].abs_rank[3][suit].rank)) ];
 
       tpos.win_ranks[depth][commSuit] |= bit_map_rank[commRank];
 
@@ -1107,10 +1107,10 @@ int QuickTricksPartnerHandNT(
     for (int h = 0; h < DDS_HANDS; h++)
       ranks |= tpos.rank_in_suit[h][suit];
 
-    if (ctx.thread()->rel[ranks].abs_rank[3][suit].hand == partner[hand])
+    if (ctx.thread_ptr()->rel[ranks].abs_rank[3][suit].hand == partner[hand])
     {
       tpos.win_ranks[depth][suit] |= bit_map_rank[
-        static_cast<int>(static_cast<unsigned char>(ctx.thread()->rel[ranks].abs_rank[3][suit].rank)) ];
+        static_cast<int>(static_cast<unsigned char>(ctx.thread_ptr()->rel[ranks].abs_rank[3][suit].rank)) ];
       qt++;
       if (qt >= cutoff)
         return qt;

--- a/library/src/solver_context/solver_context.hpp
+++ b/library/src/solver_context/solver_context.hpp
@@ -78,6 +78,17 @@ public:
   }
 
   /**
+   * @brief Non-owning raw access to the underlying ThreadData.
+   *
+   * Avoids the atomic reference-count traffic of copying the shared_ptr in
+   * hot search paths. The pointer is valid for the lifetime of the context.
+   */
+  auto thread_ptr() const -> ThreadData*
+  {
+    return thr_.get();
+  }
+
+  /**
    * @brief Access the current configuration snapshot.
    *
    * @return Const reference to the configuration stored in this context.


### PR DESCRIPTION
Add a non-owning SolverContext::thread_ptr() accessor and use it at the hot ThreadData access sites in ab_search, quick_tricks, and later_tricks instead of copying the shared_ptr returned by thread(). This removes the atomic reference-count traffic from the inner search loop.

Measured on dtest -f hands/list100.txt -s solve -n 14 (14 cores), interleaved against develop to cancel machine drift: ~3-4% lower user and system time with tighter run-to-run variance. Behavior is unchanged; the pointer lifetime is tied to the owning context.