### PR TITLE
Check createSolverContext for NULL in embedded FFM smoke test.

### DIFF
--- a/jni/java/org/dds/ffm/DdsEmbeddedSmokeTest.java
+++ b/jni/java/org/dds/ffm/DdsEmbeddedSmokeTest.java
@@ -50,6 +50,7 @@ public final class DdsEmbeddedSmokeTest {
             setRemain(deal, 3, 3, FULL_SUIT);
 
             MemorySegment ctx = dds.createSolverContext();
+            check(!ctx.equals(MemorySegment.NULL), "createSolverContext returned NULL");
             try {
                 MemorySegment fut = arena.allocate(Dds.FUTURE_TRICKS);
                 int rc = dds.solveBoard(ctx, deal, -1, 1, 1, fut);


### PR DESCRIPTION
Aligns DdsEmbeddedSmokeTest with DdsSmokeTest so a failed context allocation fails early with a clear assertion instead of a later RETURN_UNKNOWN_FAULT from solveBoard.