### PR TITLE
Add C++20 likely/unlikely hints on AB and quick-tricks hot paths.

### DIFF
--- a/library/src/ab_search.cpp
+++ b/library/src/ab_search.cpp
@@ -246,17 +246,17 @@ static bool ab_search_0_ctx(
     }
   }
 
-  if (posPoint->tricks_max >= target)
+  if (posPoint->tricks_max >= target) [[likely]]
   {
     AB_COUNT(AB_TARGET_REACHED, true, depth);
     return true;
   }
-  else if (posPoint->tricks_max + tricks + 1 < target)
+  else if (posPoint->tricks_max + tricks + 1 < target) [[unlikely]]
   {
     AB_COUNT(AB_TARGET_REACHED, false, depth);
     return false;
   }
-  else if (depth == 0) /* Maximum depth? */
+  else if (depth == 0) [[unlikely]] /* Maximum depth? */
   {
     TIMER_START(TIMER_NO_EVALUATE, depth);
     EvalType evalData = evaluate_with_context(posPoint, trump, ctx);
@@ -279,7 +279,7 @@ static bool ab_search_0_ctx(
 
   if (ctx.search().node_type_store(hand) == MAXNODE)
   {
-    if (res)
+    if (res) [[unlikely]]
     {
       AB_COUNT(AB_QUICKTRICKS, 1, depth);
       return (qtricks == 0 ? false : true);
@@ -289,7 +289,7 @@ static bool ab_search_0_ctx(
   res = LaterTricksMIN(* posPoint, hand, depth, target, trump, ctx);
   TIMER_END(TIMER_NO_LT, depth);
 
-    if (! res)
+    if (! res) [[unlikely]]
     {
       AB_COUNT(AB_LATERTRICKS, true, depth);
       return false;
@@ -297,7 +297,7 @@ static bool ab_search_0_ctx(
   }
   else
   {
-    if (res)
+    if (res) [[unlikely]]
     {
       AB_COUNT(AB_QUICKTRICKS, false, depth);
       return (qtricks == 0 ? true : false);
@@ -307,7 +307,7 @@ static bool ab_search_0_ctx(
   res = LaterTricksMAX(* posPoint, hand, depth, target, trump, ctx);
   TIMER_END(TIMER_NO_LT, depth);
 
-    if (res)
+    if (res) [[unlikely]]
     {
       AB_COUNT(AB_LATERTRICKS, false, depth);
       return true;
@@ -507,7 +507,7 @@ static bool ab_search_1_ctx(
   TIMER_START(TIMER_NO_QT, depth);
   int res = QuickTricksSecondHand(* posPoint, hand, depth, target, trump, ctx);
   TIMER_END(TIMER_NO_QT, depth);
-  if (res) 
+  if (res) [[unlikely]]
   {
     AB_COUNT(AB_QUICKTRICKS_2ND, true, depth);
     return success;

--- a/library/src/quick_tricks.cpp
+++ b/library/src/quick_tricks.cpp
@@ -234,9 +234,9 @@ int QuickTricks(
     int countPart = len[partner[hand]][suit];
     int opps = countLho | countRho;
 
-    if (!opps && (countPart == 0))
+    if (!opps && (countPart == 0)) [[unlikely]]
     {
-      if (countOwn == 0)
+      if (countOwn == 0) [[unlikely]]
       {
         /* Continue with next suit. */
         if ((trump != DDS_NOTRUMP) && (trump != suit))
@@ -263,7 +263,7 @@ int QuickTricks(
       /* Long tricks when only leading hand have cards in the suit. */
       if ((trump != DDS_NOTRUMP) && (trump != suit))
       {
-        if ((lhoTrumpRanks == 0) && (rhoTrumpRanks == 0))
+        if ((lhoTrumpRanks == 0) && (rhoTrumpRanks == 0)) [[unlikely]]
         {
           qtricks += countOwn;
           if (qtricks >= cutoff)
@@ -273,7 +273,7 @@ int QuickTricks(
             suit++;
           continue;
         }
-        else
+        else [[likely]]
         {
           suit++;
           if ((trump != DDS_NOTRUMP) && (suit == trump))
@@ -281,7 +281,7 @@ int QuickTricks(
           continue;
         }
       }
-      else
+      else [[likely]]
       {
         qtricks += countOwn;
         if (qtricks >= cutoff)
@@ -303,9 +303,9 @@ int QuickTricks(
         continue;
       }
     }
-    else
+    else [[likely]]
     {
-      if (!opps && (trump != DDS_NOTRUMP) && (suit == trump))
+      if (!opps && (trump != DDS_NOTRUMP) && (suit == trump)) [[unlikely]]
       {
         /* The partner but not the opponents have cards in
            the trump suit. */
@@ -328,7 +328,7 @@ int QuickTricks(
         if (sum >= cutoff)
           return sum;
       }
-      else if (!opps)
+      else if (!opps) [[unlikely]]
       {
         /* The partner but not the opponents have cards in the suit. */
         int sum = std::min(countOwn, countPart);
@@ -348,11 +348,11 @@ int QuickTricks(
 
       if (commPartner)
       {
-        if (!opps && (countOwn == 0))
+        if (!opps && (countOwn == 0)) [[unlikely]]
         {
           if ((trump != DDS_NOTRUMP) && (trump != suit))
           {
-            if ((lhoTrumpRanks == 0) && (rhoTrumpRanks == 0))
+            if ((lhoTrumpRanks == 0) && (rhoTrumpRanks == 0)) [[unlikely]]
             {
               qtricks += countPart;
               tpos.win_ranks[depth][commSuit] |=
@@ -366,7 +366,7 @@ int QuickTricks(
                 suit++;
               continue;
             }
-            else
+            else [[likely]]
             {
               suit++;
               if ((trump != DDS_NOTRUMP) && (suit == trump))
@@ -374,7 +374,7 @@ int QuickTricks(
               continue;
             }
           }
-          else
+          else [[likely]]
           {
             qtricks += countPart;
             tpos.win_ranks[depth][commSuit] |=
@@ -399,9 +399,9 @@ int QuickTricks(
             continue;
           }
         }
-        else
+        else [[likely]]
         {
-          if (!opps && (trump != DDS_NOTRUMP) && (suit == trump))
+          if (!opps && (trump != DDS_NOTRUMP) && (suit == trump)) [[unlikely]]
           {
             int sum = std::max(countOwn, countPart);
             for (int s = 0; s < DDS_SUITS; s++)
@@ -423,7 +423,7 @@ int QuickTricks(
               return sum;
             }
           }
-          else if (!opps)
+          else if (!opps) [[unlikely]]
           {
             int sum = std::min(countOwn, countPart);
             if (trump == DDS_NOTRUMP)
@@ -443,7 +443,7 @@ int QuickTricks(
       }
     }
 
-    if (winner[suit].rank == 0)
+    if (winner[suit].rank == 0) [[unlikely]]
     {
       if ((trump != DDS_NOTRUMP) && (suit == trump))
       {


### PR DESCRIPTION
Guide the compiler toward fall-through search and common QT suit cases so rare void/cutoff branches mispredict less often.