### PR TITLE
Ignore bazel shutdown failures in Windows CI retries.

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -47,7 +47,7 @@ jobs:
               Write-Host "Build failed (attempt $i/$max). Retrying in 20s..."
               Start-Sleep -Seconds 20
               # Restart server only — keep downloaded external repos / disk cache.
-              bazel shutdown
+              bazel shutdown || $true
             }
           }
           exit 1


### PR DESCRIPTION
Match the WASM workflow so a missing server cannot abort the PowerShell retry loop.