### PR TITLE
Fix trump-void1 move ordering to restore v2.9 search efficiency

### DIFF
--- a/library/src/heuristic_sorting/heuristic_sorting.cpp
+++ b/library/src/heuristic_sorting/heuristic_sorting.cpp
@@ -681,7 +681,7 @@ void weight_alloc_trump_void1(HeuristicContext& ctx)
     if (tpos.rank_in_suit[rho_lh][lead_suit] >
         (tpos.rank_in_suit[partner_lh][lead_suit] |
          bit_map_rank[ctx.lead0_rank]))
-      // Partner can win.
+      // RHO can win.
       suitAdd = (suitCount << 6) / 44;
     else
     {

--- a/library/src/heuristic_sorting/heuristic_sorting.cpp
+++ b/library/src/heuristic_sorting/heuristic_sorting.cpp
@@ -676,49 +676,17 @@ void weight_alloc_trump_void1(HeuristicContext& ctx)
   unsigned short suitCount = tpos.length[curr_hand][suit];
   int suitAdd;
 
-  if (suit == trump)
+  if (lead_suit == trump) // We pitch
   {
-    // We trump a non-trump card.
-    
-    if (tpos.length[partner_lh][lead_suit] != 0)
-    {
-      // 3rd hand will follow.
-  if ((tpos.rank_in_suit[rho_lh][lead_suit] >
-       (tpos.rank_in_suit[partner_lh][lead_suit] |
-    bit_map_rank[ctx.lead0_rank])) ||
-          ((tpos.length[rho_lh][lead_suit] == 0) &&
-           (tpos.length[rho_lh][trump] != 0)))
-      {
-        // Partner can win with a card or by ruffing.
-        suitAdd = 60 + (suitCount << 6) / 44;
-      }
-      else
-      {
-        suitAdd = -2 + (suitCount << 6) / 36;
-        // Don't ruff from Kx.
-        if ((suitCount == 2) &&
-            (tpos.second_best[suit].hand == curr_hand))
-          suitAdd += -4;
-      }
-    }
-    else if ((tpos.length[rho_lh][lead_suit] == 0) &&
-             (tpos.rank_in_suit[rho_lh][trump] >
-              tpos.rank_in_suit[partner_lh][trump]))
-    {
-      // Partner can overruff 3rd hand.
-      suitAdd = 60 + (suitCount << 6) / 44;
-    }
-  else if ((tpos.length[partner_lh][trump] == 0) &&
-       (tpos.rank_in_suit[rho_lh][lead_suit] >
-        bit_map_rank[ctx.lead0_rank]))
-    {
-      // 3rd hand has no trumps, and partner has suit winner.
-      suitAdd = 60 + (suitCount << 6) / 44;
-    }
+    if (tpos.rank_in_suit[rho_lh][lead_suit] >
+        (tpos.rank_in_suit[partner_lh][lead_suit] |
+         bit_map_rank[ctx.lead0_rank]))
+      // Partner can win.
+      suitAdd = (suitCount << 6) / 44;
     else
     {
-      suitAdd = -2 + (suitCount << 6) / 36;
-      // Don't ruff from Kx.
+      // Don't pitch from Kx.
+      suitAdd = (suitCount << 6) / 36;
       if ((suitCount == 2) &&
           (tpos.second_best[suit].hand == curr_hand))
         suitAdd += -4;


### PR DESCRIPTION
Opus 4.8's fix for 3.0's performance regression v 2.9.

The heuristic extraction refactor changed weight_alloc_trump_void1's first branch from `lead_suit == trump` to `suit == trump`. Since that is exhaustive with the following `else if (suit != trump)`, the three ruffing branches (using the `24 - rank + ...` formula) became dead code, and trump ruffs were scored with side-suit discard weights instead. This mis-ordered ruffs, costing alpha-beta cutoffs.

The effect is small for solve but compounds heavily in calc's warm-TT iterative deepening: calc explored ~34% more nodes than v2.9. Restoring the original `lead_suit == trump` pitch branch makes the ruffing
branches reachable again and cuts calc time ~25% (gap to v2.9: 1.37x ->
1.02x). Ordering-only change; double-dummy results are unchanged.

Benchmarks. Compare is the PR code, branch is the develop head.

```
solver file           compare_avg   branch_avg cmp/branch note
------ ------------- ------------ ------------ ---------- ---------------
solve  list100.txt           2.14         2.24      0.96x compare faster
solve  list10.txt            4.60         4.50      1.02x branch faster
solve  list1.txt            12.00        15.00      0.80x compare faster
calc   list100.txt           9.91        12.34      0.80x compare faster
calc   list10.txt           16.80        23.70      0.71x compare faster
calc   list1.txt            45.00        45.00      1.00x equal
```