### PR TITLE
feat: expose max_threads on batch solve/calc-table Python bindings

### DIFF
--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -213,7 +213,7 @@ auto register_solve_bindings(py::module_& module) -> void
 
     module.def(
         "solve_all_boards_pbn",
-        [](const py::list& boards) {
+        [](const py::list& boards, const int max_threads) {
             const auto board_count = boards.size();
             if (board_count > MAXNOOFBOARDS) {
                 throw py::value_error(
@@ -249,7 +249,7 @@ auto register_solve_bindings(py::module_& module) -> void
             int code = RETURN_NO_FAULT;
             {
                 py::gil_scoped_release release;
-                code = SolveAllBoards(&native_boards, &solved_boards);
+                code = SolveAllBoardsN(&native_boards, &solved_boards, max_threads);
             }
             throw_on_dds_error(code);
 
@@ -260,6 +260,7 @@ auto register_solve_bindings(py::module_& module) -> void
             return result;
         },
         py::arg("boards"),
+        py::arg("max_threads") = 0,
         "Solve multiple bridge deals in PBN format.\n\n"
         "Args:\n"
         "    boards (list): List of board dicts, each with:\n"
@@ -270,7 +271,9 @@ auto register_solve_bindings(py::module_& module) -> void
         "        current_trick_rank (tuple, optional): Ranks in current trick. Default: (0, 0, 0)\n"
         "        target (int, optional): Target number of tricks (-1 = no target). Default: -1\n"
         "        solutions (int, optional): Depth of search (1-3). Default: 3\n"
-        "        mode (int, optional): 0=auto, 1=thread depth 6, 2=node depth 12. Default: 0\n\n"
+        "        mode (int, optional): 0=auto, 1=thread depth 6, 2=node depth 12. Default: 0\n"
+        "    max_threads (int, optional): Cap on worker threads for the batch. <=0 uses the\n"
+        "        automatic (hardware_concurrency) default. Default: 0\n\n"
         "Returns:\n"
         "    list: List of result dicts with keys 'nodes', 'cards', 'suit', 'rank', 'equals', 'score'.\n\n"
         "Raises:\n"
@@ -279,7 +282,7 @@ auto register_solve_bindings(py::module_& module) -> void
 
     module.def(
         "solve_all_boards_bin",
-        [](const py::list& boards) {
+        [](const py::list& boards, const int max_threads) {
             const auto board_count = boards.size();
             if (board_count > MAXNOOFBOARDS) {
                 throw py::value_error(
@@ -305,7 +308,7 @@ auto register_solve_bindings(py::module_& module) -> void
             int code = RETURN_NO_FAULT;
             {
                 py::gil_scoped_release release;
-                code = SolveAllBoardsBin(&native_boards, &solved_boards);
+                code = SolveAllBoardsBinN(&native_boards, &solved_boards, max_threads);
             }
             throw_on_dds_error(code);
 
@@ -316,6 +319,7 @@ auto register_solve_bindings(py::module_& module) -> void
             return result;
         },
         py::arg("boards"),
+        py::arg("max_threads") = 0,
         "Solve multiple bridge deals in binary format.\n\n"
         "Args:\n"
         "    boards (list): List of board dicts, each with:\n"
@@ -326,7 +330,9 @@ auto register_solve_bindings(py::module_& module) -> void
         "        current_trick_rank (tuple): Ranks in current trick (3-tuple of ints, 0 or 2-14).\n"
         "        target (int, optional): Target number of tricks (-1 = no target). Default: -1\n"
         "        solutions (int, optional): Depth of search (1-3). Default: 3\n"
-        "        mode (int, optional): 0=auto, 1=thread depth 6, 2=node depth 12. Default: 0\n\n"
+        "        mode (int, optional): 0=auto, 1=thread depth 6, 2=node depth 12. Default: 0\n"
+        "    max_threads (int, optional): Cap on worker threads for the batch. <=0 uses the\n"
+        "        automatic (hardware_concurrency) default. Default: 0\n\n"
         "Returns:\n"
         "    list: List of result dicts with keys 'nodes', 'cards', 'suit', 'rank', 'equals', 'score'.\n\n"
         "Raises:\n"
@@ -363,7 +369,8 @@ auto register_table_bindings(py::module_& module) -> void
 
     module.def(
         "calc_all_tables_pbn",
-        [](const py::list& deals_pbn, const int mode, const py::sequence& trump_filter) {
+        [](const py::list& deals_pbn, const int mode, const py::sequence& trump_filter,
+           const int max_threads) {
             // Validate mode parameter
             if (mode < -1 || mode > 3) {
                 throw py::value_error(
@@ -423,12 +430,13 @@ auto register_table_bindings(py::module_& module) -> void
             int code = RETURN_NO_FAULT;
             {
                 py::gil_scoped_release release;
-                code = CalcAllTablesPBN(
+                code = CalcAllTablesPBNN(
                     &native_deals,
                     mode,
                     trump_filter_vec.data(),
                     &tables_res,
-                    &all_par_results);
+                    &all_par_results,
+                    max_threads);
             }
             throw_on_dds_error(code);
 
@@ -453,12 +461,15 @@ auto register_table_bindings(py::module_& module) -> void
         py::arg("deals_pbn"),
         py::arg("mode") = -1,
         py::arg("trump_filter") = py::make_tuple(0, 0, 0, 0, 0),
+        py::arg("max_threads") = 0,
         "Calculate double-dummy tables for multiple PBN deals with optional par scores.\n\n"
         "Args:\n"
         "    deals_pbn (list): List of PBN strings (e.g., ['N:AK.234.456.789T...', ...]).\n"
         "    mode (int, optional): Par vulnerability mode (-1=disabled, 0=none, 1=both, 2=NS, 3=EW). Default: -1\n"
         "    trump_filter (sequence, optional): Strains to skip (0=include, 1=skip). Default: (0,0,0,0,0)\n"
-        "                                     Order: [♠, ♥, ♦, ♣, NT]\n\n"
+        "                                     Order: [♠, ♥, ♦, ♣, NT]\n"
+        "    max_threads (int, optional): Cap on worker threads for the batch. <=0 uses the\n"
+        "        automatic (hardware_concurrency) default. Default: 0\n\n"
         "Returns:\n"
         "    dict: Result dict with keys:\n"
         "          'no_of_boards' (int): Total number of calculated boards.\n"

--- a/python/tests/test_calc_tables.py
+++ b/python/tests/test_calc_tables.py
@@ -186,6 +186,20 @@ class TestCalcAllTablesPBN(unittest.TestCase):
         result_with_par = calc_all_tables_pbn(deals, mode=0)
         self.assertTrue(len(result_with_par["par_results"]) > 0)
 
+    def test_calc_all_tables_pbn_max_threads_matches_default(self) -> None:
+        """Passing an explicit max_threads must be accepted and give the same tables as the default."""
+        deals = [
+            "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3",
+            "N:Q87.K932.QJT32.7 AKJ9632.J84.6.Q5 .AQT765.K87.J962 T54..A954.AKT843",
+        ]
+        default = calc_all_tables_pbn(deals)
+        for max_threads in (1, 2):
+            capped = calc_all_tables_pbn(deals, max_threads=max_threads)
+            self.assertEqual(capped["no_of_boards"], default["no_of_boards"])
+            self.assertEqual(len(capped["tables"]), len(default["tables"]))
+            for capped_t, default_t in zip(capped["tables"], default["tables"]):
+                self.assertEqual(capped_t["res_table"], default_t["res_table"])
+
 
 class TestTableParity(unittest.TestCase):
     """Tests for parity between single and batch table calculations."""

--- a/python/tests/test_solve_all_boards.py
+++ b/python/tests/test_solve_all_boards.py
@@ -124,8 +124,10 @@ class TestSolveAllBoardsPBN(unittest.TestCase):
             self.assertEqual(len(capped), len(default))
             for capped_r, default_r in zip(capped, default):
                 # Only the first `cards` entries of a result are meaningful.
-                self.assertEqual(capped_r["cards"], default_r["cards"])
-                self.assertEqual(capped_r["score"][0], default_r["score"][0])
+                cards = capped_r["cards"]
+                self.assertEqual(cards, default_r["cards"])
+                for key in ("suit", "rank", "equals", "score"):
+                    self.assertEqual(capped_r[key][:cards], default_r[key][:cards])
 
 
 class TestSolveAllBoardsBin(unittest.TestCase):
@@ -197,8 +199,10 @@ class TestSolveAllBoardsBin(unittest.TestCase):
             self.assertEqual(len(capped), len(default))
             for capped_r, default_r in zip(capped, default):
                 # Only the first `cards` entries of a result are meaningful.
-                self.assertEqual(capped_r["cards"], default_r["cards"])
-                self.assertEqual(capped_r["score"][0], default_r["score"][0])
+                cards = capped_r["cards"]
+                self.assertEqual(cards, default_r["cards"])
+                for key in ("suit", "rank", "equals", "score"):
+                    self.assertEqual(capped_r[key][:cards], default_r[key][:cards])
 
 
 class TestSolveAllBoardsParity(unittest.TestCase):

--- a/python/tests/test_solve_all_boards.py
+++ b/python/tests/test_solve_all_boards.py
@@ -115,6 +115,18 @@ class TestSolveAllBoardsPBN(unittest.TestCase):
         results = solve_all_boards_pbn(boards)
         self.assertTrue(_result_shape_ok(results[0]))
 
+    def test_max_threads_accepted_and_matches_default(self) -> None:
+        """Passing an explicit max_threads must be accepted and give the same results as the default."""
+        boards = [{"remain_cards": _PBN, "trump": 4, "first": 0}] * 3
+        default = solve_all_boards_pbn(boards)
+        for max_threads in (1, 2):
+            capped = solve_all_boards_pbn(boards, max_threads=max_threads)
+            self.assertEqual(len(capped), len(default))
+            for capped_r, default_r in zip(capped, default):
+                # Only the first `cards` entries of a result are meaningful.
+                self.assertEqual(capped_r["cards"], default_r["cards"])
+                self.assertEqual(capped_r["score"][0], default_r["score"][0])
+
 
 class TestSolveAllBoardsBin(unittest.TestCase):
     """Tests for solve_all_boards_bin (binary format batch input)."""
@@ -175,6 +187,18 @@ class TestSolveAllBoardsBin(unittest.TestCase):
             board = {**_BINARY_DEAL, "trump": trump}
             results = solve_all_boards_bin([board])
             self.assertEqual(len(results), 1)
+
+    def test_max_threads_accepted_and_matches_default(self) -> None:
+        """Passing an explicit max_threads must be accepted and give the same results as the default."""
+        boards = [_BINARY_DEAL] * 3
+        default = solve_all_boards_bin(boards)
+        for max_threads in (1, 2):
+            capped = solve_all_boards_bin(boards, max_threads=max_threads)
+            self.assertEqual(len(capped), len(default))
+            for capped_r, default_r in zip(capped, default):
+                # Only the first `cards` entries of a result are meaningful.
+                self.assertEqual(capped_r["cards"], default_r["cards"])
+                self.assertEqual(capped_r["score"][0], default_r["score"][0])
 
 
 class TestSolveAllBoardsParity(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Add an optional `max_threads` argument (default `0` = auto) to the `solve_all_boards_pbn`, `solve_all_boards_bin`, and `calc_all_tables_pbn` Python bindings, giving callers control over the worker-thread cap for batch operations.
- Route these bindings through the threaded C wrappers `SolveAllBoardsN`, `SolveAllBoardsBinN`, and `CalcAllTablesPBNN`, which delegate to the internal `solve_all_boards_pbn_n` / `solve_all_boards_n` / `calc_all_boards_n` helpers.
- `max_threads <= 0` preserves the existing `hardware_concurrency()` default, so the change is fully backward compatible.
- Play analysis has no parallel variant, so no binding was added there; the calc-tables family had the same gap as solve and is included here.

## Test plan
- [x] `bazel build //python:_dds3` compiles cleanly
- [x] `bazel test //python:solve_all_boards_test //python:calc_tables_test` pass (default behavior unchanged)
- [x] Verified `max_threads=1/2/4` is accepted and returns results identical to the default for both solve and calc-table paths
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #206 