### PR TITLE
dtest: add optional --max/--min per-hand timing summary

### DIFF
--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -9,6 +9,8 @@ filegroup(
         exclude = [
             "context_equivalence.cpp",
             "calc_par_test.cpp",  # Uses GoogleTest, compiled separately
+            "test_timer_test.cpp",  # Uses GoogleTest, compiled separately
+            "args_test.cpp",  # Uses GoogleTest, compiled separately
         ],
     ),
 )
@@ -52,6 +54,39 @@ cc_test(
     local_defines = DDS_LOCAL_DEFINES,
     deps = [
         "//library/src:dds",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "test_timer_test",
+    srcs = [
+        "test_timer_test.cpp",
+        "TestTimer.cpp",
+        "TestTimer.hpp",
+    ],
+    size = "small",
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    deps = [
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "args_test",
+    srcs = [
+        "args_test.cpp",
+        "args.cpp",
+        "args.hpp",
+        "cst.hpp",
+    ],
+    size = "small",
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    deps = [
         "@googletest//:gtest_main",
     ],
 )

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -9,6 +9,7 @@
 
 
 #include <algorithm>
+#include <ctime>
 #include <iostream>
 #include <iomanip>
 

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -199,6 +199,31 @@ void TestTimer::print_hands(
   const bool show_min,
   const bool show_max) const
 {
+  struct StreamFormatGuard
+  {
+    explicit StreamFormatGuard(ostream& os)
+      : os_(os),
+        flags_(os.flags()),
+        precision_(os.precision()),
+        fill_(os.fill())
+    {
+    }
+
+    ~StreamFormatGuard()
+    {
+      os_.flags(flags_);
+      os_.precision(precision_);
+      os_.fill(fill_);
+    }
+
+    ostream& os_;
+    const std::ios_base::fmtflags flags_;
+    const std::streamsize precision_;
+    const char fill_;
+  };
+
+  const StreamFormatGuard format_guard(out);
+
   if (name_ != "")
     out << setw(21) << left << "Timer name" << 
       setw(12) << right << name_ << "\n";

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -8,6 +8,7 @@
 */
 
 
+#include <algorithm>
 #include <iostream>
 #include <iomanip>
 
@@ -22,6 +23,7 @@ using std::setprecision;
 using std::right;
 using std::fixed;
 using std::left;
+using std::ostream;
 
 
 TestTimer::TestTimer()
@@ -42,6 +44,12 @@ void TestTimer::reset()
   user_cum_ = 0;
   user_cum_old_ = 0;
   sys_cum_ = 0;
+  user_min_ = 0;
+  user_max_ = 0;
+  sys_min_ = 0;
+  sys_max_ = 0;
+  batch_count_ = 0;
+  pending_hands_ = 0;
 }
 
 
@@ -53,7 +61,7 @@ void TestTimer::set_name(const string& s)
 
 void TestTimer::start(const int number)
 {
-  count_ += number;
+  pending_hands_ = number;
   user0_ = Clock::now();
   sys0_ = clock();
 }
@@ -65,11 +73,69 @@ void TestTimer::end()
   clock_t sys1 = clock();
 
   duration<double, std::milli> d = user1 - user0_;
-  int tuser = static_cast<int>(d.count());
-
-  user_cum_ += tuser;
-  sys_cum_ += static_cast<int>((1000 * (sys1 - sys0_)) /
+  const long tuser = static_cast<long>(d.count());
+  const long tsys = static_cast<long>((1000 * (sys1 - sys0_)) /
     static_cast<double>(CLOCKS_PER_SEC));
+
+  TestTimer::record(pending_hands_, tuser, tsys);
+  pending_hands_ = 0;
+}
+
+
+void TestTimer::record(const int hands, const long user_ms, const long sys_ms)
+{
+  count_ += hands;
+  user_cum_ += user_ms;
+  sys_cum_ += sys_ms;
+
+  if (hands > 0)
+  {
+    const double user_per_hand = user_ms / static_cast<double>(hands);
+    const double sys_per_hand = sys_ms / static_cast<double>(hands);
+    if (batch_count_ == 0)
+    {
+      user_min_ = user_max_ = user_per_hand;
+      sys_min_ = sys_max_ = sys_per_hand;
+    }
+    else
+    {
+      user_min_ = std::min(user_min_, user_per_hand);
+      user_max_ = std::max(user_max_, user_per_hand);
+      sys_min_ = std::min(sys_min_, sys_per_hand);
+      sys_max_ = std::max(sys_max_, sys_per_hand);
+    }
+    batch_count_++;
+  }
+}
+
+
+bool TestTimer::has_batch_times() const
+{
+  return batch_count_ > 0;
+}
+
+
+double TestTimer::user_min_ms() const
+{
+  return user_min_;
+}
+
+
+double TestTimer::user_max_ms() const
+{
+  return user_max_;
+}
+
+
+double TestTimer::sys_min_ms() const
+{
+  return sys_min_;
+}
+
+
+double TestTimer::sys_max_ms() const
+{
+  return sys_max_;
 }
 
 
@@ -128,47 +194,61 @@ void TestTimer::print_basic() const
 }
 
 
-void TestTimer::print_hands() const
+void TestTimer::print_hands(
+  ostream& out,
+  const bool show_min,
+  const bool show_max) const
 {
   if (name_ != "")
-    cout << setw(21) << left << "Timer name" << 
+    out << setw(21) << left << "Timer name" << 
       setw(12) << right << name_ << "\n";
 
-  cout << setw(21) << left << "Number of hands" << 
+  out << setw(21) << left << "Number of hands" << 
     setw(12) << right << count_ << "\n";
 
   if (count_ == 0)
     return;
   
   if (user_cum_ == 0)
-    cout << setw(21) << left << "User time (ms)" <<
+    out << setw(21) << left << "User time (ms)" <<
       setw(12) << right << "zero" << "\n";
   else
   {
-    cout << setw(21) << left << "User time (ms)" <<
+    out << setw(21) << left << "User time (ms)" <<
       setw(12) << right << fixed << 
         setprecision(0) << user_cum_ << "\n";
-    cout << setw(21) << left << "Avg user time (ms)" <<
+    out << setw(21) << left << "Avg user time (ms)" <<
       setw(12) << right << fixed << setprecision(2) << user_cum_ / 
         static_cast<float>(count_) << "\n";
+    if (show_min && has_batch_times())
+      out << setw(21) << left << "Min user time (ms)" <<
+        setw(12) << right << fixed << setprecision(2) << user_min_ << "\n";
+    if (show_max && has_batch_times())
+      out << setw(21) << left << "Max user time (ms)" <<
+        setw(12) << right << fixed << setprecision(2) << user_max_ << "\n";
   }
 
   if (sys_cum_ == 0)
-    cout << setw(21) << left << "Sys time (ms)" << 
+    out << setw(21) << left << "Sys time (ms)" << 
       setw(12) << right << "zero" << "\n";
   else
   {
-    cout << setw(21) << left << "Sys time (ms)" <<
+    out << setw(21) << left << "Sys time (ms)" <<
       setw(12) << right << fixed << setprecision(0) << sys_cum_ << "\n";
-    cout << setw(21) << left << "Avg sys time (ms)" <<
+    out << setw(21) << left << "Avg sys time (ms)" <<
       setw(12) << right << fixed << setprecision(2) << sys_cum_ / 
         static_cast<float>(count_) << "\n";
+    if (show_min && has_batch_times())
+      out << setw(21) << left << "Min sys time (ms)" <<
+        setw(12) << right << fixed << setprecision(2) << sys_min_ << "\n";
+    if (show_max && has_batch_times())
+      out << setw(21) << left << "Max sys time (ms)" <<
+        setw(12) << right << fixed << setprecision(2) << sys_max_ << "\n";
     if (user_cum_ > 0) {
-      cout << setw(21) << left << "Ratio" << 
+      out << setw(21) << left << "Ratio" << 
         setw(12) << right << fixed << setprecision(2) << 
         sys_cum_ / static_cast<float>(user_cum_);
     }
   }
-  cout << endl;
+  out << endl;
 }
-

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -84,28 +84,28 @@ void TestTimer::end()
 
 void TestTimer::record(const int hands, const long user_ms, const long sys_ms)
 {
+  if (hands <= 0)
+    return;
+
   count_ += hands;
   user_cum_ += user_ms;
   sys_cum_ += sys_ms;
 
-  if (hands > 0)
+  const double user_per_hand = user_ms / static_cast<double>(hands);
+  const double sys_per_hand = sys_ms / static_cast<double>(hands);
+  if (batch_count_ == 0)
   {
-    const double user_per_hand = user_ms / static_cast<double>(hands);
-    const double sys_per_hand = sys_ms / static_cast<double>(hands);
-    if (batch_count_ == 0)
-    {
-      user_min_ = user_max_ = user_per_hand;
-      sys_min_ = sys_max_ = sys_per_hand;
-    }
-    else
-    {
-      user_min_ = std::min(user_min_, user_per_hand);
-      user_max_ = std::max(user_max_, user_per_hand);
-      sys_min_ = std::min(sys_min_, sys_per_hand);
-      sys_max_ = std::max(sys_max_, sys_per_hand);
-    }
-    batch_count_++;
+    user_min_ = user_max_ = user_per_hand;
+    sys_min_ = sys_max_ = sys_per_hand;
   }
+  else
+  {
+    user_min_ = std::min(user_min_, user_per_hand);
+    user_max_ = std::max(user_max_, user_per_hand);
+    sys_min_ = std::min(sys_min_, sys_per_hand);
+    sys_max_ = std::max(sys_max_, sys_per_hand);
+  }
+  batch_count_++;
 }
 
 

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <string>
 #include <chrono>
+#include <ctime>
 #include <iostream>
 
 using Clock = std::chrono::steady_clock;

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -66,6 +66,7 @@ class TestTimer
     /// Record one completed batch without wall-clock measurement.
     /// Updates cumulative totals and per-hand min/max extremes.
     /// Used by end() and by unit tests for deterministic extremes.
+    /// Non-positive hands is ignored (no cumulative or extreme updates).
     /// @param hands Number of hands in the batch
     /// @param user_ms Batch user (wall) time in milliseconds
     /// @param sys_ms Batch system (CPU) time in milliseconds

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -9,8 +9,10 @@
 
 #pragma once
 
+#include <ostream>
 #include <string>
 #include <chrono>
+#include <iostream>
 
 using Clock = std::chrono::steady_clock;
 using std::chrono::time_point;
@@ -32,6 +34,12 @@ class TestTimer
     long user_cum_;         ///< Cumulative user time (milliseconds)
     long user_cum_old_;     ///< Previous cumulative user time (milliseconds)
     long sys_cum_;          ///< Cumulative system time (milliseconds)
+    double user_min_;       ///< Min per-hand user time across batches (ms)
+    double user_max_;       ///< Max per-hand user time across batches (ms)
+    double sys_min_;        ///< Min per-hand system time across batches (ms)
+    double sys_max_;        ///< Max per-hand system time across batches (ms)
+    long batch_count_;      ///< Number of completed batches
+    int pending_hands_;     ///< Hands counted into the open start()/end() batch
 
     time_point<Clock> user0_;  ///< Wall-clock start time
     clock_t sys0_;             ///< CPU start time
@@ -55,6 +63,29 @@ class TestTimer
     /// Stop timing and accumulate results.
     void end();
 
+    /// Record one completed batch without wall-clock measurement.
+    /// Updates cumulative totals and per-hand min/max extremes.
+    /// Used by end() and by unit tests for deterministic extremes.
+    /// @param hands Number of hands in the batch
+    /// @param user_ms Batch user (wall) time in milliseconds
+    /// @param sys_ms Batch system (CPU) time in milliseconds
+    void record(const int hands, const long user_ms, const long sys_ms);
+
+    /// Whether at least one batch has been recorded.
+    bool has_batch_times() const;
+
+    /// Minimum per-hand user time across batches (milliseconds).
+    double user_min_ms() const;
+
+    /// Maximum per-hand user time across batches (milliseconds).
+    double user_max_ms() const;
+
+    /// Minimum per-hand system time across batches (milliseconds).
+    double sys_min_ms() const;
+
+    /// Maximum per-hand system time across batches (milliseconds).
+    double sys_max_ms() const;
+
     /// Print timer status while running.
     /// @param reached Number of iterations completed so far
     /// @param number Total number of iterations
@@ -66,5 +97,11 @@ class TestTimer
     void print_basic() const;
     
     /// Print detailed per-hand timer results.
-    void print_hands() const;
+    /// @param out Output stream
+    /// @param show_min Include min per-hand times across batches
+    /// @param show_max Include max per-hand times across batches
+    void print_hands(
+        std::ostream& out = std::cout,
+        bool show_min = false,
+        bool show_max = false) const;
 };

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -41,7 +41,18 @@ struct optEntry
   unsigned numArgs;
 };
 
