### PR TITLE
Fixes so that DDS_AB_STATS will work when it's set.

### DIFF
--- a/library/src/BUILD.bazel
+++ b/library/src/BUILD.bazel
@@ -6,6 +6,21 @@ external_headers = [
     "dds.hpp",
 ]
 
+cc_library(
+    name = "ab_stats",
+    srcs = ["ab_stats.cpp"],
+    hdrs = ["ab_stats.hpp"],
+    includes = ["."],
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    visibility = [
+        "//library/src:__subpackages__",
+        "//library/tests:__subpackages__",
+    ],
+    deps = ["//library/src/utility:constants"],
+)
+
 filegroup(
     name = "dds_sources",
     srcs = glob([
@@ -13,7 +28,10 @@ filegroup(
         "*.hpp",
         "*.h",
     ],
-    exclude = external_headers,
+    exclude = external_headers + [
+        "ab_stats.cpp",
+        "ab_stats.hpp",
+    ],
     )
 )
 
@@ -39,6 +57,7 @@ cc_library(
         "//library/src/heuristic_sorting",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
         "//library/src/system",
         "//library/src/solver_context:solver_context",
     ],

--- a/library/src/BUILD.bazel
+++ b/library/src/BUILD.bazel
@@ -65,9 +65,10 @@ cc_library(
 
 filegroup(
     name = "testable_dds_sources",
-    srcs = glob([
-        "*.cpp",
-    ],),
+    srcs = glob(
+        ["*.cpp"],
+        exclude = ["ab_stats.cpp"],
+    ),
     visibility = [
         "//examples:__pkg__",
     ],
@@ -109,6 +110,7 @@ cc_library(
         "//library/src/heuristic_sorting",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
         "//library/src/system",
         "//library/src/solver_context:solver_context",
     ],
@@ -135,6 +137,7 @@ cc_library(
         "//library/src/heuristic_sorting",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
         "//library/src/system:system_util_log",
         "//library/src/solver_context:solver_context_log",
     ],
@@ -160,6 +163,7 @@ cc_library(
         "//library/src/heuristic_sorting",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
         "//library/src/system:system_util_stats",
         "//library/src/solver_context:solver_context_stats",
     ],

--- a/library/src/dds.cpp
+++ b/library/src/dds.cpp
@@ -39,7 +39,6 @@ extern "C" BOOL APIENTRY DllMain(
     SetMaxThreads(0);
   else if (ul_reason_for_call == DLL_PROCESS_DETACH)
   {
-    CloseDebugFiles();
     FreeMemory();
 #ifdef DDS_MEMORY_LEAKS_WIN32
     _CrtDumpMemoryLeaks();
@@ -73,7 +72,6 @@ void DDSInitialize(void)
  */
 void DDSFinalize(void) 
 {
-  CloseDebugFiles();
   FreeMemory();
 }
 
@@ -87,17 +85,6 @@ void DDSFinalize(void)
 static void __attribute__ ((constructor)) libInit(void)
 {
   SetMaxThreads(0);
-}
-
-
-/**
- * @brief Library destructor for platforms supporting destructor attribute.
- *
- * This function is called when the library is unloaded.
- */
-static void __attribute__ ((destructor)) libEnd(void)
-{
-  CloseDebugFiles();
 }
 
 #endif

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -163,14 +163,6 @@ void InitDebugFiles()
 }
 
 
-void CloseDebugFiles()
-{
-  // Per-context debug files are opened when SolverContext owns its ThreadData
-  // (SolverContext(SolverConfig)) and closed in ~SolverContext() when the last
-  // shared_ptr to that ThreadData is released.
-}
-
-
 void SetDeal(
   const std::shared_ptr<ThreadData>& thrp)
 {

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -166,7 +166,8 @@ void InitDebugFiles()
 void CloseDebugFiles()
 {
   // Per-context debug files are opened when SolverContext owns its ThreadData
-  // (SolverContext(SolverConfig)) and closed in ~SolverContext() for owners only.
+  // (SolverContext(SolverConfig)) and closed in ~SolverContext() when the last
+  // shared_ptr to that ThreadData is released.
 }
 
 

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -165,12 +165,8 @@ void InitDebugFiles()
 
 void CloseDebugFiles()
 {
-  for (unsigned thrId = 0; thrId < memory.NumThreads(); thrId++)
-  {
-  SolverContext tmp_ctx;
-  [[maybe_unused]] auto thrp = tmp_ctx.thread();
-  thrp->close_debug_files();
-  }
+  // Per-context debug files are opened in SolverContext::bind_thread_data()
+  // and closed in ~SolverContext().
 }
 
 

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -165,8 +165,8 @@ void InitDebugFiles()
 
 void CloseDebugFiles()
 {
-  // Per-context debug files are opened in SolverContext::bind_thread_data()
-  // and closed in ~SolverContext().
+  // Per-context debug files are opened when SolverContext owns its ThreadData
+  // (SolverContext(SolverConfig)) and closed in ~SolverContext() for owners only.
 }
 
 

--- a/library/src/init.hpp
+++ b/library/src/init.hpp
@@ -23,5 +23,3 @@ void InitWinners(
   const Deal& dl,
   Pos& posPoint,
   const std::shared_ptr<ThreadData>& thrp);
-
-void CloseDebugFiles();

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -1,6 +1,8 @@
 #include "solver_context.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <memory>

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -1,13 +1,43 @@
 #include "solver_context.hpp"
 
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include <api/dds.h>
 //#include <api/dds_api.hpp>
 #include <trans_table/trans_table_l.hpp>
 #include <trans_table/trans_table_s.hpp>
+#include <utility/debug.h>
+
+namespace {
+
+#if defined(DDS_TOP_LEVEL) || defined(DDS_AB_STATS) || defined(DDS_AB_HITS) || \
+    defined(DDS_TT_STATS) || defined(DDS_TIMING) || defined(DDS_MOVES)
+std::string next_debug_file_suffix()
+{
+  static std::atomic<unsigned> serial{0};
+  return std::to_string(serial.fetch_add(1, std::memory_order_relaxed)) +
+         DDS_DEBUG_SUFFIX;
+}
+#endif
+
+}  // namespace
+
+void SolverContext::bind_thread_data()
+{
+  // Ensure persistent facades like SearchContext see the bound ThreadData.
+  search_.set_thread(thr_);
+  search_.set_owner(this);
+  if (!thr_) return;
+
+#if defined(DDS_TOP_LEVEL) || defined(DDS_AB_STATS) || defined(DDS_AB_HITS) || \
+    defined(DDS_TT_STATS) || defined(DDS_TIMING) || defined(DDS_MOVES)
+  thr_->init_debug_files(next_debug_file_suffix());
+#endif
+}
 
 // Owned-ThreadData constructor: allocate ThreadData as a member of the
 // SolverContext so callers can create a context at the top of the stack
@@ -17,9 +47,7 @@ SolverContext::SolverContext(SolverConfig cfg)
 {
   // Create an owned ThreadData instance and keep it in thr_.
   thr_ = std::make_shared<ThreadData>();
-  // Ensure persistent facades like SearchContext see the bound ThreadData.
-  search_.set_thread(thr_);
-  search_.set_owner(this);
+  bind_thread_data();
 }
 
 auto SolverContext::trans_table() const -> TransTable*
@@ -117,7 +145,10 @@ auto SolverContext::dispose_trans_table() const -> void
 // Defaulted destructor defined out-of-line so destruction of the
 // owned std::shared_ptr<ThreadData> happens where ThreadData is a
 // complete type.
-SolverContext::~SolverContext() = default;
+SolverContext::~SolverContext()
+{
+  if (thr_) thr_->close_debug_files();
+}
 
 auto SolverContext::reset_for_solve() const -> void
 {

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -33,11 +33,12 @@ void SolverContext::bind_thread_data()
   search_.set_owner(this);
   if (!thr_) return;
 
+  if (owns_thread_data_) {
 #if defined(DDS_TOP_LEVEL) || defined(DDS_AB_STATS) || defined(DDS_AB_HITS) || \
     defined(DDS_TT_STATS) || defined(DDS_TIMING) || defined(DDS_MOVES)
-  if (owns_thread_data_)
     thr_->init_debug_files(next_debug_file_suffix());
 #endif
+  }
 }
 
 // Owned-ThreadData constructor: allocate ThreadData as a member of the
@@ -148,7 +149,10 @@ auto SolverContext::dispose_trans_table() const -> void
 // complete type.
 SolverContext::~SolverContext()
 {
-  if (owns_thread_data_ && thr_)
+  // Close debug files only when this context holds the last shared_ptr to
+  // ThreadData. close_debug_files() is a no-op when files were never opened
+  // (e.g. non-owning wrappers over stack ThreadData).
+  if (thr_ && thr_.use_count() == 1)
     thr_->close_debug_files();
 }
 

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -35,7 +35,8 @@ void SolverContext::bind_thread_data()
 
 #if defined(DDS_TOP_LEVEL) || defined(DDS_AB_STATS) || defined(DDS_AB_HITS) || \
     defined(DDS_TT_STATS) || defined(DDS_TIMING) || defined(DDS_MOVES)
-  thr_->init_debug_files(next_debug_file_suffix());
+  if (owns_thread_data_)
+    thr_->init_debug_files(next_debug_file_suffix());
 #endif
 }
 
@@ -43,7 +44,7 @@ void SolverContext::bind_thread_data()
 // SolverContext so callers can create a context at the top of the stack
 // and pass it down without a separate per-thread lookup.
 SolverContext::SolverContext(SolverConfig cfg)
-  : cfg_(cfg)
+  : cfg_(cfg), owns_thread_data_(true)
 {
   // Create an owned ThreadData instance and keep it in thr_.
   thr_ = std::make_shared<ThreadData>();
@@ -147,7 +148,8 @@ auto SolverContext::dispose_trans_table() const -> void
 // complete type.
 SolverContext::~SolverContext()
 {
-  if (thr_) thr_->close_debug_files();
+  if (owns_thread_data_ && thr_)
+    thr_->close_debug_files();
 }
 
 auto SolverContext::reset_for_solve() const -> void

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -149,10 +149,13 @@ auto SolverContext::dispose_trans_table() const -> void
 // complete type.
 SolverContext::~SolverContext()
 {
-  // Close debug files only when this context holds the last shared_ptr to
-  // ThreadData. close_debug_files() is a no-op when files were never opened
-  // (e.g. non-owning wrappers over stack ThreadData).
-  if (thr_ && thr_.use_count() == 1)
+  if (!thr_)
+    return;
+
+  // SearchContext holds its own shared_ptr; release it before testing whether
+  // this context is the last owner of ThreadData.
+  search_.set_thread({});
+  if (thr_.use_count() == 1)
     thr_->close_debug_files();
 }
 

--- a/library/src/solver_context/solver_context.hpp
+++ b/library/src/solver_context/solver_context.hpp
@@ -50,9 +50,7 @@ public:
   explicit SolverContext(std::shared_ptr<ThreadData> thread, SolverConfig cfg = {})
   : thr_(std::move(thread)), cfg_(cfg)
   {
-    // Bind the persistent facades to the underlying ThreadData.
-    search_.set_thread(thr_);
-    search_.set_owner(this);
+    bind_thread_data();
   }
 
   // NOTE: constructors that accepted raw ThreadData* were removed as part
@@ -431,6 +429,8 @@ private:
   // Transposition table is now owned per SearchContext and created lazily.
   //
   // See the developer note above for details on TT lifecycle and resets.
+
+  void bind_thread_data();
 };
 
 auto ThreadMemoryUsed() -> double;

--- a/library/src/solver_context/solver_context.hpp
+++ b/library/src/solver_context/solver_context.hpp
@@ -47,8 +47,9 @@ struct SolverConfig
 class SolverContext
 {
 public:
-  // Wrap existing ThreadData (helper/sub-context). Does not open or close
-  // debug files; the owning context is responsible for debug file lifecycle.
+  // Wrap existing ThreadData (helper/sub-context). Does not initialize debug
+  // files; ~SolverContext() closes them only when this context is the last
+  // shared_ptr holder of that ThreadData.
   explicit SolverContext(std::shared_ptr<ThreadData> thread, SolverConfig cfg = {})
   : thr_(std::move(thread)), cfg_(cfg)
   {

--- a/library/src/solver_context/solver_context.hpp
+++ b/library/src/solver_context/solver_context.hpp
@@ -47,6 +47,8 @@ struct SolverConfig
 class SolverContext
 {
 public:
+  // Wrap existing ThreadData (helper/sub-context). Does not open or close
+  // debug files; the owning context is responsible for debug file lifecycle.
   explicit SolverContext(std::shared_ptr<ThreadData> thread, SolverConfig cfg = {})
   : thr_(std::move(thread)), cfg_(cfg)
   {
@@ -429,6 +431,9 @@ private:
   // Transposition table is now owned per SearchContext and created lazily.
   //
   // See the developer note above for details on TT lifecycle and resets.
+
+  // True when this context created thr_ via SolverContext(SolverConfig).
+  bool owns_thread_data_ = false;
 
   void bind_thread_data();
 };

--- a/library/src/system/BUILD.bazel
+++ b/library/src/system/BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
         "//library/src/api:api_definitions",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
         # Utilities lives under system/util (header-only for now)
     ],
     include_prefix = "system",
@@ -34,6 +35,7 @@ cc_library(
     "//library/src/api:api_definitions",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
     ],
     include_prefix = "system",
     copts = DDS_CPPOPTS,
@@ -53,6 +55,7 @@ cc_library(
     "//library/src/api:api_definitions",
         "//library/src/trans_table",
         "//library/src/moves:moves",
+        "//library/src:ab_stats",
     ],
     include_prefix = "system",
     copts = DDS_CPPOPTS,

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -31,20 +31,14 @@ void File::SetName(const std::string& fname_in)
 
 std::ofstream& File::GetStream()
 {
-  if (!file_open_)
-  {
+  if (!fout_.is_open() && !fname_.empty())
     fout_.open(fname_);
-    file_open_ = true;
-  }
 
   return fout_;
 }
 
 void File::Close()
 {
-  if (file_open_)
-  {
+  if (fout_.is_open())
     fout_.close();
-    file_open_ = false;
-  }
 }

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -22,6 +22,10 @@ void File::Reset()
 
 void File::SetName(const std::string& fname_in)
 {
+  if (fname_in == fname_)
+    return;
+
+  Close();
   fname_ = fname_in;
 }
 

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -9,18 +9,18 @@
 
 #include "file.hpp"
 
-File::~File()
+dds::File::~File()
 {
   Close();
 }
 
-void File::Reset()
+void dds::File::Reset()
 {
   Close();
   fname_.clear();
 }
 
-void File::SetName(const std::string& fname_in)
+void dds::File::SetName(const std::string& fname_in)
 {
   if (fname_in == fname_)
     return;
@@ -29,7 +29,7 @@ void File::SetName(const std::string& fname_in)
   fname_ = fname_in;
 }
 
-std::ofstream& File::GetStream()
+std::ofstream& dds::File::GetStream()
 {
   if (!fout_.is_open() && !fname_.empty())
     fout_.open(fname_);
@@ -37,7 +37,7 @@ std::ofstream& File::GetStream()
   return fout_;
 }
 
-void File::Close()
+void dds::File::Close()
 {
   if (fout_.is_open())
     fout_.close();

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -16,8 +16,8 @@ File::~File()
 
 void File::Reset()
 {
+  Close();
   fname_.clear();
-  file_open_ = false;
 }
 
 void File::SetName(const std::string& fname_in)

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -1,0 +1,46 @@
+/*
+   DDS, a bridge double dummy solver.
+
+   Copyright (C) 2006-2014 by Bo Haglund /
+   2014-2018 by Bo Haglund & Soren Hein.
+
+   See LICENSE and README.
+*/
+
+#include "file.hpp"
+
+File::~File()
+{
+  Close();
+}
+
+void File::Reset()
+{
+  fname_.clear();
+  file_open_ = false;
+}
+
+void File::SetName(const std::string& fname_in)
+{
+  fname_ = fname_in;
+}
+
+std::ofstream& File::GetStream()
+{
+  if (!file_open_)
+  {
+    fout_.open(fname_);
+    file_open_ = true;
+  }
+
+  return fout_;
+}
+
+void File::Close()
+{
+  if (file_open_)
+  {
+    fout_.close();
+    file_open_ = false;
+  }
+}

--- a/library/src/system/file.hpp
+++ b/library/src/system/file.hpp
@@ -22,7 +22,6 @@ class File
   private:
 
     std::string fname_;
-    bool file_open_ = false;
     std::ofstream fout_;
 
   public:

--- a/library/src/system/file.hpp
+++ b/library/src/system/file.hpp
@@ -40,5 +40,3 @@ class File
 };
 
 }  // namespace dds
-
-using dds::File;

--- a/library/src/system/file.hpp
+++ b/library/src/system/file.hpp
@@ -1,0 +1,45 @@
+/*
+   DDS, a bridge double dummy solver.
+
+   Copyright (C) 2006-2014 by Bo Haglund /
+   2014-2018 by Bo Haglund & Soren Hein.
+
+   See LICENSE and README.
+*/
+
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace dds {
+
+/**
+ * @brief Lazy-opening output file for debug/statistics logging.
+ */
+class File
+{
+  private:
+
+    std::string fname_;
+    bool file_open_ = false;
+    std::ofstream fout_;
+
+  public:
+
+    File() = default;
+
+    ~File();
+
+    void Reset();
+
+    void SetName(const std::string& fname_in);
+
+    std::ofstream& GetStream();
+
+    void Close();
+};
+
+}  // namespace dds
+
+using dds::File;

--- a/library/src/system/thread_data.cpp
+++ b/library/src/system/thread_data.cpp
@@ -6,6 +6,9 @@ using std::string;
 
 void ThreadData::init_debug_files([[maybe_unused]] const string& suffix)
 {
+  if (debug_files_initialized_)
+    return;
+
 #ifdef DDS_TOP_LEVEL
 	fileTopLevel.SetName(DDS_TOP_LEVEL_PREFIX + suffix);
 #endif
@@ -30,10 +33,15 @@ void ThreadData::init_debug_files([[maybe_unused]] const string& suffix)
 #ifdef DDS_MOVES
 	fileMoves.SetName(DDS_MOVES_PREFIX + suffix);
 #endif
+
+  debug_files_initialized_ = true;
 }
 
 void ThreadData::close_debug_files()
 {
+  if (!debug_files_initialized_)
+    return;
+
 #ifdef DDS_TOP_LEVEL
 	fileTopLevel.Close();
 #endif
@@ -58,4 +66,6 @@ void ThreadData::close_debug_files()
 #ifdef DDS_MOVES
 	fileMoves.Close();
 #endif
+
+  debug_files_initialized_ = false;
 }

--- a/library/src/system/thread_data.hpp
+++ b/library/src/system/thread_data.hpp
@@ -73,30 +73,30 @@ struct ThreadData
   Moves moves;
 
 #ifdef DDS_TOP_LEVEL
-  File fileTopLevel;
+  dds::File fileTopLevel;
 #endif
 
 #ifdef DDS_AB_STATS
   ABstats ABStats;
-  File fileABstats;
+  dds::File fileABstats;
 #endif
 
 #ifdef DDS_AB_HITS
-  File fileRetrieved;
-  File fileStored;
+  dds::File fileRetrieved;
+  dds::File fileStored;
 #endif
 
 #ifdef DDS_TT_STATS
-  File fileTTstats;
+  dds::File fileTTstats;
 #endif 
 
 #ifdef DDS_TIMING
   TimerList timerList;
-  File fileTimerList;
+  dds::File fileTimerList;
 #endif
 
 #ifdef DDS_MOVES
-  File fileMoves;
+  dds::File fileMoves;
 #endif
 
   // True after init_debug_files(); cleared by close_debug_files().

--- a/library/src/system/thread_data.hpp
+++ b/library/src/system/thread_data.hpp
@@ -102,7 +102,8 @@ struct ThreadData
   // True after init_debug_files(); cleared by close_debug_files().
   bool debug_files_initialized_ = false;
 
-  // Initialize per-thread debug/stat files with a suffix (e.g., "<thrId>_suffix").
+  // Initialize per-thread debug/stat files. suffix is appended to each debug
+  // prefix (e.g. "0.txt" from SolverContext serial + DDS_DEBUG_SUFFIX).
   void init_debug_files([[maybe_unused]] const std::string& suffix);
 
   // Close any open per-thread debug/stat files.

--- a/library/src/system/thread_data.hpp
+++ b/library/src/system/thread_data.hpp
@@ -1,13 +1,19 @@
 #ifndef DDS_THREAD_DATA_H
 #define DDS_THREAD_DATA_H
 
+#include <utility/debug.h>
+
 #include <api/dds.h>
 #include <moves/moves.hpp>
 #include <string>
 
-
 #ifdef DDS_AB_STATS
-  #include "ab_stats.hpp"
+#include "ab_stats.hpp"
+#endif
+
+#if defined(DDS_TOP_LEVEL) || defined(DDS_AB_STATS) || defined(DDS_AB_HITS) || \
+    defined(DDS_TT_STATS) || defined(DDS_TIMING) || defined(DDS_MOVES)
+#include "file.hpp"
 #endif
 
 #ifdef DDS_TIMING

--- a/library/src/system/thread_data.hpp
+++ b/library/src/system/thread_data.hpp
@@ -99,11 +99,19 @@ struct ThreadData
   File fileMoves;
 #endif
 
+  // True after init_debug_files(); cleared by close_debug_files().
+  bool debug_files_initialized_ = false;
+
   // Initialize per-thread debug/stat files with a suffix (e.g., "<thrId>_suffix").
   void init_debug_files([[maybe_unused]] const std::string& suffix);
 
   // Close any open per-thread debug/stat files.
   void close_debug_files();
+
+  auto debug_files_initialized() const -> bool
+  {
+    return debug_files_initialized_;
+  }
 };
 
 

--- a/library/src/utility/debug.h
+++ b/library/src/utility/debug.h
@@ -123,18 +123,4 @@
 #endif
 #endif
 
-/// @name Performance Counters
-/// @brief Statistics counters for profiling and analysis.
-/// @{
-
-/// @brief Number of available counter slots for performance tracking.
-constexpr int COUNTER_SLOTS = 200;
-
-/// @brief Global array of performance counters.
-/// Each thread may use these counters for statistics collection.
-/// Size: COUNTER_SLOTS (200) entries.
-extern long long counter[COUNTER_SLOTS];
-
-/// @}
-
 /// @}


### PR DESCRIPTION
I've tested this locally with `bazel build //library/tests:dtest --cxxopt=-DDDS_AB_STATS`. A dtest run then produces ABstats*.txt files, as it ought to. The build fails without this PR.

We should either merge this PR or else remove the DDS_AB_STATS code entirely.

Another possible enhancement would be to mirror the DDS_SCHEDULER pattern, so that we can use `--define=ab_stats=true` instead of `--cxxopt`.