### PR TITLE
benchmark.sh: allow dirty tree when --branch stays on HEAD

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -86,6 +86,21 @@ config_setting(
 
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# benchmark.sh --branch dirty-tree gate (clean tree only when switching commits).
+# Needs bash + git; skipped on Windows like other host-tool shell checks.
+sh_test(
+    name = "benchmark_git_prep_test",
+    size = "small",
+    srcs = ["benchmark_git_prep_test.sh"],
+    data = ["benchmark.sh"],
+    deps = ["@rules_shell//shell/runfiles"],
+    target_compatible_with = select({
+        "//:build_windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
 
 genrule(
     name = "doxygen_docs",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,9 @@ bazel_dep(name = "platforms", version = "1.1.0")
 # Pin to the version the graph resolves (via rules_jvm_external) to avoid a
 # direct-dependency mismatch warning on every invocation.
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
+# sh_test for //:benchmark_git_prep_test (already pulled in transitively;
+# pin directly so the load path stays stable).
+bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "pybind11_bazel", version = "3.0.1")
 bazel_dep(name = "rules_python", version = "2.0.1")

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -339,7 +339,7 @@ git_prep_for_branches() {
   head_commit="$(git -C "$ROOT" rev-parse HEAD)"
   for i in "${!SPEC_VALS[@]}"; do
     if [[ "${SPEC_KINDS[$i]}" == "branch" ]]; then
-      ref_commit="$(git -C "$ROOT" rev-parse "${SPEC_VALS[$i]}^{commit}")"
+      ref_commit="$(git -C "$ROOT" rev-parse --verify --quiet "${SPEC_VALS[$i]}^{commit}")"
       if [[ "$ref_commit" != "$head_commit" ]]; then
         needs_switch=1
         break

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -325,8 +325,11 @@ git_prep_for_branches() {
     fi
   done
   for i in "${!SPEC_VALS[@]}"; do
+    # Require a commit-ish: plain rev-parse accepts trees/blobs, but later
+    # ^{commit} peels (and checkout) need a commit.
     if [[ "${SPEC_KINDS[$i]}" == "branch" ]] \
-       && ! git -C "$ROOT" rev-parse --verify --quiet "${SPEC_VALS[$i]}" >/dev/null; then
+       && ! git -C "$ROOT" rev-parse --verify --quiet \
+            "${SPEC_VALS[$i]}^{commit}" >/dev/null; then
       echo "error: --branch: unknown git ref '${SPEC_VALS[$i]}'" >&2
       exit 1
     fi

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -108,8 +108,8 @@ Options:
   --build             Build dtest for the current checkout (bazel build //library/tests:dtest)
   --branch NAME       Git branch to build and benchmark ("." means the current branch).
                       Repeatable. Each named branch is checked out, dtest is built and
-                      its binary saved, then the original branch is restored (requires a
-                      clean tree).
+                      its binary saved, then the original branch is restored. A clean
+                      tree is required only when a ref would switch away from HEAD.
   --binary PATH      Path to a prebuilt dtest binary to benchmark. Repeatable.
   --details           Keep per-run timing rows and build (git/bazel) output
   --epsilon PCT       For a two-binary comparison, treat timings within PCT% as equal
@@ -331,10 +331,24 @@ git_prep_for_branches() {
       exit 1
     fi
   done
-  # Untracked files can also block a checkout ("would be overwritten"), so treat
-  # any working tree change (tracked or untracked) as non-clean.
-  if [[ -n "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]]; then
-    echo "error: working tree not clean; commit, stash, or remove changes (tracked or untracked) before using --branch" >&2
+  # A dirty tree only blocks when a --branch ref would leave HEAD's commit
+  # (git checkout of a different commit can refuse or overwrite local changes).
+  # Benchmarking the current branch / HEAD commit itself needs no switch, so
+  # uncommitted work is fine. Untracked files can also block a foreign checkout.
+  local head_commit needs_switch=0 ref_commit
+  head_commit="$(git -C "$ROOT" rev-parse HEAD)"
+  for i in "${!SPEC_VALS[@]}"; do
+    if [[ "${SPEC_KINDS[$i]}" == "branch" ]]; then
+      ref_commit="$(git -C "$ROOT" rev-parse "${SPEC_VALS[$i]}^{commit}")"
+      if [[ "$ref_commit" != "$head_commit" ]]; then
+        needs_switch=1
+        break
+      fi
+    fi
+  done
+  if (( needs_switch )) \
+     && [[ -n "$(git -C "$ROOT" status --porcelain --untracked-files=normal)" ]]; then
+    echo "error: working tree not clean; commit, stash, or remove changes (tracked or untracked) before using --branch with a different commit" >&2
     exit 1
   fi
 }

--- a/benchmark_git_prep_test.sh
+++ b/benchmark_git_prep_test.sh
@@ -33,7 +33,6 @@ resolve_benchmark() {
 
 BENCHMARK="$(resolve_benchmark)"
 [[ -f "$BENCHMARK" ]] || fail "benchmark.sh not found at $BENCHMARK"
-[[ -x "$BENCHMARK" ]] || chmod +x "$BENCHMARK"
 
 command -v git >/dev/null 2>&1 || fail "git is required"
 
@@ -72,7 +71,8 @@ setup_repo() {
 run_bench() {
   local repo="$1"
   shift
-  ( cd "$repo" && DRY_RUN=1 "$BENCHMARK" "$@" ) 2>&1
+  # Invoke via bash: Bazel runfiles may be read-only (no chmod +x).
+  ( cd "$repo" && DRY_RUN=1 bash "$BENCHMARK" "$@" ) 2>&1
 }
 
 setup_repo "$TMP/repo"

--- a/benchmark_git_prep_test.sh
+++ b/benchmark_git_prep_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Exercises benchmark.sh's --branch dirty-tree gate: a clean tree is required
+# only when a --branch ref would check out a different commit than HEAD.
+set -euo pipefail
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+resolve_benchmark() {
+  # Under bazel test, locate via runfiles. Otherwise, use the script directory.
+  if [[ -n "${TEST_SRCDIR:-}${RUNFILES_DIR:-}${RUNFILES_MANIFEST_FILE:-}" ]]; then
+    # --- begin runfiles.bash initialization v3 ---
+    set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+    # shellcheck disable=SC1090
+    source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+      source "$0.runfiles/$f" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+      source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+      { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+    # --- end runfiles.bash initialization v3 ---
+    local path
+    path="$(rlocation "_main/benchmark.sh" || true)"
+    if [[ -n "$path" && -f "$path" ]]; then
+      printf '%s' "$path"
+      return 0
+    fi
+  fi
+  local script_dir
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  printf '%s' "$script_dir/benchmark.sh"
+}
+
+BENCHMARK="$(resolve_benchmark)"
+[[ -f "$BENCHMARK" ]] || fail "benchmark.sh not found at $BENCHMARK"
+[[ -x "$BENCHMARK" ]] || chmod +x "$BENCHMARK"
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+
+TMP="$(mktemp -d "${TEST_TMPDIR:-${TMPDIR:-/tmp}}/dds-benchmark-git-prep.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+git_q() {
+  git -c core.fsmonitor=false -c advice.detachedHead=false "$@"
+}
+
+setup_repo() {
+  local repo="$1"
+  mkdir -p "$repo/library/tests" "$repo/hands"
+  # Minimal DDS root markers that benchmark.sh requires.
+  printf 'module(name = "dds")\n' >"$repo/MODULE.bazel"
+  printf '# test BUILD\n' >"$repo/library/tests/BUILD.bazel"
+  printf 'hand\n' >"$repo/hands/list100.txt"
+
+  git_q -C "$repo" init -q -b main
+  git_q -C "$repo" config user.email "test@example.com"
+  git_q -C "$repo" config user.name "Test"
+  git_q -C "$repo" add MODULE.bazel library/tests/BUILD.bazel hands/list100.txt
+  git_q -C "$repo" commit -q -m "initial"
+
+  # Second commit on a side branch so --branch other differs from HEAD.
+  git_q -C "$repo" checkout -q -b other
+  echo "other" >"$repo/other.txt"
+  git_q -C "$repo" add other.txt
+  git_q -C "$repo" commit -q -m "other"
+  git_q -C "$repo" checkout -q main
+
+  # Dirty tracked change on main.
+  echo "dirty" >>"$repo/MODULE.bazel"
+}
+
+run_bench() {
+  local repo="$1"
+  shift
+  ( cd "$repo" && DRY_RUN=1 "$BENCHMARK" "$@" ) 2>&1
+}
+
+setup_repo "$TMP/repo"
+
+# Dirty tree + --branch for the current branch (by name) must succeed: no switch.
+out="$(run_bench "$TMP/repo" --branch main)" || fail "dirty + --branch main exited $?"
+[[ "$out" != *"working tree not clean"* ]] || fail "dirty + --branch main wrongly rejected: $out"
+pass "dirty + --branch main allowed"
+
+# Dirty tree + --branch . (current branch shorthand) must succeed.
+out="$(run_bench "$TMP/repo" --branch .)" || fail "dirty + --branch . exited $?"
+[[ "$out" != *"working tree not clean"* ]] || fail "dirty + --branch . wrongly rejected: $out"
+pass "dirty + --branch . allowed"
+
+# Dirty tree + --branch other (different commit) must fail with the clean-tree error.
+set +e
+out="$(run_bench "$TMP/repo" --branch other 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "dirty + --branch other should fail"
+[[ "$out" == *"working tree not clean"* ]] || fail "dirty + --branch other missing clean-tree error: $out"
+pass "dirty + --branch other rejected"
+
+echo "All benchmark git-prep tests passed."

--- a/benchmark_git_prep_test.sh
+++ b/benchmark_git_prep_test.sh
@@ -43,7 +43,8 @@ git_q() {
   git -c core.fsmonitor=false -c advice.detachedHead=false "$@"
 }
 
-setup_repo() {
+# Minimal two-branch repo at $1. Caller adds dirtiness (tracked and/or untracked).
+setup_repo_base() {
   local repo="$1"
   mkdir -p "$repo/library/tests" "$repo/hands"
   # Minimal DDS root markers that benchmark.sh requires.
@@ -66,9 +67,6 @@ setup_repo() {
 
   # Tag at HEAD so --branch can name the same commit without switching.
   git_q -C "$repo" tag head-tag
-
-  # Dirty tracked change on main.
-  echo "dirty" >>"$repo/MODULE.bazel"
 }
 
 run_bench() {
@@ -78,7 +76,9 @@ run_bench() {
   ( cd "$repo" && DRY_RUN=1 bash "$BENCHMARK" "$@" ) 2>&1
 }
 
-setup_repo "$TMP/repo"
+# --- Tracked dirty tree ---
+setup_repo_base "$TMP/repo"
+echo "dirty" >>"$TMP/repo/MODULE.bazel"
 
 # Dirty tree + --branch for the current branch (by name) must succeed: no switch.
 out="$(run_bench "$TMP/repo" --branch main)" || fail "dirty + --branch main exited $?"
@@ -112,5 +112,26 @@ set -e
 [[ "$rc" -ne 0 ]] || fail "HEAD^{tree} should fail"
 [[ "$out" == *"unknown git ref"* ]] || fail "HEAD^{tree} missing unknown-ref error: $out"
 pass "non-commit revspec rejected"
+
+# --- Untracked-only dirty tree (status --porcelain --untracked-files=normal) ---
+setup_repo_base "$TMP/repo_untracked"
+echo "untracked" >"$TMP/repo_untracked/scratch.txt"
+
+# Untracked + --branch main (no switch) must succeed.
+out="$(run_bench "$TMP/repo_untracked" --branch main)" \
+  || fail "untracked + --branch main exited $?"
+[[ "$out" != *"working tree not clean"* ]] \
+  || fail "untracked + --branch main wrongly rejected: $out"
+pass "untracked + --branch main allowed"
+
+# Untracked + --branch other (switch) must fail: untracked can block checkout.
+set +e
+out="$(run_bench "$TMP/repo_untracked" --branch other 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "untracked + --branch other should fail"
+[[ "$out" == *"working tree not clean"* ]] \
+  || fail "untracked + --branch other missing clean-tree error: $out"
+pass "untracked + --branch other rejected"
 
 echo "All benchmark git-prep tests passed."

--- a/benchmark_git_prep_test.sh
+++ b/benchmark_git_prep_test.sh
@@ -64,6 +64,9 @@ setup_repo() {
   git_q -C "$repo" commit -q -m "other"
   git_q -C "$repo" checkout -q main
 
+  # Tag at HEAD so --branch can name the same commit without switching.
+  git_q -C "$repo" tag head-tag
+
   # Dirty tracked change on main.
   echo "dirty" >>"$repo/MODULE.bazel"
 }
@@ -86,6 +89,11 @@ pass "dirty + --branch main allowed"
 out="$(run_bench "$TMP/repo" --branch .)" || fail "dirty + --branch . exited $?"
 [[ "$out" != *"working tree not clean"* ]] || fail "dirty + --branch . wrongly rejected: $out"
 pass "dirty + --branch . allowed"
+
+# Dirty tree + tag at HEAD (same commit, peeled via ^{commit}) must succeed.
+out="$(run_bench "$TMP/repo" --branch head-tag)" || fail "dirty + --branch head-tag exited $?"
+[[ "$out" != *"working tree not clean"* ]] || fail "dirty + --branch head-tag wrongly rejected: $out"
+pass "dirty + --branch head-tag allowed"
 
 # Dirty tree + --branch other (different commit) must fail with the clean-tree error.
 set +e

--- a/benchmark_git_prep_test.sh
+++ b/benchmark_git_prep_test.sh
@@ -104,4 +104,13 @@ set -e
 [[ "$out" == *"working tree not clean"* ]] || fail "dirty + --branch other missing clean-tree error: $out"
 pass "dirty + --branch other rejected"
 
+# Non-commit revspec must fail at validation with a clear error (not a later ^{commit} crash).
+set +e
+out="$(run_bench "$TMP/repo" --branch 'HEAD^{tree}' 2>&1)"
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] || fail "HEAD^{tree} should fail"
+[[ "$out" == *"unknown git ref"* ]] || fail "HEAD^{tree} missing unknown-ref error: $out"
+pass "non-commit revspec rejected"
+
 echo "All benchmark git-prep tests passed."


### PR DESCRIPTION
## Summary
- Allow `benchmark.sh --branch` on a dirty working tree when every named branch resolves to the current HEAD commit (no checkout needed).
- Still require a clean tree (tracked and untracked) when a `--branch` ref would switch commits.
- Add `//:benchmark_git_prep_test` (`sh_test`) and pin `rules_shell` so the gate is covered in the Bazel suite.

## Test plan
- [ ] `bazel test //:benchmark_git_prep_test`
- [ ] With uncommitted changes on the current branch: `./benchmark.sh --branch .` (or the current branch name) succeeds past git prep
- [ ] With uncommitted changes: `./benchmark.sh --branch <other-branch-at-different-commit>` still errors asking to clean the tree


Made with [Cursor](https://cursor.com)