-#define DTEST_NUM_OPTIONS 5
+#define DTEST_NUM_OPTIONS 7
+
+enum DtestOpt
+{
+  OPT_FILE = 0,
+  OPT_SOLVER = 1,
+  OPT_NUMTHR = 2,
+  OPT_MEMORY = 3,
+  OPT_REPORT = 4,
+  OPT_MAX = 5,
+  OPT_MIN = 6
+};
 
 const optEntry optList[DTEST_NUM_OPTIONS] =
 {
@@ -49,7 +60,9 @@ const optEntry optList[DTEST_NUM_OPTIONS] =
   {"s", "solver", 1},
   {"n", "numthr", 1},
   {"m", "memory", 1},
-  {"r", "report", 0}
+  {"r", "report", 0},
+  {"", "max", 0},
+  {"", "min", 0}
 };
 
 const vector<string> solverList =
@@ -100,6 +113,10 @@ void usage(
     "\n" <<
     "-r, --report       Print per-board timings sorted by longest first.\n" <<
     "\n" <<
+    "    --max          Also print max per-hand user/sys time across batches.\n" <<
+    "\n" <<
+    "    --min          Also print min per-hand user/sys time across batches.\n" <<
+    "\n" <<
     endl;
 }
 
@@ -133,7 +150,9 @@ int GetNextArgToken(
 
   for (unsigned i = 0; i < DTEST_NUM_OPTIONS; i++)
   {
-    if (str == optList[i].shortName || str == optList[i].longName)
+    const bool short_ok =
+      !optList[i].shortName.empty() && str == optList[i].shortName;
+    if (short_ok || str == optList[i].longName)
     {
       if (optList[i].numArgs == 1)
       {
@@ -146,7 +165,9 @@ int GetNextArgToken(
       else
         nextToken++;
 
-      return str[0];
+      // Return 1-based option index so --max/--min do not collide with
+      // --memory on the shared leading 'm'.
+      return static_cast<int>(i) + 1;
     }
   }
 
@@ -161,6 +182,8 @@ void SetDefaults()
   options.num_threads_ = 0;
   options.memory_mb_ = 0;
   options.report_slow_boards_ = false;
+  options.show_min_ = false;
+  options.show_max_ = false;
 }
 
 
@@ -183,6 +206,10 @@ void read_args(
   int argc,
   char * argv[])
 {
+  nextToken = 1;
+  shortOptsAll.clear();
+  shortOptsWithArg.clear();
+
   for (unsigned i = 0; i < DTEST_NUM_OPTIONS; i++)
   {
     shortOptsAll += optList[i].shortName;
@@ -206,9 +233,9 @@ void read_args(
 
   while ((c = GetNextArgToken(argc, argv)) > 0)
   {
-    switch(c)
+    switch(c - 1)
     {
-      case 'f':
+      case OPT_FILE:
         if (stat(optarg, &buffer) == 0)
         {
           options.fname_ = string(optarg);
@@ -228,7 +255,7 @@ void read_args(
         errFlag = true;
         break;
 
-      case 's':
+      case OPT_SOLVER:
         matchFlag = false;
         stmp = optarg;
         transform(stmp.begin(), stmp.end(), stmp.begin(),
@@ -256,7 +283,7 @@ void read_args(
         }
         break;
 
-      case 'n':
+      case OPT_NUMTHR:
         m = static_cast<int>(strtol(optarg, &ctmp, 0));
         if (m < 0)
         {
@@ -267,7 +294,7 @@ void read_args(
         options.num_threads_ = m;
         break;
 
-      case 'm':
+      case OPT_MEMORY:
         m = static_cast<int>(strtol(optarg, &ctmp, 0));
         if (m < 0)
         {
@@ -278,8 +305,16 @@ void read_args(
         options.memory_mb_ = m;
         break;
 
-      case 'r':
+      case OPT_REPORT:
         options.report_slow_boards_ = true;
+        break;
+
+      case OPT_MAX:
+        options.show_max_ = true;
+        break;
+
+      case OPT_MIN:
+        options.show_min_ = true;
         break;
 
       default:

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -19,6 +19,7 @@
 /// - Number of threads
 /// - Memory allocation
 /// - Slow board reporting
+/// - Optional min/max per-hand timing summary across batches
 
 /// Print usage information.
 /// @param base Command name for usage message

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -16,7 +16,8 @@ namespace
 
 std::string make_temp_input_file()
 {
-  const std::string path = "args_test_input.txt";
+  const std::string path =
+    std::string(::testing::TempDir()) + "args_test_input.txt";
   std::ofstream out(path);
   out << "placeholder\n";
   return path;

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -1,0 +1,74 @@
+/// @file args_test.cpp
+/// @brief Unit tests for dtest --max / --min option parsing.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+#include "args.hpp"
+#include "cst.hpp"
+
+OptionsType options;
+
+namespace
+{
+
+std::string make_temp_input_file()
+{
+  const std::string path = "args_test_input.txt";
+  std::ofstream out(path);
+  out << "placeholder\n";
+  return path;
+}
+
+}  // namespace
+
+TEST(Args, MaxAndMinFlagsDefaultOff)
+{
+  const std::string path = make_temp_input_file();
+  char arg0[] = "dtest";
+  char arg_f[] = "-f";
+  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str())};
+  read_args(3, argv);
+  EXPECT_FALSE(options.show_min_);
+  EXPECT_FALSE(options.show_max_);
+}
+
+TEST(Args, MaxFlagEnablesShowMax)
+{
+  const std::string path = make_temp_input_file();
+  char arg0[] = "dtest";
+  char arg_f[] = "-f";
+  char arg_max[] = "--max";
+  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_max};
+  read_args(4, argv);
+  EXPECT_TRUE(options.show_max_);
+  EXPECT_FALSE(options.show_min_);
+}
+
+TEST(Args, MinFlagEnablesShowMin)
+{
+  const std::string path = make_temp_input_file();
+  char arg0[] = "dtest";
+  char arg_f[] = "-f";
+  char arg_min[] = "--min";
+  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_min};
+  read_args(4, argv);
+  EXPECT_TRUE(options.show_min_);
+  EXPECT_FALSE(options.show_max_);
+}
+
+TEST(Args, MaxAndMinFlagsCanCombine)
+{
+  const std::string path = make_temp_input_file();
+  char arg0[] = "dtest";
+  char arg_f[] = "-f";
+  char arg_max[] = "--max";
+  char arg_min[] = "--min";
+  char* argv[] = {
+    arg0, arg_f, const_cast<char*>(path.c_str()), arg_max, arg_min};
+  read_args(5, argv);
+  EXPECT_TRUE(options.show_min_);
+  EXPECT_TRUE(options.show_max_);
+}

--- a/library/tests/cst.hpp
+++ b/library/tests/cst.hpp
@@ -36,5 +36,7 @@ struct OptionsType
   int num_threads_;                         ///< Number of threads to use
   int memory_mb_;                           ///< Memory allocation in MB
   bool report_slow_boards_;                 ///< Report slow-executing hands
+  bool show_min_;                           ///< Report min per-hand time across batches
+  bool show_max_;                           ///< Report max per-hand time across batches
 };
 

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -64,6 +64,26 @@ TEST(TestTimer, UnevenBatchSizesUsePerHandNotBatchTotal)
   EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 2.0);
 }
 
+TEST(TestTimer, RecordIgnoresNonPositiveHands)
+{
+  TestTimer timer;
+  timer.record(10, 100, 50);
+  timer.record(0, 999, 999);
+  timer.record(-3, 999, 999);
+
+  EXPECT_TRUE(timer.has_batch_times());
+  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 10.0);
+  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 10.0);
+  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 5.0);
+  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 5.0);
+
+  const std::string out = capture_print_hands(timer, false, false);
+  EXPECT_NE(out.find("Number of hands"), std::string::npos);
+  EXPECT_NE(out.find("100"), std::string::npos);
+  EXPECT_NE(out.find("10.00"), std::string::npos);
+  EXPECT_EQ(out.find("999"), std::string::npos);
+}
+
 TEST(TestTimer, ResetClearsBatchExtremes)
 {
   TestTimer timer;

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -1,0 +1,120 @@
+/// @file test_timer_test.cpp
+/// @brief Unit tests for TestTimer batch min/max tracking and optional reporting.
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+#include "TestTimer.hpp"
+
+namespace
+{
+
+std::string capture_print_hands(
+  const TestTimer& timer,
+  const bool show_min,
+  const bool show_max)
+{
+  std::ostringstream out;
+  timer.print_hands(out, show_min, show_max);
+  return out.str();
+}
+
+}  // namespace
+
+TEST(TestTimer, RecordTracksMinAndMaxPerHandAcrossBatches)
+{
+  TestTimer timer;
+
+  // Batch totals: (100ms / 10 hands), (300 / 10), (200 / 10)
+  timer.record(10, 100, 50);
+  timer.record(10, 300, 80);
+  timer.record(10, 200, 40);
+
+  EXPECT_TRUE(timer.has_batch_times());
+  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 10.0);
+  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 30.0);
+  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 4.0);
+  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 8.0);
+}
+
+TEST(TestTimer, SingleBatchMinEqualsMaxEqualsPerHand)
+{
+  TestTimer timer;
+  timer.record(5, 42, 7);
+
+  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 8.4);
+  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 8.4);
+  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 1.4);
+  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 1.4);
+}
+
+TEST(TestTimer, UnevenBatchSizesUsePerHandNotBatchTotal)
+{
+  TestTimer timer;
+  // Slower per hand but smaller total: 50ms / 5 = 10.0
+  timer.record(5, 50, 10);
+  // Faster per hand but larger total: 90ms / 30 = 3.0
+  timer.record(30, 90, 30);
+
+  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 3.0);
+  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 10.0);
+  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 1.0);
+  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 2.0);
+}
+
+TEST(TestTimer, ResetClearsBatchExtremes)
+{
+  TestTimer timer;
+  timer.record(1, 10, 2);
+  timer.reset();
+
+  EXPECT_FALSE(timer.has_batch_times());
+}
+
+TEST(TestTimer, PrintHandsOmitsMinMaxByDefault)
+{
+  TestTimer timer;
+  timer.set_name("Hand stats");
+  timer.record(2, 20, 4);
+
+  const std::string out = capture_print_hands(timer, false, false);
+
+  EXPECT_NE(out.find("Avg user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Min sys time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Max sys time (ms)"), std::string::npos);
+}
+
+TEST(TestTimer, PrintHandsShowsMinWhenRequested)
+{
+  TestTimer timer;
+  timer.record(2, 20, 4);  // 10.0 user / hand, 2.0 sys / hand
+  timer.record(2, 10, 8);  // 5.0 user / hand, 4.0 sys / hand
+
+  const std::string out = capture_print_hands(timer, true, false);
+
+  EXPECT_NE(out.find("Min user time (ms)"), std::string::npos);
+  EXPECT_NE(out.find("Min sys time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Max sys time (ms)"), std::string::npos);
+  EXPECT_NE(out.find("5.00"), std::string::npos);
+  EXPECT_NE(out.find("2.00"), std::string::npos);
+}
+
+TEST(TestTimer, PrintHandsShowsMaxWhenRequested)
+{
+  TestTimer timer;
+  timer.record(2, 20, 4);  // 10.0 / 2.0
+  timer.record(2, 10, 8);  // 5.0 / 4.0
+
+  const std::string out = capture_print_hands(timer, false, true);
+
+  EXPECT_NE(out.find("Max user time (ms)"), std::string::npos);
+  EXPECT_NE(out.find("Max sys time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Min sys time (ms)"), std::string::npos);
+  EXPECT_NE(out.find("10.00"), std::string::npos);
+  EXPECT_NE(out.find("4.00"), std::string::npos);
+}

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -2,6 +2,7 @@
 /// @brief Unit tests for TestTimer batch min/max tracking and optional reporting.
 
 #include <gtest/gtest.h>
+#include <iomanip>
 #include <sstream>
 #include <string>
 
@@ -117,4 +118,20 @@ TEST(TestTimer, PrintHandsShowsMaxWhenRequested)
   EXPECT_EQ(out.find("Min sys time (ms)"), std::string::npos);
   EXPECT_NE(out.find("10.00"), std::string::npos);
   EXPECT_NE(out.find("4.00"), std::string::npos);
+}
+
+TEST(TestTimer, PrintHandsRestoresStreamFormatState)
+{
+  TestTimer timer;
+  timer.record(2, 20, 4);
+
+  std::ostringstream out;
+  out << std::scientific << std::setprecision(5);
+  const auto flags_before = out.flags();
+  const auto precision_before = out.precision();
+
+  timer.print_hands(out, true, true);
+
+  EXPECT_EQ(out.flags(), flags_before);
+  EXPECT_EQ(out.precision(), precision_before);
 }

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -145,7 +145,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     exit(0);
   }
 
-  timer.print_hands();
+  timer.print_hands(cout, options.show_min_, options.show_max_);
 
   if (options.report_slow_boards_)
   {


### PR DESCRIPTION
Report min/max ms-per-hand across batches alongside the existing average, so extremes are in the same units as Avg user/sys time.