### PR TITLE
Fix dotnet doc error check and remove debugging notes

### DIFF
--- a/docs/dotnet_interface.md
+++ b/docs/dotnet_interface.md
@@ -367,10 +367,6 @@ public void sample()
         throw new InvalidOperationException(error);               
     }
 
-    if (!(int)ctx.SolveBoard(deal, -1, 1, 0, out FutureTricks fut))
-        throw new InvalidOperationException("DDS_Core failed to solve the board.");
-
-
     ...
 
     var ddTableDeal = new() {Cards = hands };

--- a/dotnet/DDS_Core/DDS.cs
+++ b/dotnet/DDS_Core/DDS.cs
@@ -189,7 +189,6 @@ public class DDS
         {
             solved = default;
 
-            //Note: To step into c++ code you must set a break in c++?
             var rc = DdsNative.SolveAllBoardsBin( bop
                                                 , out solved);
 

--- a/dotnet/DDS_Core/DDS.cs
+++ b/dotnet/DDS_Core/DDS.cs
@@ -169,7 +169,6 @@ public class DDS
                                  , out SolvedBoards solved)
         {
             solved = default;
-            //Note: To step into c++ code you must set a break in c++?
             var rc = DdsNative.SolveAllBoards( boards
                                              , out solved);
 


### PR DESCRIPTION
## Summary
- Remove a duplicate `SolveBoard` error-check example in `docs/dotnet_interface.md` that cast the return code to `bool` (inverted success/failure; `NoFault` is 0).
- Remove stray debugger comments from the `SolveAllBoards` wrappers in `dotnet/DDS_Core/DDS.cs`.

## Test plan
- [ ] Review doc example: only the `rc != (int)SolveBoardResult.NoFault` check remains
- [ ] Confirm `DDS.cs` has no leftover debugging notes in `SolveAllBoards` methods


Made with [Cursor](https://cursor.com)