### PR TITLE
Enable DDS_AB_STATS via --define=ab_stats=true.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -56,6 +56,12 @@ config_setting(
     define_values = {"scheduler": "true"},
 )
 
+# Enable DDS_AB_STATS via --define=ab_stats=true
+config_setting(
+    name = "ab_stats",
+    define_values = {"ab_stats": "true"},
+)
+
 # Enable DDS_TT_CONTEXT_OWNERSHIP via --define=tt_context_ownership=true
 config_setting(
     name = "tt_context_ownership",

--- a/CPPVARIABLES.bzl
+++ b/CPPVARIABLES.bzl
@@ -84,6 +84,9 @@ DDS_LOCAL_DEFINES = select({
 }) + select({
     "//:tt_reset_debug": ["DDS_DEBUG_TT_RESET"],
     "//conditions:default": [],
+}) + select({
+    "//:ab_stats": ["DDS_AB_STATS"],
+    "//conditions:default": [],
 })
 
 DDS_LINKOPTS = select({

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -260,7 +260,7 @@
     },
     "@@emsdk+//:emscripten_deps.bzl%emscripten_deps": {
       "general": {
-        "bzlTransitiveDigest": "reX42Ca3PEP5mFXph0pqMqqqwHJbvykl5X4FHfXD6qg=",
+        "bzlTransitiveDigest": "Dt5IF0PG0xjU5iMLeU6FQ1/xWvBqUgUognNk3r5pJXY=",
         "usagesDigest": "lqS0hMGr6MqmX63BGZOskMFcqzqO53K0UlYFxuE3QSU=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",

--- a/library/src/utility/debug.h
+++ b/library/src/utility/debug.h
@@ -53,6 +53,7 @@
 
 /// @brief Enable AB search statistics (node counts, timing, etc.).
 /// Records alpha-beta search performance metrics for optimization analysis.
+/// Enable via Bazel: --define=ab_stats=true
 // #define DDS_AB_STATS
 #define DDS_AB_STATS_PREFIX "ABstats"
 


### PR DESCRIPTION
Wire a Bazel config_setting into DDS_LOCAL_DEFINES so AB stats can be turned on without --cxxopt=-DDDS_AB_STATS; refresh MODULE.bazel.lock.

Addresses Issue https://github.com/dds-bridge/dds/issues/198