### PR TITLE
Fix DDS_SCHEDULER build consistency and dtest -r reporting.

### DIFF
--- a/library/src/BUILD.bazel
+++ b/library/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:CPPVARIABLES.bzl", "DDS_CPPOPTS", "DDS_LINKOPTS", "DDS_LOCAL_DEFINES")
+load("//:CPPVARIABLES.bzl", "DDS_CPPOPTS", "DDS_LINKOPTS", "DDS_LOCAL_DEFINES", "DDS_SCHEDULER_DEFINE")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 external_headers = [
@@ -29,7 +29,7 @@ cc_library(
     includes = ["."],
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
-    local_defines = DDS_LOCAL_DEFINES,
+    local_defines = DDS_LOCAL_DEFINES + DDS_SCHEDULER_DEFINE,
     visibility = ["//visibility:public"],
     include_prefix = "dds",
     deps = [
@@ -71,7 +71,7 @@ cc_library(
     includes = ["."],
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
-    local_defines = DDS_LOCAL_DEFINES,
+    local_defines = DDS_LOCAL_DEFINES + DDS_SCHEDULER_DEFINE,
     include_prefix = "dds",
     visibility = [
         "//:__pkg__",  # allow root package to wrap/export
@@ -103,7 +103,7 @@ cc_library(
     includes = ["."],
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
-    local_defines = DDS_LOCAL_DEFINES,
+    local_defines = DDS_LOCAL_DEFINES + DDS_SCHEDULER_DEFINE,
     include_prefix = "dds",
     visibility = [
         "//:__pkg__",
@@ -128,7 +128,7 @@ cc_library(
     includes = ["."],
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
-    local_defines = DDS_LOCAL_DEFINES,
+    local_defines = DDS_LOCAL_DEFINES + DDS_SCHEDULER_DEFINE,
     include_prefix = "dds",
     visibility = [
         "//:__pkg__",

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -157,9 +157,6 @@ int STDCALL SetThreading(
 
 void InitDebugFiles()
 {
-#ifdef DDS_SCHEDULER
-  InitFileScheduler();
-#endif
 }
 
 

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -29,9 +29,41 @@ auto same_board(
   const unsigned index2) -> bool;
 
 
+static auto boards_from_pbn(
+  BoardsPBN const& bop,
+  Boards& bo) -> int
+{
+  bo.no_of_boards = bop.no_of_boards;
+  if (bo.no_of_boards > MAXNOOFBOARDS)
+    return RETURN_TOO_MANY_BOARDS;
+
+  for (int k = 0; k < bop.no_of_boards; k++)
+  {
+    bo.mode[k] = bop.mode[k];
+    bo.solutions[k] = bop.solutions[k];
+    bo.target[k] = bop.target[k];
+    bo.deals[k].first = bop.deals[k].first;
+    bo.deals[k].trump = bop.deals[k].trump;
+
+    for (int i = 0; i <= 2; i++)
+    {
+      bo.deals[k].currentTrickSuit[i] = bop.deals[k].currentTrickSuit[i];
+      bo.deals[k].currentTrickRank[i] = bop.deals[k].currentTrickRank[i];
+    }
+
+    if (convert_from_pbn(bop.deals[k].remainCards, bo.deals[k].remainCards)
+        != RETURN_NO_FAULT)
+      return RETURN_PBN_FAULT;
+  }
+
+  return RETURN_NO_FAULT;
+}
+
+
 auto solve_all_boards_n(
   Boards const& bds,
-  SolvedBoards& solved) -> int
+  SolvedBoards& solved,
+  const int worker_cap) -> int
 {
   const int n = bds.no_of_boards;
   if (n > MAXNOOFBOARDS)
@@ -44,7 +76,7 @@ auto solve_all_boards_n(
 
   START_BLOCK_TIMER;
 
-  const int err = parallel_all_boards_n(n, 0,
+  const int err = parallel_all_boards_n(n, worker_cap,
     [&](const int worker_id, const int bno) -> int {
       (void)worker_id;
 
@@ -75,6 +107,19 @@ auto solve_all_boards_n(
 #endif
 
   return RETURN_NO_FAULT;
+}
+
+
+auto solve_all_boards_pbn_n(
+  BoardsPBN const& bop,
+  SolvedBoards& solved,
+  const int worker_cap) -> int
+{
+  Boards bo;
+  const int rc = boards_from_pbn(bop, bo);
+  if (rc != RETURN_NO_FAULT)
+    return rc;
+  return solve_all_boards_n(bo, solved, worker_cap);
 }
 
 
@@ -121,32 +166,7 @@ int STDCALL SolveAllBoards(
   BoardsPBN const * bop,
   SolvedBoards * solvedp)
 {
-  Boards bo;
-  bo.no_of_boards = bop->no_of_boards;
-  if (bo.no_of_boards > MAXNOOFBOARDS)
-    return RETURN_TOO_MANY_BOARDS;
-
-  for (int k = 0; k < bop->no_of_boards; k++)
-  {
-    bo.mode[k] = bop->mode[k];
-    bo.solutions[k] = bop->solutions[k];
-    bo.target[k] = bop->target[k];
-    bo.deals[k].first = bop->deals[k].first;
-    bo.deals[k].trump = bop->deals[k].trump;
-
-    for (int i = 0; i <= 2; i++)
-    {
-      bo.deals[k].currentTrickSuit[i] = bop->deals[k].currentTrickSuit[i];
-      bo.deals[k].currentTrickRank[i] = bop->deals[k].currentTrickRank[i];
-    }
-
-    if (convert_from_pbn(bop->deals[k].remainCards, bo.deals[k].remainCards) 
-        != 1)
-      return RETURN_PBN_FAULT;
-  }
-
-  int res = solve_all_boards_n(bo, * solvedp);
-  return res;
+  return solve_all_boards_pbn_n(*bop, *solvedp, 0);
 }
 
 
@@ -163,29 +183,9 @@ int STDCALL SolveAllBoardsSeq(
   SolvedBoards * solvedp)
 {
   Boards bo;
-  bo.no_of_boards = bop->no_of_boards;
-  if (bo.no_of_boards > MAXNOOFBOARDS)
-    return RETURN_TOO_MANY_BOARDS;
-
-  for (int k = 0; k < bop->no_of_boards; k++)
-  {
-    bo.mode[k] = bop->mode[k];
-    bo.solutions[k] = bop->solutions[k];
-    bo.target[k] = bop->target[k];
-    bo.deals[k].first = bop->deals[k].first;
-    bo.deals[k].trump = bop->deals[k].trump;
-
-    for (int i = 0; i <= 2; i++)
-    {
-      bo.deals[k].currentTrickSuit[i] = bop->deals[k].currentTrickSuit[i];
-      bo.deals[k].currentTrickRank[i] = bop->deals[k].currentTrickRank[i];
-    }
-
-    if (convert_from_pbn(bop->deals[k].remainCards, bo.deals[k].remainCards)
-        != 1)
-      return RETURN_PBN_FAULT;
-  }
-
+  const int rc = boards_from_pbn(*bop, bo);
+  if (rc != RETURN_NO_FAULT)
+    return rc;
   return solve_all_boards_n_seq(bo, * solvedp);
 }
 

--- a/library/src/solve_board.hpp
+++ b/library/src/solve_board.hpp
@@ -14,6 +14,16 @@
 #include <api/dll.h>
 
 
+auto solve_all_boards_n(
+  Boards const& bds,
+  SolvedBoards& solved,
+  int worker_cap = 0) -> int;
+
+auto solve_all_boards_pbn_n(
+  BoardsPBN const& bop,
+  SolvedBoards& solved,
+  int worker_cap = 0) -> int;
+
 auto solve_all_boards_n_seq(
   Boards const& bds,
   SolvedBoards& solved) -> int;

--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -135,7 +135,24 @@ void Scheduler::ClearTiming()
 void Scheduler::Reset()
 {
   for (int b = 0; b < MAXNOOFBOARDS; b++)
+  {
     hands[b].next = -1;
+    hands[b].repeatNo = 0;
+    hands[b].depth = 0;
+    hands[b].strength = 0;
+    hands[b].fanout = 0;
+    hands[b].thread = 0;
+    hands[b].selectFlag = 0;
+    hands[b].time = 0;
+  }
+
+  for (int g = 0; g < MAXNOOFBOARDS; g++)
+  {
+    group[g].head = -1;
+    group[g].actual = 0;
+    group[g].repeatNo = 0;
+    group[g].pred = 0;
+  }
 
   numGroups = 0;
   extraGroups = 0;
@@ -266,6 +283,9 @@ void Scheduler::MakeGroups(const Boards& bds)
 
       group[numGroups].strain = strain;
       group[numGroups].hash = key;
+      group[numGroups].head = -1;
+      group[numGroups].actual = 0;
+      group[numGroups].repeatNo = 0;
       numGroups++;
     }
     else
@@ -332,6 +352,9 @@ void Scheduler::FinetuneGroups()
 
       group[numGroups].strain = 5;
       group[numGroups].hash = extraGroups;
+      group[numGroups].head = -1;
+      group[numGroups].actual = 0;
+      group[numGroups].repeatNo = 0;
 
       numGroups++;
       extraGroups++;
@@ -422,6 +445,9 @@ void Scheduler::FinetuneGroups()
 
           group[numGroups].strain = 5;
           group[numGroups].hash = extraGroups;
+          group[numGroups].head = -1;
+          group[numGroups].actual = 0;
+          group[numGroups].repeatNo = 0;
 
           numGroups++;
           extraGroups++;
@@ -903,7 +929,7 @@ void Scheduler::EndBlockTimer()
     if (timeUser > blockMax)
       blockMax = timeUser;
 
-    if (hp->repeatNo == 0)
+    if (hp->repeatNo == 0 && timeUser > 0)
     {
       int bin = timeUser / 1000;
       timeHist[bin]++;
@@ -916,8 +942,11 @@ void Scheduler::EndBlockTimer()
 
   for (int g = 0; g < numGroups; g++)
   {
-    int head = group[g].head;
-    int NTflag = (hands[head].strain == 4 ? 1 : 0);
+    const int head = group[g].head;
+    if (head < 0 || head >= numHands)
+      continue;
+
+    const int NTflag = (hands[head].strain == 4 ? 1 : 0);
 
     TimeStat ts;
 

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -20,6 +20,7 @@
 
 #include "cst.hpp"
 #include "dtest_parallel.hpp"
+#include <solve_board.hpp>
 
 using std::cout;
 using std::endl;
@@ -68,7 +69,8 @@ void loop_solve(
     }
     else
     {
-      ret = SolveAllBoards(bop, solvedbdp);
+      ret = solve_all_boards_pbn_n(*bop, *solvedbdp,
+        dtest_effective_threads(options.num_threads_, count));
     }
     if (ret != RETURN_NO_FAULT)
     {

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -68,20 +68,7 @@ void loop_solve(
     }
     else
     {
-      solvedbdp->no_of_boards = count;
-      ret = dtest_run_parallel(count, options.num_threads_,
-        [&](const int j) -> int {
-          FutureTricks fut;
-          const int res = SolveBoardPBN(
-            bop->deals[j], bop->target[j], bop->solutions[j], bop->mode[j],
-            &fut, 0);
-          if (res == RETURN_NO_FAULT)
-          {
-            solvedbdp->solved_board[j] = fut;
-            return RETURN_NO_FAULT;
-          }
-          return res;
-        });
+      ret = SolveAllBoards(bop, solvedbdp);
     }
     if (ret != RETURN_NO_FAULT)
     {

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -153,7 +153,15 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     scheduler.GetBoardTimes(times);
     if (times.empty())
     {
-      cout << "Per-board timing data not available. Rebuild with DDS_SCHEDULER enabled to collect per-board timings." << std::endl;
+      if (options.solver_ == Solver::DTEST_SOLVER_CALC)
+      {
+        cout << "Per-board timing data not available for calc (use -s solve -r)."
+             << std::endl;
+      }
+      else
+      {
+        cout << "Per-board timing data not available." << std::endl;
+      }
     }
     else
     {


### PR DESCRIPTION
Propagate scheduler define through :dds to fix Scheduler ODR/crash; use SolveAllBoards for parallel solve timing; clarify calc has no per-board data.

Test with

`bazel build --define=scheduler=true //library/tests:dtest`
`bazel-bin/library/tests/dtest -f hands/list10.txt -r`