### PR TITLE
Remove commented SORT_SOLVE_STRENGTH table from scheduler.

### DIFF
--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -482,13 +482,6 @@ static int SORT_SOLVE_TIMES[2][8] =
   { 388000, 140000, 60000, 40000, 30000, 23000, 18000, 6000 },
 };
 
-// #define SORT_SOLVE_STRENGTH_CUTOFF 0
-//
-// static double SORT_SOLVE_STRENGTH[2][3] =
-// {
-//   { 1.525, 1.810, 0.0285 },
-//   { 1.585, 1.940, 0.0354 }
-// };
 
 // Lower end of linear, upper end of linear, slope of linear,
 // exponential start, coefficient.


### PR DESCRIPTION
The strength-based sort weights were never enabled; SortSolve uses SORT_SOLVE_TIMES and SORT_SOLVE_FANOUT instead.

We could also clean up `par.cpp`. Per Cursor:

DEALER_PAR_ENGINE_ONLY is never defined anywhere in the build, so the #else branch is dead (~150 lines). It also uses old types (parResultsMaster).

Safe cleanup: delete lines 693–841 and the #ifndef / #else / #endif wrapper; keep the single SidesParBin implementation.