### PR TITLE
Add Link-Time Optimization for MacOS builds.

### DIFF
--- a/CPPVARIABLES.bzl
+++ b/CPPVARIABLES.bzl
@@ -3,6 +3,7 @@
 DDS_CPPOPTS = select({
     "//:build_macos": [
         "-O3",
+        "-flto=thin",
         "-mtune=generic",
         "-fPIC",
         "-Wpedantic",
@@ -86,7 +87,7 @@ DDS_LOCAL_DEFINES = select({
 })
 
 DDS_LINKOPTS = select({
-    "//:build_macos": [],
+    "//:build_macos": ["-flto=thin"],
     "//:debug_build_macos": [],
     "//:build_linux": [],
     "//:debug_build_linux": [],


### PR DESCRIPTION
Speeds up calc runtime by a few percent, with a negligible slowdown in full builds. Would likely help on Windows and Linux as well - someone with those environments could test that.

WASM builds already include full lto.