### PR TITLE
Benchmark script to wrap dtest

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -198,14 +198,14 @@ if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   git_branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
 fi
 
-RESULTS="$(mktemp)"
+RESULTS="$(mktemp "${TMPDIR:-/tmp}/dds-benchmark.XXXXXX")"
 trap 'rm -f "$RESULTS"' EXIT
 
 parse_dtest_output() {
   awk '
-    /^User time \(ms\)/ { user = $NF }
-    /^Sys time \(ms\)/  { sys = $NF }
-    /^Avg user time \(ms\)/ { avg = $NF }
+    /^User time \(ms\)/ { user = ($NF == "zero" ? 0 : $NF) }
+    /^Sys time \(ms\)/  { sys = ($NF == "zero" ? 0 : $NF) }
+    /^Avg user time \(ms\)/ { avg = ($NF == "zero" ? 0 : $NF) }
     /^Ratio[[:space:]]/ { ratio = $NF }
     END {
       if (user == "") user = "NA"
@@ -239,7 +239,9 @@ run_dtest() {
   fi
   local parsed
   parsed="$(parse_dtest_output <<<"$out")"
-  if [[ "$parsed" == *"NA"* ]]; then
+  local parsed_user parsed_sys
+  read -r parsed_user parsed_sys _ _ <<<"$parsed"
+  if [[ "$parsed_user" == "NA" || "$parsed_sys" == "NA" ]]; then
     echo "warning: incomplete dtest timing output: ${cmd[*]}" >&2
   fi
   echo "$parsed"
@@ -307,7 +309,7 @@ done
 
 if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo
-  echo "Summary (branch vs compare, total user ms; cmp/branch > 1 => branch faster)"
+  echo "Summary (branch vs compare, avg user ms; cmp/branch > 1 => branch faster)"
   echo "=============================================================================="
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "solver" "file" "compare_user" "branch_user" "cmp/branch" "note"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -397,7 +397,7 @@ clear_transient_progress
 
 if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo
-  echo "Summary (branch vs compare, avg user ms; cmp/branch > 1 => branch faster)"
+  echo "Summary (branch vs compare, avg user ms)"
   echo "=============================================================================="
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "solver" "file" "compare_avg" "branch_avg" "cmp/branch" "note"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,7 +3,8 @@
 #
 # Runs all combinations of solver (solve, calc) and hand file
 # (list100/1000/…/1), largest files first. With --compare, prints summary only
-# unless --details; without --compare, prints per-run rows.
+# unless --details; without --compare, prints per-run rows. With --compare and a
+# tty, per-run rows appear during the run then are cleared before the summary.
 # Does not pass dtest options unless given after "--" (see below).
 #
 # Usage:
@@ -21,7 +22,7 @@
 #   REPEATS    Runs per combination per binary (default: 1)
 #   MAX_DEALS  Include list10^n.txt files with 10^n <= N (default: 100)
 #   DRY_RUN    If 1, print commands only
-#   DETAILS    If 1 with --compare, print per-run timing rows (default: summary only)
+#   DETAILS    If 1 with --compare, keep per-run rows in output (default: transient on tty)
 
 set -euo pipefail
 
@@ -52,8 +53,8 @@ Options:
                       (alias: --max_deals)
   --build             Build branch dtest only (bazel build //library/tests:dtest)
   --branch PATH       Branch dtest binary (default: $BRANCH)
-  --compare PATH      Optional second dtest binary for comparison (summary only)
-  --details           With --compare, also print per-run timing rows
+  --compare PATH      Optional second dtest binary (summary; transient progress on tty)
+  --details           With --compare, keep per-run timing rows in final output
   --reverse           With --compare, run compare before branch each repeat (default: branch first)
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
@@ -278,6 +279,41 @@ run_dtest() {
   echo "$parsed"
 }
 
+progress_lines=0
+TRANSIENT_PROGRESS=0
+show_run_lines=1
+
+print_run_table_header() {
+  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
+    "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
+  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
+    "------" "-------------" "-------" "--------" "--------" "----------" "------" "---"
+  if [[ "$TRANSIENT_PROGRESS" == "1" ]]; then
+    progress_lines=$((progress_lines + 2))
+  fi
+}
+
+print_run_row() {
+  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
+    "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8"
+  if [[ "$TRANSIENT_PROGRESS" == "1" ]]; then
+    progress_lines=$((progress_lines + 1))
+  fi
+}
+
+clear_transient_progress() {
+  if [[ "$TRANSIENT_PROGRESS" != "1" || progress_lines -le 0 ]]; then
+    return
+  fi
+  # Cursor rests on a blank line below the last row; erase it too.
+  local lines_to_clear=$((progress_lines + 1))
+  local i
+  for (( i = 0; i < lines_to_clear; i++ )); do
+    printf '\033[2K\033[1A'
+  done
+  progress_lines=0
+}
+
 echo "DDS dtest benchmark"
 echo "==================="
 printf "%-12s %s\n" "branch:" "$BRANCH"
@@ -285,6 +321,8 @@ if [[ -n "${COMPARE:-}" ]]; then
   printf "%-12s %s\n" "compare:" "$COMPARE"
   if [[ "$DETAILS" == "1" ]]; then
     printf "%-12s %s\n" "details:" "on"
+  elif [[ -t 1 ]]; then
+    printf "%-12s %s\n" "details:" "transient (cleared before summary)"
   else
     printf "%-12s %s\n" "details:" "off (summary only)"
   fi
@@ -305,15 +343,16 @@ fi
 echo
 
 show_run_lines=1
+TRANSIENT_PROGRESS=0
 if [[ -n "${COMPARE:-}" && "$DETAILS" != "1" ]]; then
   show_run_lines=0
+  if [[ -t 1 ]]; then
+    TRANSIENT_PROGRESS=1
+  fi
 fi
 
-if [[ "$DRY_RUN" != "1" && "$show_run_lines" == "1" ]]; then
-  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
-    "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
-  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
-    "------" "-------------" "-------" "--------" "--------" "----------" "------" "---"
+if [[ "$DRY_RUN" != "1" && ( "$show_run_lines" == "1" || "$TRANSIENT_PROGRESS" == "1" ) ]]; then
+  print_run_table_header
 fi
 
 total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * num_bins * REPEATS ))
@@ -342,9 +381,8 @@ for solver in "${SOLVERS[@]}"; do
 
         read -r user sys avg ratio < <(run_dtest "$bin" "$solver" "$hands")
 
-        if [[ "$show_run_lines" == "1" ]]; then
-          printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
-            "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
+        if [[ "$show_run_lines" == "1" || "$TRANSIENT_PROGRESS" == "1" ]]; then
+          print_run_row "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
         fi
 
         printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
@@ -354,6 +392,8 @@ for solver in "${SOLVERS[@]}"; do
     done
   done
 done
+
+clear_transient_progress
 
 if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -23,6 +23,7 @@
 #   MAX_DEALS  Include list10^n.txt files with 10^n <= N (default: 100)
 #   DRY_RUN    If 1, print commands only
 #   DETAILS    If 1 with --compare, keep per-run rows in output (default: transient on tty)
+#   EPSILON    With --compare, max % diff to treat branch/compare as equal (default: 0.5)
 
 set -euo pipefail
 
@@ -33,6 +34,7 @@ REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
 DETAILS="${DETAILS:-0}"
+EPSILON="${EPSILON:-0.5}"
 BUILD=0
 REVERSE=0
 DTEST_EXTRA=()
@@ -55,12 +57,13 @@ Options:
   --branch PATH       Branch dtest binary (default: $BRANCH)
   --compare PATH      Optional second dtest binary (summary; transient progress on tty)
   --details           With --compare, keep per-run timing rows in final output
+  --epsilon PCT       With --compare, treat timings within PCT% as equal (default: 0.5; env: EPSILON)
   --reverse           With --compare, run compare before branch each repeat (default: branch first)
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
 
 Environment:
-  BRANCH, COMPARE, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN, DETAILS
+  BRANCH, COMPARE, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN, DETAILS, EPSILON
 
 Examples:
   ./benchmark.sh
@@ -113,6 +116,11 @@ while [[ $# -gt 0 ]]; do
       DETAILS=1
       shift
       ;;
+    --epsilon)
+      shift
+      EPSILON="${1:?missing value for --epsilon}"
+      shift
+      ;;
     --)
       shift
       DTEST_EXTRA=("$@")
@@ -133,6 +141,11 @@ fi
 
 if ! [[ "$REPEATS" =~ ^[0-9]+$ ]] || (( REPEATS < 1 )); then
   echo "error: repeats must be a positive integer (got: $REPEATS)" >&2
+  exit 1
+fi
+
+if ! [[ "$EPSILON" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "error: epsilon must be a non-negative number (got: $EPSILON)" >&2
   exit 1
 fi
 
@@ -331,6 +344,7 @@ if [[ -n "${COMPARE:-}" ]]; then
   else
     printf "%-12s %s\n" "run order:" "interleaved branch, compare"
   fi
+  printf "%-12s %s\n" "epsilon:" "${EPSILON}%"
 fi
 printf "%-12s %s\n" "hands dir:" "$HANDS_DIR"
 printf "%-12s %s\n" "max_deals:" "$MAX_DEALS"
@@ -404,7 +418,12 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "------" "-------------" "------------" "------------" "----------" "---------------"
 
-  awk -F'\t' -v files="${FILES[*]}" '
+  awk -F'\t' -v files="${FILES[*]}" -v epsilon_pct="$EPSILON" '
+    function within_epsilon(a, b,    eps, hi, lo) {
+      eps = epsilon_pct / 100
+      if (a > b) { hi = a; lo = b } else { hi = b; lo = a }
+      return (hi <= 0 || (hi - lo) / hi <= eps)
+    }
     {
       base = $1 SUBSEP $2
       if ($3 == "compare") {
@@ -427,7 +446,13 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
           cmp_branch = u2 / u1
-          note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
+          if (within_epsilon(u1, u2)) {
+            note = "equal"
+          } else if (cmp_branch >= 1) {
+            note = "branch faster"
+          } else {
+            note = "compare faster"
+          }
           sp = sprintf("%9.2fx", cmp_branch)
           printf "%-6s %-13s %12.2f %12.2f %10s %-15s\n",
             solvers[si], filearr[fi], u2, u1, sp, note

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -445,7 +445,7 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           base = solvers[si] SUBSEP filearr[fi]
           if (!(base in c2) || !(base in c1)) continue
           # Every member of s1, c1, s2, and c2 should be positive.
-          # If not, it will be due to a rounding error. To fix, update
+          # If not, it will be due to rounding to zero. To fix, update
           # TestTimer.cpp to accumulate microseconds rather than milliseconds. 
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -297,10 +297,10 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo
   echo "Summary (branch vs compare, user time)"
   echo "======================================"
-  printf "%-6s %-13s %12s %12s %10s %s\n" \
+  printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "solver" "file" "compare_user" "branch_user" "speedup" "note"
-  printf "%-6s %-13s %12s %12s %10s %s\n" \
-    "------" "-------------" "------------" "------------" "----------" "----"
+  printf "%-6s %-13s %12s %12s %10s %-15s\n" \
+    "------" "-------------" "------------" "------------" "----------" "---------------"
 
   awk -F'\t' -v files="${FILES[*]}" '
     {
@@ -325,8 +325,9 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           u1 = s1[base] / c1[base]
           speedup = (u1 > 0) ? u2 / u1 : 0
           note = (speedup >= 1) ? "branch faster" : "compare faster"
-          printf "%-6s %-13s %12.1f %12.1f %10.2fx %s\n",
-            solvers[si], filearr[fi], u2, u1, speedup, note
+          sp = sprintf("%9.2fx", speedup)
+          printf "%-6s %-13s %12.1f %12.1f %10s %-15s\n",
+            solvers[si], filearr[fi], u2, u1, sp, note
         }
       }
     }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,7 +2,8 @@
 # Benchmark dtest performance on one or two binaries.
 #
 # Runs all combinations of solver (solve, calc) and hand file
-# (list100/1000/…/1), largest files first, then prints per-run timings and an optional summary.
+# (list100/1000/…/1), largest files first. With --compare, prints summary only
+# unless --details; without --compare, prints per-run rows.
 # Does not pass dtest options unless given after "--" (see below).
 #
 # Usage:
@@ -20,6 +21,7 @@
 #   REPEATS    Runs per combination per binary (default: 1)
 #   MAX_DEALS  Include list10^n.txt files with 10^n <= N (default: 100)
 #   DRY_RUN    If 1, print commands only
+#   DETAILS    If 1 with --compare, print per-run timing rows (default: summary only)
 
 set -euo pipefail
 
@@ -29,6 +31,7 @@ HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
 REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
+DETAILS="${DETAILS:-0}"
 BUILD=0
 REVERSE=0
 DTEST_EXTRA=()
@@ -39,7 +42,8 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Benchmark dtest across solver/file combinations. With --compare, compare two binaries.
+Benchmark dtest across solver/file combinations. With --compare, prints a summary
+by default; use --details for per-run rows.
 
 Options:
   -h, --help          Show this help
@@ -48,13 +52,14 @@ Options:
                       (alias: --max_deals)
   --build             Build branch dtest only (bazel build //library/tests:dtest)
   --branch PATH       Branch dtest binary (default: $BRANCH)
-  --compare PATH      Optional second dtest binary for comparison
+  --compare PATH      Optional second dtest binary for comparison (summary only)
+  --details           With --compare, also print per-run timing rows
   --reverse           With --compare, run compare before branch each repeat (default: branch first)
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
 
 Environment:
-  BRANCH, COMPARE, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
+  BRANCH, COMPARE, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN, DETAILS
 
 Examples:
   ./benchmark.sh
@@ -62,6 +67,7 @@ Examples:
   ./benchmark.sh -- -n 8
   ./benchmark.sh --repeats 3 -- -n 4 -r
   ./benchmark.sh --compare /path/to/dtest
+  ./benchmark.sh --compare /path/to/dtest --details
   ./benchmark.sh --compare /path/to/dtest --reverse
   ./benchmark.sh --repeats 5 --compare /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
@@ -100,6 +106,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --reverse)
       REVERSE=1
+      shift
+      ;;
+    --details)
+      DETAILS=1
       shift
       ;;
     --)
@@ -273,6 +283,11 @@ echo "==================="
 printf "%-12s %s\n" "branch:" "$BRANCH"
 if [[ -n "${COMPARE:-}" ]]; then
   printf "%-12s %s\n" "compare:" "$COMPARE"
+  if [[ "$DETAILS" == "1" ]]; then
+    printf "%-12s %s\n" "details:" "on"
+  else
+    printf "%-12s %s\n" "details:" "off (summary only)"
+  fi
   if [[ "$REVERSE" == "1" ]]; then
     printf "%-12s %s\n" "run order:" "interleaved compare, branch"
   else
@@ -289,7 +304,12 @@ if ((${#DTEST_EXTRA[@]} > 0)); then
 fi
 echo
 
-if [[ "$DRY_RUN" != "1" ]]; then
+show_run_lines=1
+if [[ -n "${COMPARE:-}" && "$DETAILS" != "1" ]]; then
+  show_run_lines=0
+fi
+
+if [[ "$DRY_RUN" != "1" && "$show_run_lines" == "1" ]]; then
   printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
     "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
   printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
@@ -322,8 +342,10 @@ for solver in "${SOLVERS[@]}"; do
 
         read -r user sys avg ratio < <(run_dtest "$bin" "$solver" "$hands")
 
-        printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
-          "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
+        if [[ "$show_run_lines" == "1" ]]; then
+          printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
+            "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
+        fi
 
         printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
           "$solver" "$file" "$ver" "$rep" "$user" "$sys" "$avg" "$ratio" \

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -49,7 +49,7 @@ Options:
   --build             Build branch dtest only (bazel build //library/tests:dtest)
   --branch PATH       Branch dtest binary (default: $BRANCH)
   --compare PATH      Optional second dtest binary for comparison
-  --reverse           With --compare, run compare before branch (default: branch first)
+  --reverse           With --compare, run compare before branch each repeat (default: branch first)
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
 
@@ -274,9 +274,9 @@ printf "%-12s %s\n" "branch:" "$BRANCH"
 if [[ -n "${COMPARE:-}" ]]; then
   printf "%-12s %s\n" "compare:" "$COMPARE"
   if [[ "$REVERSE" == "1" ]]; then
-    printf "%-12s %s\n" "run order:" "compare, branch"
+    printf "%-12s %s\n" "run order:" "interleaved compare, branch"
   else
-    printf "%-12s %s\n" "run order:" "branch, compare"
+    printf "%-12s %s\n" "run order:" "interleaved branch, compare"
   fi
 fi
 printf "%-12s %s\n" "hands dir:" "$HANDS_DIR"
@@ -302,22 +302,22 @@ run_no=0
 for solver in "${SOLVERS[@]}"; do
   for file in "${FILES[@]}"; do
     hands="$HANDS_DIR/$file"
-    for pair in "${BIN_PAIRS[@]}"; do
-      ver="${pair%%:*}"
-      bin="${pair#*:}"
 
-      for (( rep = 1; rep <= REPEATS; rep++ )); do
+    for (( rep = 1; rep <= REPEATS; rep++ )); do
+      if [[ "$REPEATS" -gt 1 ]]; then
+        run_label="${rep}/${REPEATS}"
+      else
+        run_label="1/1"
+      fi
+
+      for pair in "${BIN_PAIRS[@]}"; do
+        ver="${pair%%:*}"
+        bin="${pair#*:}"
         run_no=$((run_no + 1))
 
         if [[ "$DRY_RUN" == "1" ]]; then
           run_dtest "$bin" "$solver" "$hands"
           continue
-        fi
-
-        if [[ "$REPEATS" -gt 1 ]]; then
-          run_label="${rep}/${REPEATS}"
-        else
-          run_label="1/1"
         fi
 
         read -r user sys avg ratio < <(run_dtest "$bin" "$solver" "$hands")

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -12,6 +12,7 @@
 #   ./benchmark.sh --build
 #   ./benchmark.sh -- -n 8 -r
 #   ./benchmark.sh --build --compare /path/to/other/dtest
+#   ./benchmark.sh --compare /path/to/other/dtest --epsilon 1
 #   ./benchmark.sh --repeats 5 -- -n 4
 #   REPEATS=3 ./benchmark.sh
 #
@@ -72,6 +73,7 @@ Examples:
   ./benchmark.sh --repeats 3 -- -n 4 -r
   ./benchmark.sh --compare /path/to/dtest
   ./benchmark.sh --compare /path/to/dtest --details
+  ./benchmark.sh --compare /path/to/dtest --epsilon 1
   ./benchmark.sh --compare /path/to/dtest --reverse
   ./benchmark.sh --repeats 5 --compare /path/to/dtest
   DRY_RUN=1 ./benchmark.sh

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -444,7 +444,9 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
         for (fi = 1; fi <= nfiles; fi++) {
           base = solvers[si] SUBSEP filearr[fi]
           if (!(base in c2) || !(base in c1)) continue
-          # Every member of s1, c1, s2, and c2 will be positive.
+          # Every member of s1, c1, s2, and c2 should be positive.
+          # If not, it will be due to a rounding error. To fix, update
+          # TestTimer.cpp to accumulate microseconds rather than milliseconds. 
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
           cmp_branch = u2 / u1

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Benchmark dtest performance on one or two binaries.
 #
-# Runs all combinations of solver (calc, solve) and hand file
-# (list1/10/100/1000/10000), then prints per-run timings and an optional summary.
+# Runs all combinations of solver (solve, calc) and hand file
+# (list100/1000/…/1), largest files first, then prints per-run timings and an optional summary.
 # Does not pass dtest options unless given after "--" (see below).
 #
 # Usage:
@@ -30,9 +30,10 @@ REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
 BUILD=0
+REVERSE=0
 DTEST_EXTRA=()
 
-SOLVERS=(calc solve)
+SOLVERS=(solve calc)
 
 usage() {
   cat <<EOF
@@ -48,6 +49,7 @@ Options:
   --build             Build branch dtest only (bazel build //library/tests:dtest)
   --branch PATH       Branch dtest binary (default: $BRANCH)
   --compare PATH      Optional second dtest binary for comparison
+  --reverse           With --compare, run compare before branch (default: branch first)
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
 
@@ -60,6 +62,7 @@ Examples:
   ./benchmark.sh -- -n 8
   ./benchmark.sh --repeats 3 -- -n 4 -r
   ./benchmark.sh --compare /path/to/dtest
+  ./benchmark.sh --compare /path/to/dtest --reverse
   ./benchmark.sh --repeats 5 --compare /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
 EOF
@@ -95,6 +98,10 @@ while [[ $# -gt 0 ]]; do
       BUILD=1
       shift
       ;;
+    --reverse)
+      REVERSE=1
+      shift
+      ;;
     --)
       shift
       DTEST_EXTRA=("$@")
@@ -115,6 +122,11 @@ fi
 
 if ! [[ "$REPEATS" =~ ^[0-9]+$ ]] || (( REPEATS < 1 )); then
   echo "error: repeats must be a positive integer (got: $REPEATS)" >&2
+  exit 1
+fi
+
+if [[ "$REVERSE" == "1" && -z "${COMPARE:-}" ]]; then
+  echo "error: --reverse requires --compare" >&2
   exit 1
 fi
 
@@ -153,7 +165,7 @@ select_hand_files() {
   local item
   while IFS= read -r item; do
     FILES+=("${item#*:}")
-  done < <(printf '%s\n' "${candidates[@]}" | sort -t: -k1,1n)
+  done < <(printf '%s\n' "${candidates[@]}" | sort -t: -k1,1rn)
 }
 
 select_hand_files
@@ -182,7 +194,11 @@ fi
 
 BIN_PAIRS=("branch:$BRANCH")
 if [[ -n "${COMPARE:-}" ]]; then
-  BIN_PAIRS=("branch:$BRANCH" "compare:$COMPARE")
+  if [[ "$REVERSE" == "1" ]]; then
+    BIN_PAIRS=("compare:$COMPARE" "branch:$BRANCH")
+  else
+    BIN_PAIRS=("branch:$BRANCH" "compare:$COMPARE")
+  fi
 fi
 num_bins=${#BIN_PAIRS[@]}
 
@@ -252,6 +268,11 @@ echo "==================="
 printf "%-12s %s\n" "branch:" "$BRANCH"
 if [[ -n "${COMPARE:-}" ]]; then
   printf "%-12s %s\n" "compare:" "$COMPARE"
+  if [[ "$REVERSE" == "1" ]]; then
+    printf "%-12s %s\n" "run order:" "compare, branch"
+  else
+    printf "%-12s %s\n" "run order:" "branch, compare"
+  fi
 fi
 printf "%-12s %s\n" "hands dir:" "$HANDS_DIR"
 printf "%-12s %s\n" "max_deals:" "$MAX_DEALS"
@@ -312,7 +333,7 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo "Summary (branch vs compare, avg user ms; cmp/branch > 1 => branch faster)"
   echo "=============================================================================="
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
-    "solver" "file" "compare_user" "branch_user" "cmp/branch" "note"
+    "solver" "file" "compare_avg" "branch_avg" "cmp/branch" "note"
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "------" "-------------" "------------" "------------" "----------" "---------------"
 
@@ -320,15 +341,15 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
     {
       base = $1 SUBSEP $2
       if ($3 == "compare") {
-        s2[base] += $5
+        s2[base] += $7
         c2[base]++
       } else if ($3 == "branch") {
-        s1[base] += $5
+        s1[base] += $7
         c1[base]++
       }
     }
     END {
-      split("calc solve", solvers, " ")
+      split("solve calc", solvers, " ")
       nfiles = split(files, filearr, " ")
 
       for (si = 1; si <= 2; si++) {
@@ -340,7 +361,7 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           cmp_branch = (u1 > 0) ? u2 / u1 : 0
           note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
           sp = sprintf("%9.2fx", cmp_branch)
-          printf "%-6s %-13s %12.1f %12.1f %10s %-15s\n",
+          printf "%-6s %-13s %12.2f %12.2f %10s %-15s\n",
             solvers[si], filearr[fi], u2, u1, sp, note
         }
       }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -361,9 +361,10 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
         for (fi = 1; fi <= nfiles; fi++) {
           base = solvers[si] SUBSEP filearr[fi]
           if (!(base in c2) || !(base in c1)) continue
+          # Every member of s1, c1, s2, and c2 will be positive.
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
-          cmp_branch = (u1 > 0) ? u2 / u1 : 0
+          cmp_branch = u2 / u1
           note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
           sp = sprintf("%9.2fx", cmp_branch)
           printf "%-6s %-13s %12.2f %12.2f %10s %-15s\n",

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -42,8 +42,8 @@ Benchmark dtest across solver/file combinations. With --dtest2, compare two bina
 
 Options:
   -h, --help          Show this help
-  --repeats N         Runs per combination per binary (default: 1 or $REPEATS)
-  --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100 or $MAX_DEALS)
+  --repeats N         Runs per combination per binary (default: 1; env: REPEATS)
+  --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100; env: MAX_DEALS)
                       (alias: --max_deals)
   --build             Run bazel build //library/tests:dtest before benchmarking
   --dtest1 PATH       First dtest binary (default: $DTEST1)
@@ -140,7 +140,7 @@ select_hand_files() {
   shopt -u nullglob
 
   if ((${#candidates[@]} == 0)); then
-    echo "error: no list10^n.txt files with n <= $MAX_DEALS in $HANDS_DIR" >&2
+    echo "error: no list10^n.txt files with 10^n <= $MAX_DEALS in $HANDS_DIR" >&2
     exit 1
   fi
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -3,12 +3,14 @@
 #
 # Runs all combinations of solver (calc, solve) and hand file
 # (list1/10/100/1000/10000), then prints per-run timings and an optional summary.
-# Does not pass -n to dtest (library default thread count).
+# Does not pass dtest options unless given after "--" (see below).
 #
 # Usage:
 #   ./benchmark.sh
 #   ./benchmark.sh --build
+#   ./benchmark.sh -- -n 8 -r
 #   ./benchmark.sh --build --dtest2 /path/to/other/dtest
+#   ./benchmark.sh -n 5 -- -n 4
 #   REPEATS=3 ./benchmark.sh
 #
 # Environment:
@@ -28,6 +30,7 @@ REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
 BUILD=0
+DTEST_EXTRA=()
 
 SOLVERS=(calc solve)
 
@@ -45,6 +48,10 @@ Options:
   --build             Run bazel build //library/tests:dtest before benchmarking
   --dtest1 PATH       First dtest binary (default: $DTEST1)
   --dtest2 PATH       Optional second dtest binary for comparison
+  --                  End benchmark options; remaining args are passed to dtest
+                      (e.g. -- -n 8 -r for 8 threads and slow-board report)
+
+Note: -n before -- sets benchmark repeat count; -n after -- sets dtest threads.
 
 Environment:
   DTEST1, DTEST2, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
@@ -52,6 +59,8 @@ Environment:
 Examples:
   ./benchmark.sh
   ./benchmark.sh --build
+  ./benchmark.sh -- -n 8
+  ./benchmark.sh -n 3 -- -n 4 -r
   ./benchmark.sh --dtest2 /path/to/dtest
   ./benchmark.sh -n 5 --dtest2 /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
@@ -87,6 +96,11 @@ while [[ $# -gt 0 ]]; do
     --build)
       BUILD=1
       shift
+      ;;
+    --)
+      shift
+      DTEST_EXTRA=("$@")
+      break
       ;;
     *)
       echo "Unknown option: $1" >&2
@@ -202,16 +216,20 @@ run_dtest() {
   local binary="$1"
   local solver="$2"
   local hands="$3"
+  local -a cmd=("$binary" -f "$hands" -s "$solver")
+  if ((${#DTEST_EXTRA[@]} > 0)); then
+    cmd+=("${DTEST_EXTRA[@]}")
+  fi
 
   if [[ "$DRY_RUN" == "1" ]]; then
-    echo "DRY_RUN: $binary -f $hands -s $solver" >&2
+    echo "DRY_RUN: ${cmd[*]}" >&2
     echo "0 0 0.00 0.00"
     return 0
   fi
 
   local out
-  if ! out="$("$binary" -f "$hands" -s "$solver" 2>&1)"; then
-    echo "error: dtest failed: $binary -f $hands -s $solver" >&2
+  if ! out="$("${cmd[@]}" 2>&1)"; then
+    echo "error: dtest failed: ${cmd[*]}" >&2
     echo "$out" >&2
     exit 1
   fi
@@ -229,6 +247,9 @@ echo "max_deals:  $MAX_DEALS"
 echo "files:      ${FILES[*]}"
 echo "branch:     $branch"
 echo "repeats:    $REPEATS"
+if ((${#DTEST_EXTRA[@]} > 0)); then
+  echo "dtest args: ${DTEST_EXTRA[*]}"
+fi
 echo
 
 printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -9,13 +9,13 @@
 #   ./benchmark.sh
 #   ./benchmark.sh --build
 #   ./benchmark.sh -- -n 8 -r
-#   ./benchmark.sh --build --dtest2 /path/to/other/dtest
+#   ./benchmark.sh --build --compare /path/to/other/dtest
 #   ./benchmark.sh --repeats 5 -- -n 4
 #   REPEATS=3 ./benchmark.sh
 #
 # Environment:
-#   DTEST1     Path to first dtest (default: bazel-bin in this repo)
-#   DTEST2     Optional second dtest for comparison
+#   BRANCH     Path to branch dtest (default: bazel-bin in this repo)
+#   COMPARE    Optional second dtest binary for comparison
 #   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
 #   REPEATS    Runs per combination per binary (default: 1)
 #   MAX_DEALS  Include listN.txt files where N <= this value (default: 100)
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DTEST1="${DTEST1:-$ROOT/bazel-bin/library/tests/dtest}"
+BRANCH="${BRANCH:-$ROOT/bazel-bin/library/tests/dtest}"
 HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
 REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
@@ -38,7 +38,7 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Benchmark dtest across solver/file combinations. With --dtest2, compare two binaries.
+Benchmark dtest across solver/file combinations. With --compare, compare two binaries.
 
 Options:
   -h, --help          Show this help
@@ -46,21 +46,21 @@ Options:
   --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100; env: MAX_DEALS)
                       (alias: --max_deals)
   --build             Run bazel build //library/tests:dtest before benchmarking
-  --dtest1 PATH       First dtest binary (default: $DTEST1)
-  --dtest2 PATH       Optional second dtest binary for comparison
+  --branch PATH       Branch dtest binary (default: $BRANCH)
+  --compare PATH      Optional second dtest binary for comparison
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
 
 Environment:
-  DTEST1, DTEST2, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
+  BRANCH, COMPARE, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
 
 Examples:
   ./benchmark.sh
   ./benchmark.sh --build
   ./benchmark.sh -- -n 8
   ./benchmark.sh --repeats 3 -- -n 4 -r
-  ./benchmark.sh --dtest2 /path/to/dtest
-  ./benchmark.sh --repeats 5 --dtest2 /path/to/dtest
+  ./benchmark.sh --compare /path/to/dtest
+  ./benchmark.sh --repeats 5 --compare /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
 EOF
 }
@@ -76,14 +76,14 @@ while [[ $# -gt 0 ]]; do
       REPEATS="${1:?missing value for --repeats}"
       shift
       ;;
-    --dtest1)
+    --branch)
       shift
-      DTEST1="${1:?missing value for --dtest1}"
+      BRANCH="${1:?missing value for --branch}"
       shift
       ;;
-    --dtest2)
+    --compare)
       shift
-      DTEST2="${1:?missing value for --dtest2}"
+      COMPARE="${1:?missing value for --compare}"
       shift
       ;;
     --max-deals|--max_deals|-max-deals|-max_deals)
@@ -162,20 +162,20 @@ if [[ "$BUILD" == "1" ]]; then
   fi
 fi
 
-if [[ ! -x "$DTEST1" ]]; then
-  echo "error: dtest1 not found or not executable: $DTEST1" >&2
+if [[ ! -x "$BRANCH" ]]; then
+  echo "error: branch binary not found or not executable: $BRANCH" >&2
   echo "hint: bazel build //library/tests:dtest" >&2
   exit 1
 fi
 
-if [[ -n "${DTEST2:-}" && ! -x "$DTEST2" ]]; then
-  echo "error: dtest2 not found or not executable: $DTEST2" >&2
+if [[ -n "${COMPARE:-}" && ! -x "$COMPARE" ]]; then
+  echo "error: compare binary not found or not executable: $COMPARE" >&2
   exit 1
 fi
 
-BIN_PAIRS=("dtest1:$DTEST1")
-if [[ -n "${DTEST2:-}" ]]; then
-  BIN_PAIRS=("dtest2:$DTEST2" "dtest1:$DTEST1")
+BIN_PAIRS=("branch:$BRANCH")
+if [[ -n "${COMPARE:-}" ]]; then
+  BIN_PAIRS=("compare:$COMPARE" "branch:$BRANCH")
 fi
 num_bins=${#BIN_PAIRS[@]}
 
@@ -235,25 +235,25 @@ run_dtest() {
 
 echo "DDS dtest benchmark"
 echo "==================="
-echo "dtest1:     $DTEST1"
-if [[ -n "${DTEST2:-}" ]]; then
-  echo "dtest2:     $DTEST2"
+printf "%-12s %s\n" "branch:" "$BRANCH"
+if [[ -n "${COMPARE:-}" ]]; then
+  printf "%-12s %s\n" "compare:" "$COMPARE"
 fi
-echo "hands dir:  $HANDS_DIR"
-echo "max_deals:  $MAX_DEALS"
-echo "files:      ${FILES[*]}"
-echo "branch:     $branch"
-echo "repeats:    $REPEATS"
+printf "%-12s %s\n" "hands dir:" "$HANDS_DIR"
+printf "%-12s %s\n" "max_deals:" "$MAX_DEALS"
+printf "%-12s %s\n" "files:" "${FILES[*]}"
+printf "%-12s %s\n" "git branch:" "$branch"
+printf "%-12s %s\n" "repeats:" "$REPEATS"
 if ((${#DTEST_EXTRA[@]} > 0)); then
-  echo "dtest args: ${DTEST_EXTRA[*]}"
+  printf "%-12s %s\n" "dtest args:" "${DTEST_EXTRA[*]}"
 fi
 echo
 
 if [[ "$DRY_RUN" != "1" ]]; then
-  printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
     "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
-  printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
-    "------" "------------" "----" "--------" "--------" "----------" "------" "---"
+  printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
+    "------" "-------------" "-------" "--------" "--------" "----------" "------" "---"
 fi
 
 total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * num_bins * REPEATS ))
@@ -282,7 +282,7 @@ for solver in "${SOLVERS[@]}"; do
 
         read -r user sys avg ratio < <(run_dtest "$bin" "$solver" "$hands")
 
-        printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+        printf "%-6s %-13s %7s %8s %8s %10s %6s %s\n" \
           "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
 
         printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
@@ -293,22 +293,22 @@ for solver in "${SOLVERS[@]}"; do
   done
 done
 
-if [[ -n "${DTEST2:-}" && "$DRY_RUN" != "1" ]]; then
+if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo
-  echo "Summary (dtest1 vs dtest2, user time)"
-  echo "====================================="
-  printf "%-6s %-12s %10s %10s %10s %s\n" \
-    "solver" "file" "dtest2_user" "dtest1_user" "speedup" "note"
-  printf "%-6s %-12s %10s %10s %10s %s\n" \
-    "------" "------------" "----------" "----------" "----------" "----"
+  echo "Summary (branch vs compare, user time)"
+  echo "======================================"
+  printf "%-6s %-13s %12s %12s %10s %s\n" \
+    "solver" "file" "compare_user" "branch_user" "speedup" "note"
+  printf "%-6s %-13s %12s %12s %10s %s\n" \
+    "------" "-------------" "------------" "------------" "----------" "----"
 
   awk -F'\t' -v files="${FILES[*]}" '
     {
       base = $1 SUBSEP $2
-      if ($3 == "dtest2") {
+      if ($3 == "compare") {
         s2[base] += $5
         c2[base]++
-      } else if ($3 == "dtest1") {
+      } else if ($3 == "branch") {
         s1[base] += $5
         c1[base]++
       }
@@ -324,8 +324,8 @@ if [[ -n "${DTEST2:-}" && "$DRY_RUN" != "1" ]]; then
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
           speedup = (u1 > 0) ? u2 / u1 : 0
-          note = (speedup >= 1) ? "dtest1 faster" : "dtest2 faster"
-          printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
+          note = (speedup >= 1) ? "branch faster" : "compare faster"
+          printf "%-6s %-13s %12.1f %12.1f %10.2fx %s\n",
             solvers[si], filearr[fi], u2, u1, speedup, note
         }
       }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# Compare dtest performance between two binaries (e.g. DDS 3.0 vs 2.9).
+# Benchmark dtest performance on one or two binaries.
 #
 # Runs all combinations of solver (calc, solve) and hand file
-# (list1/10/100/1000), then prints per-run timings and a summary.
+# (list1/10/100/1000), then prints per-run timings and an optional summary.
 # Does not pass -n to dtest (library default thread count).
 #
 # Usage:
+#   ./benchmark.sh
 #   ./benchmark.sh --dtest2 /path/to/other/dtest
-#   REPEATS=3 ./benchmark.sh --dtest2 /path/to/other/dtest
-#   DTEST1=/path/to/dtest1 DTEST2=/path/to/dtest2 ./benchmark.sh
+#   REPEATS=3 ./benchmark.sh
 #
 # Environment:
 #   DTEST1     Path to first dtest (default: bazel-bin in this repo)
-#   DTEST2     Path to second dtest (required unless --dtest2 is given)
+#   DTEST2     Optional second dtest for comparison
 #   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
 #   REPEATS    Runs per combination per binary (default: 1)
 #   DRY_RUN    If 1, print commands only
@@ -33,21 +33,22 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Compare dtest on two binaries across all solver/file combinations.
+Benchmark dtest across solver/file combinations. With --dtest2, compare two binaries.
 
 Options:
   -h, --help       Show this help
   -n REPEATS       Runs per combination per binary (default: $REPEATS)
   --dtest1 PATH    First dtest binary (default: $DTEST1)
-  --dtest2 PATH    Second dtest binary (required if DTEST2 is unset)
+  --dtest2 PATH    Optional second dtest binary for comparison
 
 Environment:
   DTEST1, DTEST2, HANDS_DIR, REPEATS, DRY_RUN
 
 Examples:
+  ./benchmark.sh
   ./benchmark.sh --dtest2 /path/to/dtest
   ./benchmark.sh -n 5 --dtest2 /path/to/dtest
-  DRY_RUN=1 ./benchmark.sh --dtest2 /path/to/dtest
+  DRY_RUN=1 ./benchmark.sh
 EOF
 }
 
@@ -80,22 +81,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${DTEST2:-}" ]]; then
-  echo "error: dtest2 required (use --dtest2 PATH or set DTEST2)" >&2
-  usage >&2
-  exit 1
-fi
-
 if [[ ! -x "$DTEST1" ]]; then
   echo "error: dtest1 not found or not executable: $DTEST1" >&2
   echo "hint: bazel build //library/tests:dtest" >&2
   exit 1
 fi
 
-if [[ ! -x "$DTEST2" ]]; then
+if [[ -n "${DTEST2:-}" && ! -x "$DTEST2" ]]; then
   echo "error: dtest2 not found or not executable: $DTEST2" >&2
   exit 1
 fi
+
+BIN_PAIRS=("dtest1:$DTEST1")
+if [[ -n "${DTEST2:-}" ]]; then
+  BIN_PAIRS=("dtest2:$DTEST2" "dtest1:$DTEST1")
+fi
+num_bins=${#BIN_PAIRS[@]}
 
 for f in "${FILES[@]}"; do
   if [[ ! -f "$HANDS_DIR/$f" ]]; then
@@ -151,7 +152,9 @@ run_dtest() {
 echo "DDS dtest benchmark"
 echo "==================="
 echo "dtest1:     $DTEST1"
-echo "dtest2:     $DTEST2"
+if [[ -n "${DTEST2:-}" ]]; then
+  echo "dtest2:     $DTEST2"
+fi
 echo "hands dir:  $HANDS_DIR"
 echo "branch:     $branch"
 echo "repeats:    $REPEATS"
@@ -162,13 +165,13 @@ printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
 printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
   "------" "------------" "----" "--------" "--------" "----------" "------" "---"
 
-total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * 2 * REPEATS ))
+total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * num_bins * REPEATS ))
 run_no=0
 
 for solver in "${SOLVERS[@]}"; do
   for file in "${FILES[@]}"; do
     hands="$HANDS_DIR/$file"
-    for pair in "dtest2:$DTEST2" "dtest1:$DTEST1"; do
+    for pair in "${BIN_PAIRS[@]}"; do
       ver="${pair%%:*}"
       bin="${pair#*:}"
 
@@ -193,43 +196,45 @@ for solver in "${SOLVERS[@]}"; do
   done
 done
 
-echo
-echo "Summary (dtest1 vs dtest2, user time)"
-echo "====================================="
-printf "%-6s %-12s %10s %10s %10s %s\n" \
-  "solver" "file" "dtest2_user" "dtest1_user" "speedup" "note"
-printf "%-6s %-12s %10s %10s %10s %s\n" \
-  "------" "------------" "----------" "----------" "----------" "----"
+if [[ -n "${DTEST2:-}" ]]; then
+  echo
+  echo "Summary (dtest1 vs dtest2, user time)"
+  echo "====================================="
+  printf "%-6s %-12s %10s %10s %10s %s\n" \
+    "solver" "file" "dtest2_user" "dtest1_user" "speedup" "note"
+  printf "%-6s %-12s %10s %10s %10s %s\n" \
+    "------" "------------" "----------" "----------" "----------" "----"
 
-awk -F'\t' '
-  {
-    base = $1 SUBSEP $2
-    if ($3 == "dtest2") {
-      s2[base] += $5
-      c2[base]++
-    } else if ($3 == "dtest1") {
-      s1[base] += $5
-      c1[base]++
-    }
-  }
-  END {
-    split("calc solve", solvers, " ")
-    split("list1.txt list10.txt list100.txt list1000.txt", files, " ")
-
-    for (si = 1; si <= 2; si++) {
-      for (fi = 1; fi <= 4; fi++) {
-        base = solvers[si] SUBSEP files[fi]
-        if (!(base in c2) || !(base in c1)) continue
-        u2 = s2[base] / c2[base]
-        u1 = s1[base] / c1[base]
-        speedup = (u1 > 0) ? u2 / u1 : 0
-        note = (speedup >= 1) ? "dtest1 faster" : "dtest2 faster"
-        printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
-          solvers[si], files[fi], u2, u1, speedup, note
+  awk -F'\t' '
+    {
+      base = $1 SUBSEP $2
+      if ($3 == "dtest2") {
+        s2[base] += $5
+        c2[base]++
+      } else if ($3 == "dtest1") {
+        s1[base] += $5
+        c1[base]++
       }
     }
-  }
-' "$RESULTS"
+    END {
+      split("calc solve", solvers, " ")
+      split("list1.txt list10.txt list100.txt list1000.txt", files, " ")
+
+      for (si = 1; si <= 2; si++) {
+        for (fi = 1; fi <= 4; fi++) {
+          base = solvers[si] SUBSEP files[fi]
+          if (!(base in c2) || !(base in c1)) continue
+          u2 = s2[base] / c2[base]
+          u1 = s1[base] / c1[base]
+          speedup = (u1 > 0) ? u2 / u1 : 0
+          note = (speedup >= 1) ? "dtest1 faster" : "dtest2 faster"
+          printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
+            solvers[si], files[fi], u2, u1, speedup, note
+        }
+      }
+    }
+  ' "$RESULTS"
+fi
 
 echo
 echo "Completed $run_no runs ($total_runs expected)."

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -18,7 +18,7 @@
 #   COMPARE    Optional second dtest binary for comparison
 #   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
 #   REPEATS    Runs per combination per binary (default: 1)
-#   MAX_DEALS  Include listN.txt files where N <= this value (default: 100)
+#   MAX_DEALS  Include list10^n.txt files with 10^n <= N (default: 100)
 #   DRY_RUN    If 1, print commands only
 
 set -euo pipefail
@@ -45,7 +45,7 @@ Options:
   --repeats N         Runs per combination per binary (default: 1; env: REPEATS)
   --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100; env: MAX_DEALS)
                       (alias: --max_deals)
-  --build             Run bazel build //library/tests:dtest before benchmarking
+  --build             Build branch dtest only (bazel build //library/tests:dtest)
   --branch PATH       Branch dtest binary (default: $BRANCH)
   --compare PATH      Optional second dtest binary for comparison
   --                  End benchmark options; remaining args are passed to dtest
@@ -113,6 +113,11 @@ if ! [[ "$MAX_DEALS" =~ ^[0-9]+$ ]] || (( MAX_DEALS < 1 )); then
   exit 1
 fi
 
+if ! [[ "$REPEATS" =~ ^[0-9]+$ ]] || (( REPEATS < 1 )); then
+  echo "error: repeats must be a positive integer (got: $REPEATS)" >&2
+  exit 1
+fi
+
 select_hand_files() {
   is_power_of_10() {
     local n="$1"
@@ -162,20 +167,22 @@ if [[ "$BUILD" == "1" ]]; then
   fi
 fi
 
-if [[ ! -x "$BRANCH" ]]; then
-  echo "error: branch binary not found or not executable: $BRANCH" >&2
-  echo "hint: bazel build //library/tests:dtest" >&2
-  exit 1
-fi
+if [[ "$DRY_RUN" != "1" ]]; then
+  if [[ ! -x "$BRANCH" ]]; then
+    echo "error: branch binary not found or not executable: $BRANCH" >&2
+    echo "hint: bazel build //library/tests:dtest" >&2
+    exit 1
+  fi
 
-if [[ -n "${COMPARE:-}" && ! -x "$COMPARE" ]]; then
-  echo "error: compare binary not found or not executable: $COMPARE" >&2
-  exit 1
+  if [[ -n "${COMPARE:-}" && ! -x "$COMPARE" ]]; then
+    echo "error: compare binary not found or not executable: $COMPARE" >&2
+    exit 1
+  fi
 fi
 
 BIN_PAIRS=("branch:$BRANCH")
 if [[ -n "${COMPARE:-}" ]]; then
-  BIN_PAIRS=("compare:$COMPARE" "branch:$BRANCH")
+  BIN_PAIRS=("branch:$BRANCH" "compare:$COMPARE")
 fi
 num_bins=${#BIN_PAIRS[@]}
 
@@ -186,9 +193,9 @@ for f in "${FILES[@]}"; do
   fi
 done
 
-branch="unknown"
+git_branch="unknown"
 if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  git_branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
 fi
 
 RESULTS="$(mktemp)"
@@ -196,10 +203,10 @@ trap 'rm -f "$RESULTS"' EXIT
 
 parse_dtest_output() {
   awk '
-    /User time \(ms\)/ { user = $4 }
-    /Sys time \(ms\)/  { sys = $4 }
-    /Avg user time \(ms\)/ { avg = $5 }
-    /Ratio/ { ratio = $2 }
+    /^User time \(ms\)/ { user = $NF }
+    /^Sys time \(ms\)/  { sys = $NF }
+    /^Avg user time \(ms\)/ { avg = $NF }
+    /^Ratio[[:space:]]/ { ratio = $NF }
     END {
       if (user == "") user = "NA"
       if (sys == "") sys = "NA"
@@ -230,7 +237,12 @@ run_dtest() {
     echo "$out" >&2
     exit 1
   fi
-  parse_dtest_output <<<"$out"
+  local parsed
+  parsed="$(parse_dtest_output <<<"$out")"
+  if [[ "$parsed" == *"NA"* ]]; then
+    echo "warning: incomplete dtest timing output: ${cmd[*]}" >&2
+  fi
+  echo "$parsed"
 }
 
 echo "DDS dtest benchmark"
@@ -242,7 +254,7 @@ fi
 printf "%-12s %s\n" "hands dir:" "$HANDS_DIR"
 printf "%-12s %s\n" "max_deals:" "$MAX_DEALS"
 printf "%-12s %s\n" "files:" "${FILES[*]}"
-printf "%-12s %s\n" "git branch:" "$branch"
+printf "%-12s %s\n" "git branch:" "$git_branch"
 printf "%-12s %s\n" "repeats:" "$REPEATS"
 if ((${#DTEST_EXTRA[@]} > 0)); then
   printf "%-12s %s\n" "dtest args:" "${DTEST_EXTRA[*]}"
@@ -295,10 +307,10 @@ done
 
 if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
   echo
-  echo "Summary (branch vs compare, user time)"
-  echo "======================================"
+  echo "Summary (branch vs compare, total user ms; cmp/branch > 1 => branch faster)"
+  echo "=============================================================================="
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
-    "solver" "file" "compare_user" "branch_user" "speedup" "note"
+    "solver" "file" "compare_user" "branch_user" "cmp/branch" "note"
   printf "%-6s %-13s %12s %12s %10s %-15s\n" \
     "------" "-------------" "------------" "------------" "----------" "---------------"
 
@@ -323,9 +335,9 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           if (!(base in c2) || !(base in c1)) continue
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
-          speedup = (u1 > 0) ? u2 / u1 : 0
-          note = (speedup >= 1) ? "branch faster" : "compare faster"
-          sp = sprintf("%9.2fx", speedup)
+          cmp_branch = (u1 > 0) ? u2 / u1 : 0
+          note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
+          sp = sprintf("%9.2fx", cmp_branch)
           printf "%-6s %-13s %12.1f %12.1f %10s %-15s\n",
             solvers[si], filearr[fi], u2, u1, sp, note
         }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -363,18 +363,9 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           if (!(base in c2) || !(base in c1)) continue
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
-          if (u1 == 0 && u2 == 0) {
-            sp = "      n/a"
-            note = "equal"
-          } else if (u1 == 0) {
-            sp = "      inf"
-            note = "branch faster"
-          } else {
-            cmp_branch = u2 / u1
-            if (cmp_branch >= 1) note = "branch faster"
-            else note = "compare faster"
-            sp = sprintf("%9.2fx", cmp_branch)
-          }
+          cmp_branch = (u1 > 0) ? u2 / u1 : 0
+          note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
+          sp = sprintf("%9.2fx", cmp_branch)
           printf "%-6s %-13s %12.2f %12.2f %10s %-15s\n",
             solvers[si], filearr[fi], u2, u1, sp, note
         }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -219,6 +219,7 @@ trap 'rm -f "$RESULTS"' EXIT
 
 parse_dtest_output() {
   awk '
+    /^Number of hands/ { hands = $NF }
     /^User time \(ms\)/ { user = ($NF == "zero" ? 0 : $NF) }
     /^Sys time \(ms\)/  { sys = ($NF == "zero" ? 0 : $NF) }
     /^Avg user time \(ms\)/ { avg = ($NF == "zero" ? 0 : $NF) }
@@ -226,7 +227,11 @@ parse_dtest_output() {
     END {
       if (user == "") user = "NA"
       if (sys == "") sys = "NA"
-      if (avg == "") avg = "NA"
+      if (avg == "") {
+        if (user == 0) avg = 0
+        else if (hands != "" && user != "NA" && hands > 0) avg = user / hands
+        else avg = "NA"
+      }
       if (ratio == "") ratio = "NA"
       print user, sys, avg, ratio
     }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -10,7 +10,7 @@
 #   ./benchmark.sh --build
 #   ./benchmark.sh -- -n 8 -r
 #   ./benchmark.sh --build --dtest2 /path/to/other/dtest
-#   ./benchmark.sh -n 5 -- -n 4
+#   ./benchmark.sh --repeats 5 -- -n 4
 #   REPEATS=3 ./benchmark.sh
 #
 # Environment:
@@ -42,16 +42,14 @@ Benchmark dtest across solver/file combinations. With --dtest2, compare two bina
 
 Options:
   -h, --help          Show this help
-  -n REPEATS          Runs per combination per binary (default: $REPEATS)
-  --max-deals N       Include list10^n.txt files with 10^n <= N (default: $MAX_DEALS)
+  --repeats N         Runs per combination per binary (default: 1 or $REPEATS)
+  --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100 or $MAX_DEALS)
                       (alias: --max_deals)
   --build             Run bazel build //library/tests:dtest before benchmarking
   --dtest1 PATH       First dtest binary (default: $DTEST1)
   --dtest2 PATH       Optional second dtest binary for comparison
   --                  End benchmark options; remaining args are passed to dtest
                       (e.g. -- -n 8 -r for 8 threads and slow-board report)
-
-Note: -n before -- sets benchmark repeat count; -n after -- sets dtest threads.
 
 Environment:
   DTEST1, DTEST2, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
@@ -60,9 +58,9 @@ Examples:
   ./benchmark.sh
   ./benchmark.sh --build
   ./benchmark.sh -- -n 8
-  ./benchmark.sh -n 3 -- -n 4 -r
+  ./benchmark.sh --repeats 3 -- -n 4 -r
   ./benchmark.sh --dtest2 /path/to/dtest
-  ./benchmark.sh -n 5 --dtest2 /path/to/dtest
+  ./benchmark.sh --repeats 5 --dtest2 /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
 EOF
 }
@@ -73,9 +71,9 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
-    -n)
+    --repeats)
       shift
-      REPEATS="${1:?missing value for -n}"
+      REPEATS="${1:?missing value for --repeats}"
       shift
       ;;
     --dtest1)
@@ -223,7 +221,6 @@ run_dtest() {
 
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "DRY_RUN: ${cmd[*]}" >&2
-    echo "0 0 0.00 0.00"
     return 0
   fi
 
@@ -252,10 +249,12 @@ if ((${#DTEST_EXTRA[@]} > 0)); then
 fi
 echo
 
-printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
-  "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
-printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
-  "------" "------------" "----" "--------" "--------" "----------" "------" "---"
+if [[ "$DRY_RUN" != "1" ]]; then
+  printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+    "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
+  printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+    "------" "------------" "----" "--------" "--------" "----------" "------" "---"
+fi
 
 total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * num_bins * REPEATS ))
 run_no=0
@@ -269,6 +268,12 @@ for solver in "${SOLVERS[@]}"; do
 
       for (( rep = 1; rep <= REPEATS; rep++ )); do
         run_no=$((run_no + 1))
+
+        if [[ "$DRY_RUN" == "1" ]]; then
+          run_dtest "$bin" "$solver" "$hands"
+          continue
+        fi
+
         if [[ "$REPEATS" -gt 1 ]]; then
           run_label="${rep}/${REPEATS}"
         else
@@ -288,7 +293,7 @@ for solver in "${SOLVERS[@]}"; do
   done
 done
 
-if [[ -n "${DTEST2:-}" ]]; then
+if [[ -n "${DTEST2:-}" && "$DRY_RUN" != "1" ]]; then
   echo
   echo "Summary (dtest1 vs dtest2, user time)"
   echo "====================================="
@@ -329,4 +334,8 @@ if [[ -n "${DTEST2:-}" ]]; then
 fi
 
 echo
-echo "Completed $run_no runs ($total_runs expected)."
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY_RUN: $total_runs dtest invocations (not run)."
+else
+  echo "Completed $run_no runs ($total_runs expected)."
+fi

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Compare dtest performance: DDS 3.0 (this repo) vs DDS 2.9 (libdds).
+#
+# Runs all combinations of solver (calc, solve) and hand file
+# (list1/10/100/1000), then prints per-run timings and a summary.
+# Does not pass -n to dtest (library default thread count).
+#
+# Usage:
+#   ./bench_dtest.sh
+#   REPEATS=3 ./bench_dtest.sh
+#   DTEST_30=/path/to/dtest DTEST_29=/path/to/dtest ./bench_dtest.sh
+#
+# Environment:
+#   DTEST_30   Path to DDS 3.0 dtest (default: bazel-bin in this repo)
+#   DTEST_29   Path to DDS 2.9 dtest
+#   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
+#   REPEATS    Runs per combination per binary (default: 1)
+#   DRY_RUN    If 1, print commands only
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DTEST_30="${DTEST_30:-$ROOT/bazel-bin/library/tests/dtest}"
+DTEST_29="${DTEST_29:-/Users/adamw/src/bridge-hackathon/dds/libdds/.build/test/dtest}"
+HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
+REPEATS="${REPEATS:-1}"
+DRY_RUN="${DRY_RUN:-0}"
+
+SOLVERS=(calc solve)
+FILES=(list1.txt list10.txt list100.txt)
+# FILES=(list1.txt list10.txt list100.txt list1000.txt)
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Compare dtest on DDS 3.0 vs 2.9 across all solver/file combinations.
+
+Options:
+  -h, --help    Show this help
+  -n REPEATS    Runs per combination per binary (default: $REPEATS)
+
+Environment:
+  DTEST_30, DTEST_29, HANDS_DIR, REPEATS, DRY_RUN
+
+Examples:
+  ./bench_dtest.sh
+  ./bench_dtest.sh -n 5
+  DRY_RUN=1 ./bench_dtest.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -n)
+      shift
+      REPEATS="${1:?missing value for -n}"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -x "$DTEST_30" ]]; then
+  echo "error: DDS 3.0 dtest not found or not executable: $DTEST_30" >&2
+  echo "hint: bazel build //library/tests:dtest" >&2
+  exit 1
+fi
+
+if [[ ! -x "$DTEST_29" ]]; then
+  echo "error: DDS 2.9 dtest not found or not executable: $DTEST_29" >&2
+  exit 1
+fi
+
+for f in "${FILES[@]}"; do
+  if [[ ! -f "$HANDS_DIR/$f" ]]; then
+    echo "error: hand file not found: $HANDS_DIR/$f" >&2
+    exit 1
+  fi
+done
+
+branch="unknown"
+if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git -C "$ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+fi
+
+RESULTS="$(mktemp)"
+trap 'rm -f "$RESULTS"' EXIT
+
+parse_dtest_output() {
+  awk '
+    /User time \(ms\)/ { user = $4 }
+    /Sys time \(ms\)/  { sys = $4 }
+    /Avg user time \(ms\)/ { avg = $5 }
+    /Ratio/ { ratio = $2 }
+    END {
+      if (user == "") user = "NA"
+      if (sys == "") sys = "NA"
+      if (avg == "") avg = "NA"
+      if (ratio == "") ratio = "NA"
+      print user, sys, avg, ratio
+    }
+  '
+}
+
+run_dtest() {
+  local binary="$1"
+  local solver="$2"
+  local hands="$3"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY_RUN: $binary -f $hands -s $solver" >&2
+    echo "0 0 0.00 0.00"
+    return 0
+  fi
+
+  local out
+  if ! out="$("$binary" -f "$hands" -s "$solver" 2>&1)"; then
+    echo "error: dtest failed: $binary -f $hands -s $solver" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+  parse_dtest_output <<<"$out"
+}
+
+echo "DDS dtest benchmark"
+echo "==================="
+echo "3.0 binary: $DTEST_30"
+echo "2.9 binary: $DTEST_29"
+echo "hands dir:  $HANDS_DIR"
+echo "branch:     $branch"
+echo "repeats:    $REPEATS"
+echo
+
+printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+  "solver" "file" "ver" "user_ms" "sys_ms" "avg_user" "ratio" "run"
+printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+  "------" "------------" "----" "--------" "--------" "----------" "------" "---"
+
+total_runs=$(( ${#SOLVERS[@]} * ${#FILES[@]} * 2 * REPEATS ))
+run_no=0
+
+for solver in "${SOLVERS[@]}"; do
+  for file in "${FILES[@]}"; do
+    hands="$HANDS_DIR/$file"
+    for pair in "2.9:$DTEST_29" "3.0:$DTEST_30"; do
+      ver="${pair%%:*}"
+      bin="${pair#*:}"
+
+      for (( rep = 1; rep <= REPEATS; rep++ )); do
+        run_no=$((run_no + 1))
+        if [[ "$REPEATS" -gt 1 ]]; then
+          run_label="${rep}/${REPEATS}"
+        else
+          run_label="1/1"
+        fi
+
+        read -r user sys avg ratio < <(run_dtest "$bin" "$solver" "$hands")
+
+        printf "%-6s %-12s %4s %8s %8s %10s %6s %s\n" \
+          "$solver" "$file" "$ver" "$user" "$sys" "$avg" "$ratio" "$run_label"
+
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+          "$solver" "$file" "$ver" "$rep" "$user" "$sys" "$avg" "$ratio" \
+          >>"$RESULTS"
+      done
+    done
+  done
+done
+
+echo
+echo "Summary (3.0 vs 2.9, user time)"
+echo "==============================="
+printf "%-6s %-12s %10s %10s %10s %s\n" \
+  "solver" "file" "2.9_user" "3.0_user" "speedup" "note"
+printf "%-6s %-12s %10s %10s %10s %s\n" \
+  "------" "------------" "----------" "----------" "----------" "----"
+
+awk -F'\t' '
+  {
+    base = $1 SUBSEP $2
+    if ($3 == "2.9") {
+      s29[base] += $5
+      c29[base]++
+    } else if ($3 == "3.0") {
+      s30[base] += $5
+      c30[base]++
+    }
+  }
+  END {
+    split("calc solve", solvers, " ")
+    split("list1.txt list10.txt list100.txt list1000.txt", files, " ")
+
+    for (si = 1; si <= 2; si++) {
+      for (fi = 1; fi <= 4; fi++) {
+        base = solvers[si] SUBSEP files[fi]
+        if (!(base in c29) || !(base in c30)) continue
+        u29 = s29[base] / c29[base]
+        u30 = s30[base] / c30[base]
+        speedup = (u30 > 0) ? u29 / u30 : 0
+        note = (speedup >= 1) ? "3.0 faster" : "2.9 faster"
+        printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
+          solvers[si], files[fi], u29, u30, speedup, note
+      }
+    }
+  }
+' "$RESULTS"
+
+echo
+echo "Completed $run_no runs ($total_runs expected)."

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -15,6 +15,7 @@
 #   DTEST2     Optional second dtest for comparison
 #   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
 #   REPEATS    Runs per combination per binary (default: 1)
+#   MAX_DEALS  Include listN.txt files where N <= this value (default: 100)
 #   DRY_RUN    If 1, print commands only
 
 set -euo pipefail
@@ -23,11 +24,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DTEST1="${DTEST1:-$ROOT/bazel-bin/library/tests/dtest}"
 HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
 REPEATS="${REPEATS:-1}"
+MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
 
 SOLVERS=(calc solve)
-FILES=(list1.txt list10.txt list100.txt)
-# FILES=(list1.txt list10.txt list100.txt list1000.txt)
 
 usage() {
   cat <<EOF
@@ -36,13 +36,15 @@ Usage: $(basename "$0") [OPTIONS]
 Benchmark dtest across solver/file combinations. With --dtest2, compare two binaries.
 
 Options:
-  -h, --help       Show this help
-  -n REPEATS       Runs per combination per binary (default: $REPEATS)
-  --dtest1 PATH    First dtest binary (default: $DTEST1)
-  --dtest2 PATH    Optional second dtest binary for comparison
+  -h, --help          Show this help
+  -n REPEATS          Runs per combination per binary (default: $REPEATS)
+  --max-deals N       Include list10^n.txt files with 10^n <= N (default: $MAX_DEALS)
+                      (alias: --max_deals)
+  --dtest1 PATH       First dtest binary (default: $DTEST1)
+  --dtest2 PATH       Optional second dtest binary for comparison
 
 Environment:
-  DTEST1, DTEST2, HANDS_DIR, REPEATS, DRY_RUN
+  DTEST1, DTEST2, HANDS_DIR, REPEATS, MAX_DEALS, DRY_RUN
 
 Examples:
   ./benchmark.sh
@@ -73,6 +75,11 @@ while [[ $# -gt 0 ]]; do
       DTEST2="${1:?missing value for --dtest2}"
       shift
       ;;
+    --max-deals|--max_deals|-max-deals|-max_deals)
+      shift
+      MAX_DEALS="${1:?missing value for --max-deals}"
+      shift
+      ;;
     *)
       echo "Unknown option: $1" >&2
       usage >&2
@@ -80,6 +87,51 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if ! [[ "$MAX_DEALS" =~ ^[0-9]+$ ]] || (( MAX_DEALS < 1 )); then
+  echo "error: max_deals must be a positive integer (got: $MAX_DEALS)" >&2
+  exit 1
+fi
+
+select_hand_files() {
+  is_power_of_10() {
+    local n="$1"
+    (( n >= 1 )) || return 1
+    while (( n > 1 )); do
+      (( n % 10 == 0 )) || return 1
+      n=$(( n / 10 ))
+    done
+    return 0
+  }
+
+  local -a candidates=()
+  local path base count
+
+  shopt -s nullglob
+  for path in "$HANDS_DIR"/list*.txt; do
+    base="${path##*/}"
+    if [[ "$base" =~ ^list([0-9]+)\.txt$ ]]; then
+      count="${BASH_REMATCH[1]}"
+      if is_power_of_10 "$count" && (( count <= MAX_DEALS )); then
+        candidates+=("${count}:${base}")
+      fi
+    fi
+  done
+  shopt -u nullglob
+
+  if ((${#candidates[@]} == 0)); then
+    echo "error: no list10^n.txt files with n <= $MAX_DEALS in $HANDS_DIR" >&2
+    exit 1
+  fi
+
+  FILES=()
+  local item
+  while IFS= read -r item; do
+    FILES+=("${item#*:}")
+  done < <(printf '%s\n' "${candidates[@]}" | sort -t: -k1,1n)
+}
+
+select_hand_files
 
 if [[ ! -x "$DTEST1" ]]; then
   echo "error: dtest1 not found or not executable: $DTEST1" >&2
@@ -156,6 +208,8 @@ if [[ -n "${DTEST2:-}" ]]; then
   echo "dtest2:     $DTEST2"
 fi
 echo "hands dir:  $HANDS_DIR"
+echo "max_deals:  $MAX_DEALS"
+echo "files:      ${FILES[*]}"
 echo "branch:     $branch"
 echo "repeats:    $REPEATS"
 echo
@@ -205,7 +259,7 @@ if [[ -n "${DTEST2:-}" ]]; then
   printf "%-6s %-12s %10s %10s %10s %s\n" \
     "------" "------------" "----------" "----------" "----------" "----"
 
-  awk -F'\t' '
+  awk -F'\t' -v files="${FILES[*]}" '
     {
       base = $1 SUBSEP $2
       if ($3 == "dtest2") {
@@ -218,18 +272,18 @@ if [[ -n "${DTEST2:-}" ]]; then
     }
     END {
       split("calc solve", solvers, " ")
-      split("list1.txt list10.txt list100.txt list1000.txt", files, " ")
+      nfiles = split(files, filearr, " ")
 
       for (si = 1; si <= 2; si++) {
-        for (fi = 1; fi <= 4; fi++) {
-          base = solvers[si] SUBSEP files[fi]
+        for (fi = 1; fi <= nfiles; fi++) {
+          base = solvers[si] SUBSEP filearr[fi]
           if (!(base in c2) || !(base in c1)) continue
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
           speedup = (u1 > 0) ? u2 / u1 : 0
           note = (speedup >= 1) ? "dtest1 faster" : "dtest2 faster"
           printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
-            solvers[si], files[fi], u2, u1, speedup, note
+            solvers[si], filearr[fi], u2, u1, speedup, note
         }
       }
     }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,12 +2,13 @@
 # Benchmark dtest performance on one or two binaries.
 #
 # Runs all combinations of solver (calc, solve) and hand file
-# (list1/10/100/1000), then prints per-run timings and an optional summary.
+# (list1/10/100/1000/10000), then prints per-run timings and an optional summary.
 # Does not pass -n to dtest (library default thread count).
 #
 # Usage:
 #   ./benchmark.sh
-#   ./benchmark.sh --dtest2 /path/to/other/dtest
+#   ./benchmark.sh --build
+#   ./benchmark.sh --build --dtest2 /path/to/other/dtest
 #   REPEATS=3 ./benchmark.sh
 #
 # Environment:
@@ -26,6 +27,7 @@ HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
 REPEATS="${REPEATS:-1}"
 MAX_DEALS="${MAX_DEALS:-100}"
 DRY_RUN="${DRY_RUN:-0}"
+BUILD=0
 
 SOLVERS=(calc solve)
 
@@ -40,6 +42,7 @@ Options:
   -n REPEATS          Runs per combination per binary (default: $REPEATS)
   --max-deals N       Include list10^n.txt files with 10^n <= N (default: $MAX_DEALS)
                       (alias: --max_deals)
+  --build             Run bazel build //library/tests:dtest before benchmarking
   --dtest1 PATH       First dtest binary (default: $DTEST1)
   --dtest2 PATH       Optional second dtest binary for comparison
 
@@ -48,6 +51,7 @@ Environment:
 
 Examples:
   ./benchmark.sh
+  ./benchmark.sh --build
   ./benchmark.sh --dtest2 /path/to/dtest
   ./benchmark.sh -n 5 --dtest2 /path/to/dtest
   DRY_RUN=1 ./benchmark.sh
@@ -78,6 +82,10 @@ while [[ $# -gt 0 ]]; do
     --max-deals|--max_deals|-max-deals|-max_deals)
       shift
       MAX_DEALS="${1:?missing value for --max-deals}"
+      shift
+      ;;
+    --build)
+      BUILD=1
       shift
       ;;
     *)
@@ -132,6 +140,15 @@ select_hand_files() {
 }
 
 select_hand_files
+
+if [[ "$BUILD" == "1" ]]; then
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY_RUN: (cd $ROOT && bazel build //library/tests:dtest)" >&2
+  else
+    echo "Building //library/tests:dtest..." >&2
+    (cd "$ROOT" && bazel build //library/tests:dtest)
+  fi
+fi
 
 if [[ ! -x "$DTEST1" ]]; then
   echo "error: dtest1 not found or not executable: $DTEST1" >&2

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# Compare dtest performance: DDS 3.0 (this repo) vs DDS 2.9 (libdds).
+# Compare dtest performance between two binaries (e.g. DDS 3.0 vs 2.9).
 #
 # Runs all combinations of solver (calc, solve) and hand file
 # (list1/10/100/1000), then prints per-run timings and a summary.
 # Does not pass -n to dtest (library default thread count).
 #
 # Usage:
-#   ./bench_dtest.sh
-#   REPEATS=3 ./bench_dtest.sh
-#   DTEST_30=/path/to/dtest DTEST_29=/path/to/dtest ./bench_dtest.sh
+#   ./benchmark.sh --dtest2 /path/to/other/dtest
+#   REPEATS=3 ./benchmark.sh --dtest2 /path/to/other/dtest
+#   DTEST1=/path/to/dtest1 DTEST2=/path/to/dtest2 ./benchmark.sh
 #
 # Environment:
-#   DTEST_30   Path to DDS 3.0 dtest (default: bazel-bin in this repo)
-#   DTEST_29   Path to DDS 2.9 dtest
+#   DTEST1     Path to first dtest (default: bazel-bin in this repo)
+#   DTEST2     Path to second dtest (required unless --dtest2 is given)
 #   HANDS_DIR  Directory containing list*.txt files (default: ./hands)
 #   REPEATS    Runs per combination per binary (default: 1)
 #   DRY_RUN    If 1, print commands only
@@ -20,8 +20,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DTEST_30="${DTEST_30:-$ROOT/bazel-bin/library/tests/dtest}"
-DTEST_29="${DTEST_29:-/Users/adamw/src/bridge-hackathon/dds/libdds/.build/test/dtest}"
+DTEST1="${DTEST1:-$ROOT/bazel-bin/library/tests/dtest}"
 HANDS_DIR="${HANDS_DIR:-$ROOT/hands}"
 REPEATS="${REPEATS:-1}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -34,19 +33,21 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Compare dtest on DDS 3.0 vs 2.9 across all solver/file combinations.
+Compare dtest on two binaries across all solver/file combinations.
 
 Options:
-  -h, --help    Show this help
-  -n REPEATS    Runs per combination per binary (default: $REPEATS)
+  -h, --help       Show this help
+  -n REPEATS       Runs per combination per binary (default: $REPEATS)
+  --dtest1 PATH    First dtest binary (default: $DTEST1)
+  --dtest2 PATH    Second dtest binary (required if DTEST2 is unset)
 
 Environment:
-  DTEST_30, DTEST_29, HANDS_DIR, REPEATS, DRY_RUN
+  DTEST1, DTEST2, HANDS_DIR, REPEATS, DRY_RUN
 
 Examples:
-  ./bench_dtest.sh
-  ./bench_dtest.sh -n 5
-  DRY_RUN=1 ./bench_dtest.sh
+  ./benchmark.sh --dtest2 /path/to/dtest
+  ./benchmark.sh -n 5 --dtest2 /path/to/dtest
+  DRY_RUN=1 ./benchmark.sh --dtest2 /path/to/dtest
 EOF
 }
 
@@ -61,6 +62,16 @@ while [[ $# -gt 0 ]]; do
       REPEATS="${1:?missing value for -n}"
       shift
       ;;
+    --dtest1)
+      shift
+      DTEST1="${1:?missing value for --dtest1}"
+      shift
+      ;;
+    --dtest2)
+      shift
+      DTEST2="${1:?missing value for --dtest2}"
+      shift
+      ;;
     *)
       echo "Unknown option: $1" >&2
       usage >&2
@@ -69,14 +80,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ ! -x "$DTEST_30" ]]; then
-  echo "error: DDS 3.0 dtest not found or not executable: $DTEST_30" >&2
+if [[ -z "${DTEST2:-}" ]]; then
+  echo "error: dtest2 required (use --dtest2 PATH or set DTEST2)" >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -x "$DTEST1" ]]; then
+  echo "error: dtest1 not found or not executable: $DTEST1" >&2
   echo "hint: bazel build //library/tests:dtest" >&2
   exit 1
 fi
 
-if [[ ! -x "$DTEST_29" ]]; then
-  echo "error: DDS 2.9 dtest not found or not executable: $DTEST_29" >&2
+if [[ ! -x "$DTEST2" ]]; then
+  echo "error: dtest2 not found or not executable: $DTEST2" >&2
   exit 1
 fi
 
@@ -133,8 +150,8 @@ run_dtest() {
 
 echo "DDS dtest benchmark"
 echo "==================="
-echo "3.0 binary: $DTEST_30"
-echo "2.9 binary: $DTEST_29"
+echo "dtest1:     $DTEST1"
+echo "dtest2:     $DTEST2"
 echo "hands dir:  $HANDS_DIR"
 echo "branch:     $branch"
 echo "repeats:    $REPEATS"
@@ -151,7 +168,7 @@ run_no=0
 for solver in "${SOLVERS[@]}"; do
   for file in "${FILES[@]}"; do
     hands="$HANDS_DIR/$file"
-    for pair in "2.9:$DTEST_29" "3.0:$DTEST_30"; do
+    for pair in "dtest2:$DTEST2" "dtest1:$DTEST1"; do
       ver="${pair%%:*}"
       bin="${pair#*:}"
 
@@ -177,22 +194,22 @@ for solver in "${SOLVERS[@]}"; do
 done
 
 echo
-echo "Summary (3.0 vs 2.9, user time)"
-echo "==============================="
+echo "Summary (dtest1 vs dtest2, user time)"
+echo "====================================="
 printf "%-6s %-12s %10s %10s %10s %s\n" \
-  "solver" "file" "2.9_user" "3.0_user" "speedup" "note"
+  "solver" "file" "dtest2_user" "dtest1_user" "speedup" "note"
 printf "%-6s %-12s %10s %10s %10s %s\n" \
   "------" "------------" "----------" "----------" "----------" "----"
 
 awk -F'\t' '
   {
     base = $1 SUBSEP $2
-    if ($3 == "2.9") {
-      s29[base] += $5
-      c29[base]++
-    } else if ($3 == "3.0") {
-      s30[base] += $5
-      c30[base]++
+    if ($3 == "dtest2") {
+      s2[base] += $5
+      c2[base]++
+    } else if ($3 == "dtest1") {
+      s1[base] += $5
+      c1[base]++
     }
   }
   END {
@@ -202,13 +219,13 @@ awk -F'\t' '
     for (si = 1; si <= 2; si++) {
       for (fi = 1; fi <= 4; fi++) {
         base = solvers[si] SUBSEP files[fi]
-        if (!(base in c29) || !(base in c30)) continue
-        u29 = s29[base] / c29[base]
-        u30 = s30[base] / c30[base]
-        speedup = (u30 > 0) ? u29 / u30 : 0
-        note = (speedup >= 1) ? "3.0 faster" : "2.9 faster"
+        if (!(base in c2) || !(base in c1)) continue
+        u2 = s2[base] / c2[base]
+        u1 = s1[base] / c1[base]
+        speedup = (u1 > 0) ? u2 / u1 : 0
+        note = (speedup >= 1) ? "dtest1 faster" : "dtest2 faster"
         printf "%-6s %-12s %10.1f %10.1f %9.2fx %s\n",
-          solvers[si], files[fi], u29, u30, speedup, note
+          solvers[si], files[fi], u2, u1, speedup, note
       }
     }
   }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -363,9 +363,18 @@ if [[ -n "${COMPARE:-}" && "$DRY_RUN" != "1" ]]; then
           if (!(base in c2) || !(base in c1)) continue
           u2 = s2[base] / c2[base]
           u1 = s1[base] / c1[base]
-          cmp_branch = (u1 > 0) ? u2 / u1 : 0
-          note = (cmp_branch >= 1) ? "branch faster" : "compare faster"
-          sp = sprintf("%9.2fx", cmp_branch)
+          if (u1 == 0 && u2 == 0) {
+            sp = "      n/a"
+            note = "equal"
+          } else if (u1 == 0) {
+            sp = "      inf"
+            note = "branch faster"
+          } else {
+            cmp_branch = u2 / u1
+            if (cmp_branch >= 1) note = "branch faster"
+            else note = "compare faster"
+            sp = sprintf("%9.2fx", cmp_branch)
+          }
           printf "%-6s %-13s %12.2f %12.2f %10s %-15s\n",
             solvers[si], filearr[fi], u2, u1, sp, note
         }


### PR DESCRIPTION
Sample output:
```
$ ./benchmark.sh 
DDS dtest benchmark
===================
branch:      /Users/adamw/src/dds/bazel-bin/library/tests/dtest
hands dir:   /Users/adamw/src/dds/hands
max_deals:   100
files:       list100.txt list10.txt list1.txt
git branch:  benchmark
repeats:     1

solver file              ver  user_ms   sys_ms   avg_user  ratio run
------ ------------- ------- -------- -------- ---------- ------ ---
solve  list100.txt    branch      284     2428       2.84   8.55 1/1
solve  list10.txt     branch       47      133       4.70   2.83 1/1
solve  list1.txt      branch       15       15      15.00   1.00 1/1
calc   list100.txt    branch     1457    14900      14.57  10.23 1/1
calc   list10.txt     branch      237     1178      23.70   4.97 1/1
calc   list1.txt      branch       45      149      45.00   3.31 1/1

Completed 6 runs (6 expected).
```

Compare against a binary from another branch or v2.9. Comparing against a branch could be automated; as is I build a dtest in another branch, rename it, and move it to dds/..

```
$ ./benchmark.sh --build --compare ../dtest_solver_context_reuse --max-deals 100
Building //library/tests:dtest...
Starting local Bazel server (9.1.0 Homebrew) and connecting to it...
INFO: Analyzed target //library/tests:dtest (126 packages loaded, 1424 targets configured).
INFO: Found 1 target...
Target //library/tests:dtest up-to-date:
  bazel-bin/library/tests/dtest
INFO: Elapsed time: 3.827s, Critical Path: 0.02s
INFO: 1 process: 96 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
DDS dtest benchmark
===================
branch:      /Users/adamw/src/dds/bazel-bin/library/tests/dtest
compare:     ../dtest_solver_context_reuse
run order:   branch, compare
hands dir:   /Users/adamw/src/dds/hands
max_deals:   100
files:       list100.txt list10.txt list1.txt
git branch:  benchmark
repeats:     1

solver file              ver  user_ms   sys_ms   avg_user  ratio run
------ ------------- ------- -------- -------- ---------- ------ ---
solve  list100.txt    branch      300     2417       3.00   8.06 1/1
solve  list100.txt   compare      246     2450       2.46   9.96 1/1
solve  list10.txt     branch       47      127       4.70   2.70 1/1
solve  list10.txt    compare       50      134       5.00   2.68 1/1
solve  list1.txt      branch       15       15      15.00   1.00 1/1
solve  list1.txt     compare       16       16      16.00   1.00 1/1
calc   list100.txt    branch     1443    14842      14.43  10.29 1/1
calc   list100.txt   compare     1408    14731      14.08  10.46 1/1
calc   list10.txt     branch      240     1123      24.00   4.68 1/1
calc   list10.txt    compare      241     1173      24.10   4.87 1/1
calc   list1.txt      branch       46      147      46.00   3.20 1/1
calc   list1.txt     compare       45      147      45.00   3.27 1/1

Summary (branch vs compare, avg user ms; cmp/branch > 1 => branch faster)
==============================================================================
solver file           compare_avg   branch_avg cmp/branch note           
------ ------------- ------------ ------------ ---------- ---------------
solve  list100.txt           2.46         3.00      0.82x compare faster 
solve  list10.txt            5.00         4.70      1.06x branch faster  
solve  list1.txt            16.00        15.00      1.07x branch faster  
calc   list100.txt          14.08        14.43      0.98x compare faster 
calc   list10.txt           24.10        24.00      1.00x branch faster  
calc   list1.txt            45.00        46.00      0.98x compare faster 

Completed 12 runs (12 expected).
```