### PR TITLE
solution: add missing parallel_boards.cpp/.hpp to VS projects

### DIFF
--- a/solution/DDS.vcxproj
+++ b/solution/DDS.vcxproj
@@ -91,6 +91,7 @@
     <ClCompile Include="..\library\src\solver_if.cpp" />
     <ClCompile Include="..\library\src\solve_board.cpp" />
     <ClCompile Include="..\library\src\system\memory.cpp" />
+    <ClCompile Include="..\library\src\system\parallel_boards.cpp" />
     <ClCompile Include="..\library\src\system\scheduler.cpp" />
     <ClCompile Include="..\library\src\system\system.cpp" />
     <ClCompile Include="..\library\src\system\thread_data.cpp" />
@@ -132,6 +133,7 @@
     <ClInclude Include="..\library\src\solver_if.hpp" />
     <ClInclude Include="..\library\src\solve_board.hpp" />
     <ClInclude Include="..\library\src\system\memory.hpp" />
+    <ClInclude Include="..\library\src\system\parallel_boards.hpp" />
     <ClInclude Include="..\library\src\system\scheduler.hpp" />
     <ClInclude Include="..\library\src\system\system.hpp" />
     <ClInclude Include="..\library\src\system\thread_data.hpp" />

--- a/solution/DDS.vcxproj.filters
+++ b/solution/DDS.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="..\library\src\system\memory.cpp">
       <Filter>library\src\system</Filter>
     </ClCompile>
+    <ClCompile Include="..\library\src\system\parallel_boards.cpp">
+      <Filter>library\src\system</Filter>
+    </ClCompile>
 
     <ClCompile Include="..\library\src\system\scheduler.cpp">
       <Filter>library\src\system</Filter>
@@ -290,6 +293,9 @@
     </ClInclude>
 
     <ClInclude Include="..\library\src\system\memory.hpp">
+      <Filter>library\src\system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\library\src\system\parallel_boards.hpp">
       <Filter>library\src\system</Filter>
     </ClInclude>
 

--- a/solution/dds_native.vcxproj
+++ b/solution/dds_native.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="..\library\src\solver_if.cpp" />
     <ClCompile Include="..\library\src\solve_board.cpp" />
     <ClCompile Include="..\library\src\system\memory.cpp" />
+    <ClCompile Include="..\library\src\system\parallel_boards.cpp" />
     <ClCompile Include="..\library\src\system\scheduler.cpp" />
     <ClCompile Include="..\library\src\system\system.cpp" />
     <ClCompile Include="..\library\src\system\thread_data.cpp" />
@@ -128,6 +129,7 @@
     <ClInclude Include="..\library\src\solver_if.hpp" />
     <ClInclude Include="..\library\src\solve_board.hpp" />
     <ClInclude Include="..\library\src\system\memory.hpp" />
+    <ClInclude Include="..\library\src\system\parallel_boards.hpp" />
     <ClInclude Include="..\library\src\system\scheduler.hpp" />
     <ClInclude Include="..\library\src\system\system.hpp" />
     <ClInclude Include="..\library\src\system\thread_data.hpp" />

--- a/solution/dds_native.vcxproj.filters
+++ b/solution/dds_native.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="..\library\src\system\memory.cpp">
       <Filter>library\src\system</Filter>
     </ClCompile>
+    <ClCompile Include="..\library\src\system\parallel_boards.cpp">
+      <Filter>library\src\system</Filter>
+    </ClCompile>
     <ClCompile Include="..\library\src\system\scheduler.cpp">
       <Filter>library\src\system</Filter>
     </ClCompile>
@@ -228,6 +231,9 @@
       <Filter>library\src</Filter>
     </ClInclude>
     <ClInclude Include="..\library\src\system\memory.hpp">
+      <Filter>library\src\system</Filter>
+    </ClInclude>
+    <ClInclude Include="..\library\src\system\parallel_boards.hpp">
       <Filter>library\src\system</Filter>
     </ClInclude>
     <ClInclude Include="..\library\src\system\scheduler.hpp">


### PR DESCRIPTION
## Summary

As noted in #139, `dds_native.dll` fails to link out of the box on Windows: `calc_tables.cpp` and `solve_board.cpp` reference `resolve_worker_count` / `parallel_all_boards_n` from `library/src/system/parallel_boards.cpp`, but neither `solution/dds_native.vcxproj` nor `solution/DDS.vcxproj` compiles that file, producing unresolved externals (for the static library, the errors surface when linking consuming executables such as the example projects).

This PR adds `parallel_boards.cpp` to the `<ClCompile>` lists of both projects, and `parallel_boards.hpp` to the `<ClInclude>` lists and the `.filters` files, matching how the other `library/src/system/` sources are registered.

Note: the same fix is needed on the PR #216 branch, whose `dds_native.vcxproj` has the same omission.

## Testing

On Windows 11 with MSVC v143 (VS 2022), from a clean checkout of develop (5cb0fb1) plus this change:

- `msbuild solution\dds_native.vcxproj /p:Configuration=Release /p:Platform=x64` links successfully (previously failed with LNK2019 unresolved externals).
- `msbuild solution\DDS.vcxproj`, then `hands.vcxproj` and `calc_all_tables.vcxproj`, all build and link successfully.
- The resulting `dds_native.dll` was used in the three-way benchmark/correctness comparison reported in #139 (agrees with DDS 2.9 and ddss on all 20,000 table cells over 1000 deals).