### PR TITLE
Bazel version referenced only through `.bazelversion` throughout the documentation.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 
 **Current State**: Work in progress towards version 3.0. The project has been refactored from the legacy 2.9.0 codebase to use modern C++ features, Bazel build system, and modular architecture.
 
-**Languages & Tools**: C++20, Bazel 7.x, GoogleTest for testing
+**Languages & Tools**: C++20, Bazel (version pinned in `.bazelversion`), GoogleTest for testing
 
 **Repository Size**: ~50 C++ source files in library/src, ~20 test files, several examples
 

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -42,8 +42,9 @@ file (do not embed it in git config) and pin the URL to the Bazel version in
 
 ```bash
 mkdir -p "${HOME}/.local/share/bazel"
+# Run from the repo root so .bazelversion supplies the pin.
 curl -fsSL \
-  "https://raw.githubusercontent.com/bazelbuild/bazel/9.1.0/scripts/bazel-lockfile-merge.jq" \
+  "https://raw.githubusercontent.com/bazelbuild/bazel/$(cat .bazelversion)/scripts/bazel-lockfile-merge.jq" \
   -o "${HOME}/.local/share/bazel/bazel-lockfile-merge.jq"
 # Optionally inspect: less "${HOME}/.local/share/bazel/bazel-lockfile-merge.jq"
 git config --global merge.bazel-lockfile-merge.name \

--- a/docs/jni_interface.md
+++ b/docs/jni_interface.md
@@ -28,7 +28,11 @@ bindings work — see [python_interface.md](python_interface.md),
   `--enable-preview` is needed. The Bazel build is hermetic: `rules_java`
   supplies the JDK (currently pinned to `remotejdk_25` in
   [`.bazelrc`](../.bazelrc)); you do **not** need a system JDK installed.
-- **Bazel 8.x or later.** (The committed `MODULE.bazel.lock` uses lockFileVersion 28; Bazel 7 users must delete/regenerate the lock file.)
+- **Bazel as pinned in [`.bazelversion`](../.bazelversion).** Use
+  [bazelisk](https://github.com/bazelbuild/bazelisk), which reads that file and
+  fetches the matching Bazel automatically. Other versions may reject the
+  committed `MODULE.bazel.lock`. See
+  [Bazel version and MODULE.bazel.lock](BUILD_SYSTEM.md#bazel-version-and-modulebazellock).
 - **JVM runtime.** These FFM bindings presume a 64-bit JVM
 
 No `jextract` install is required — the bindings are hand-written (see

--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -8,7 +8,9 @@ The DDS (Double Dummy Solver) library provides a Python interface for analyzing 
 
 ### Prerequisites
 - Python 3.10+ (tested with 3.10, 3.11, 3.12, 3.14)
-- Bazel 7.x
+- Bazel as pinned in [`.bazelversion`](../.bazelversion) (use
+  [bazelisk](https://github.com/bazelbuild/bazelisk), which picks it up
+  automatically)
 - C++ compiler (clang 15+ or GCC 11+)
 
 ### Build Instructions

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -6,8 +6,10 @@ This document explains how to build DDS examples for WebAssembly using Bazel.
 
 ### Bazel
 
-Bazel 7.x or later is required. Install using your package manager or download from:
-https://bazel.build/install
+The Bazel version is pinned in [`.bazelversion`](../.bazelversion). Use
+[bazelisk](https://github.com/bazelbuild/bazelisk), which reads that file and
+fetches the matching Bazel automatically:
+https://github.com/bazelbuild/bazelisk
 
 The Emscripten SDK (emsdk) does NOT need to be manually installed. Bazel downloads and caches a hermetic Emscripten toolchain when you build a `wasm_cc_binary` target.
 


### PR DESCRIPTION
closes #236 