### PR TITLE
Mark JNI Bazel tests as size small.

### DIFF
--- a/jni/BUILD.bazel
+++ b/jni/BUILD.bazel
@@ -153,6 +153,7 @@ java_export(
 # access is enabled for the FFM downcalls. Off Windows (nm-free / dll path).
 java_test(
     name = "dds_ffm_smoke_test",
+    size = "small",
     srcs = ["java/org/dds/ffm/DdsSmokeTest.java"],
     main_class = "org.dds.ffm.DdsSmokeTest",
     use_testrunner = False,
@@ -173,6 +174,7 @@ java_test(
 # solves the known deal. Off Windows like the other jni tests.
 java_test(
     name = "dds_ffm_embedded_smoke_test",
+    size = "small",
     srcs = ["java/org/dds/ffm/DdsEmbeddedSmokeTest.java"],
     main_class = "org.dds.ffm.DdsEmbeddedSmokeTest",
     use_testrunner = False,

--- a/jni/tests/BUILD.bazel
+++ b/jni/tests/BUILD.bazel
@@ -7,6 +7,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # dumper, so the nm-based check is scoped to Unix hosts.
 py_test(
     name = "export_set_test",
+    size = "small",
     srcs = ["export_set_test.py"],
     args = [
         "$(location //jni:dds_shared)",
@@ -29,6 +30,7 @@ py_test(
 # symbol set out) — independent of the linked library.
 py_test(
     name = "gen_export_lists_test",
+    size = "small",
     srcs = ["gen_export_lists_test.py"],
     deps = ["//jni:gen_export_lists_lib"],
 )
@@ -39,6 +41,7 @@ py_test(
 # compatibility, so it is skipped on unsupported host os/cpu.
 py_test(
     name = "jar_self_contained_test",
+    size = "small",
     srcs = ["jar_self_contained_test.py"],
     args = ["$(location //jni:dds_ffm_dist)"],
     data = ["//jni:dds_ffm_dist"],


### PR DESCRIPTION
Keeps default timeouts aligned with the rest of the suite and avoids medium-test scheduling for these quick smoke/unit checks.