### PR TITLE
Enable WASM multithreading

### DIFF
--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -125,7 +125,8 @@ For other experiments, copy built `.js` / `.wasm` files from `bazel-bin/wasm/` t
 | `-fwasm-exceptions` | Native WebAssembly exception handling (use together with `-fexceptions`; replaces the slower JS-trampoline EH lowering used when linking with `-fexceptions` alone) |
 | `-pthread` / `USE_PTHREADS` | Enable SharedArrayBuffer atomics and `std::thread` (via `wasm_cc_binary(threads = "emscripten")`) |
 | `-sWASM=1` | Emscripten WASM output (link flag) |
-| `-sALLOW_MEMORY_GROWTH=1` | Allow heap growth at runtime (emits `-Wpthreads-mem-growth` with `-pthread`; intentional) |
+| `-sALLOW_MEMORY_GROWTH=1` | Allow heap growth at runtime (with `-pthread`; warning silenced via `-Wno-pthreads-mem-growth`) |
+| `-Wno-pthreads-mem-growth` | Keep growth+pthreads without the emcc advisory on slower JS paths after grow |
 | `-sINITIAL_MEMORY=268435456` | 256MB initial memory |
 | `-sSTACK_SIZE=8388608` | 8MB stack (default 64KB is too small for DDS search) |
 | `-sPTHREAD_POOL_SIZE=8` | Pre-create a modest pthread worker pool (more threads allocate on demand; Node `dtest` shuts the pool down cleanly before exit) |

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -17,7 +17,7 @@ The Emscripten SDK (emsdk) does NOT need to be manually installed. Bazel downloa
 
 WASM builds use the Bazel Central Registry package pinned in `MODULE.bazel`:
 
-- `bazel_dep(name = "emsdk", version = "5.0.7")` (Emscripten 3.1.x toolchain)
+- `bazel_dep(name = "emsdk", version = "5.0.7")` (Emscripten 5.0.x toolchain)
 
 If you upgrade `emsdk`, rebuild WASM targets and the web MVP (`./web/update_wasm.sh`). The post-build script `web/patch_mvp_wasm.py` patches one generated `isFileURI` helper for browser/file URL safety; if Emscripten changes that line, update the regex in that script and this note.
 
@@ -58,14 +58,15 @@ Rules in `wasm/BUILD.bazel` wrap native binaries:
 - `dtest_wasm` — the `dtest` hand-list harness for Node (`//library/tests:dtest`)
 
 `dtest_wasm` is linked with `NODERAWFS` so Node can pass a real host path to
-`-f` (for example `hands/list1.txt`). Use `-n 1` (WASM is single-threaded).
+`-f` (for example `hands/list1.txt`). Multi-threading is enabled (`-pthread`);
+use `-n N` for N workers (or omit / `0` for auto).
 
 ```bash
 bazel build //wasm:dtest_wasm
-node bazel-bin/wasm/dtest.js -f hands/list1.txt -s solve -n 1
+node bazel-bin/wasm/dtest.js -f hands/list2.txt -s solve -n 2
 
 # Or via Bazel (forwards args after -- to dtest; cwd is your shell's directory):
-bazel run //wasm:run_dtest_wasm -- -f hands/list1.txt -s solve -n 1
+bazel run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2
 ```
 ## How it works
 
@@ -89,11 +90,21 @@ The `web/` demo calls `CalcDDtablePBN` in the browser via `//web:dds_mvp_wasm`:
 
 ```bash
 ./web/update_wasm.sh
-python3 -m http.server 8080 --directory web
-# open http://localhost:8080/dds_mvp.html
+python3 web/serve_mvp.py
+# open http://127.0.0.1:8080/dds_mvp.html
 ```
 
-The MVP loads wasm from `dds_mvp_wasm_bin.js` (base64, no network fetch), so `file://` and HTTP both work. Run `./web/update_wasm.sh` to refresh `dds_mvp_wasm.{js,wasm,bin.js}` (includes a small post-process step for Emscripten `isFileURI`; see **Emscripten / emsdk version** above).
+Pthread WASM needs `SharedArrayBuffer`, which requires cross-origin isolation
+(`Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: require-corp`). `web/serve_mvp.py` sets those
+headers; plain `python3 -m http.server` does not, so solving will fail there.
+`file://` is still fine for UI-only browsing; run a solve over the isolated HTTP
+server.
+
+The MVP loads wasm from `dds_mvp_wasm_bin.js` (base64, no network fetch). Run
+`./web/update_wasm.sh` to refresh `dds_mvp_wasm.{js,wasm,bin.js}` (includes a
+small post-process step for Emscripten `isFileURI`; see **Emscripten / emsdk
+version** above).
 
 `bazel clean` does not delete those copied files under `web/` (they live outside `bazel-out`). Use either:
 
@@ -112,10 +123,12 @@ For other experiments, copy built `.js` / `.wasm` files from `bazel-bin/wasm/` t
 | `-O3` | Aggressive optimization |
 | `-flto` | Link-time optimization at compile time only (see note below) |
 | `-fwasm-exceptions` | Native WebAssembly exception handling (use together with `-fexceptions`; replaces the slower JS-trampoline EH lowering used when linking with `-fexceptions` alone) |
+| `-pthread` / `USE_PTHREADS` | Enable SharedArrayBuffer atomics and `std::thread` (via `wasm_cc_binary(threads = "emscripten")`) |
 | `-sWASM=1` | Emscripten WASM output (link flag) |
-| `-sALLOW_MEMORY_GROWTH=1` | Allow heap growth at runtime |
+| `-sALLOW_MEMORY_GROWTH=1` | Allow heap growth at runtime (emits `-Wpthreads-mem-growth` with `-pthread`; intentional) |
 | `-sINITIAL_MEMORY=268435456` | 256MB initial memory |
 | `-sSTACK_SIZE=8388608` | 8MB stack (default 64KB is too small for DDS search) |
+| `-sPTHREAD_POOL_SIZE=8` | Pre-create a modest pthread worker pool (more threads allocate on demand; Node `dtest` shuts the pool down cleanly before exit) |
 
 `-flto` is applied at compile time (`DDS_CPPOPTS`) but deliberately **not** at
 link time. Passing `-flto` to the wasm link step was tried and reverted: the
@@ -151,10 +164,10 @@ bazel test //wasm:all
 `bazel test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazel test //web:web_e2e_tests` or `bazel test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazel test --test_tag_filters= /...`
 
 - **`//web:dds_mvp_wasm_system_test`** — builds `//web:dds_mvp_wasm`, runs `patch_mvp_wasm` / `gen_wasm_bin_js` / `verify_wasm_js`, then calls `dds_mvp_calc_table` via Node (`web/tests/dds_mvp_wasm_node.mjs`).
-- **`//web:dds_mvp_e2e_test`** — Playwright tests for `dds_mvp.html` over `file://` and HTTP (part-score deal table, validation error). Requires Node, network (Chromium download on first run), and `tags = ["no-sandbox"]`.
-- **`//wasm:wasm_examples_system_test`** — runs `calc_dd_table_pbn.js` under Node (expects `OK` on all three example hands) and `dtest.js` on `hands/list1.txt` (`-s solve -n 1`).
+- **`//web:dds_mvp_e2e_test`** — Playwright tests for `dds_mvp.html` over `file://` (UI) and isolated HTTP (part-score solve, COOP/COEP). Requires Node, network (Chromium download on first run), and `tags = ["no-sandbox"]`.
+- **`//wasm:wasm_examples_system_test`** — runs `calc_dd_table_pbn.js` under Node (expects `OK` on all three example hands) and `dtest.js` on `hands/list1.txt` (`-s solve -n 1`) plus `hands/list2.txt` (`-n 2`).
 
-The MVP link flags include `-sENVIRONMENT=web,node` so the same `.js` / `.wasm` artifacts work in the browser and in Node system tests.
+The MVP link flags include `-sENVIRONMENT=web,worker,node` so the same `.js` / `.wasm` artifacts work in the browser (with pthread workers) and in Node system tests.
 
 ## Development notes
 

--- a/hands/BUILD.bazel
+++ b/hands/BUILD.bazel
@@ -2,6 +2,7 @@
 exports_files(
     [
         "list1.txt",
+        "list2.txt",
     ],
     visibility = ["//visibility:public"],
 )

--- a/library/src/system/parallel_boards.cpp
+++ b/library/src/system/parallel_boards.cpp
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -198,10 +199,27 @@ private:
 };
 
 
-auto default_pool() -> BoardWorkerPool&
+struct PoolHolder
 {
-  static BoardWorkerPool pool;
-  return pool;
+  std::mutex mu;
+  std::shared_ptr<BoardWorkerPool> pool;
+};
+
+
+auto pool_holder() -> PoolHolder&
+{
+  static PoolHolder holder;
+  return holder;
+}
+
+
+auto default_pool() -> std::shared_ptr<BoardWorkerPool>
+{
+  auto& h = pool_holder();
+  std::lock_guard<std::mutex> lock(h.mu);
+  if (!h.pool)
+    h.pool = std::make_shared<BoardWorkerPool>();
+  return h.pool;
 }
 
 }  // namespace
@@ -244,6 +262,20 @@ auto parallel_boards_worker_threads_created() -> std::uint64_t
   return g_threads_created.load(std::memory_order_relaxed);
 }
 
+
+void shutdown_parallel_boards_pool()
+{
+  std::shared_ptr<BoardWorkerPool> dying;
+  {
+    auto& h = pool_holder();
+    std::lock_guard<std::mutex> lock(h.mu);
+    dying = std::move(h.pool);
+  }
+  // Drop the last shared_ptr outside the holder lock so joins cannot deadlock
+  // against a concurrent parallel_all_boards_n that needs the mutex to recreate
+  // the pool. In-flight runs keep their own shared_ptr alive until run returns.
+}
+
 }  // namespace dds::internal
 
 
@@ -284,5 +316,5 @@ auto parallel_all_boards_n(
     return RETURN_NO_FAULT;
   }
 
-  return default_pool().run(workers, count, process_board, use_order, order);
+  return default_pool()->run(workers, count, process_board, use_order, order);
 }

--- a/library/src/system/parallel_boards.hpp
+++ b/library/src/system/parallel_boards.hpp
@@ -46,6 +46,8 @@ auto resolve_worker_count(int max_threads, int count) -> int;
  * each other. Not re-entrant: calling this again with worker_cap > 1 from
  * inside @p process_board of another multi-worker run deadlocks (the inner
  * call blocks on the pool mutex while the outer run waits for that worker).
+ * Call dds::internal::shutdown_parallel_boards_pool() before process exit
+ * when hosts (notably Emscripten) tear down pthread Workers eagerly.
  */
 auto parallel_all_boards_n(
   int count,
@@ -58,5 +60,9 @@ namespace dds::internal
 
 // Cumulative number of OS worker threads created by the board pool (test seam).
 auto parallel_boards_worker_threads_created() -> std::uint64_t;
+
+// Join and destroy the process-local board worker pool. Safe to call with no
+// pool, and again after a later parallel_all_boards_n recreates it.
+void shutdown_parallel_boards_pool();
 
 }  // namespace dds::internal

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -209,8 +209,8 @@ void System::get_hardware(
 #if defined(__EMSCRIPTEN__)
   // sysconf/physical memory queries are unreliable under Emscripten; use a
   // conservative default so SetResources allocates a usable transposition table.
+  // Core count comes from get_cores() / hardware_concurrency (pthreads WASM).
   kilobytes_free = 512ULL * 1024;
-  core_count = 1;
 #elif defined(_WIN32) || defined(__CYGWIN__)
   // Using GlobalMemoryStatusEx instead of GlobalMemoryStatus
   // was suggested by Lorne Anderson.

--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -17,12 +17,12 @@ filegroup(
 )
 
 # Emscripten flags when //library/tests:dtest is built under wasm_cc_binary.
-# NODERAWFS lets Node read host hand-list paths; ENVIRONMENT=node matches dtest CLI use.
+# NODERAWFS lets Node read host hand-list paths; worker is required for pthreads.
+# EXIT_RUNTIME is off: dtest shuts the pthread pool down cleanly then process.exit.
 DTEST_LINKOPTS_WASM = select({
     "//:build_wasm": WASM_LINKOPTS + [
-        "-sENVIRONMENT=node",
+        "-sENVIRONMENT=node,worker",
         "-sNODERAWFS=1",
-        "-sEXIT_RUNTIME=1",
     ],
     "//conditions:default": [],
 })

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -51,6 +51,19 @@ void TestTimer::reset()
   sys_max_ = 0;
   batch_count_ = 0;
   pending_hands_ = 0;
+  sys_time_known_ = true;
+}
+
+
+void TestTimer::mark_sys_time_unavailable()
+{
+  sys_time_known_ = false;
+}
+
+
+bool TestTimer::sys_time_known() const
+{
+  return sys_time_known_;
 }
 
 
@@ -73,6 +86,8 @@ void TestTimer::start(const int number)
   pending_hands_ = number;
   user0_ = Clock::now();
   sys0_ = clock();
+  if (sys0_ == static_cast<clock_t>(-1))
+    sys_time_known_ = false;
 }
 
 
@@ -83,7 +98,14 @@ void TestTimer::end()
 
   duration<double, std::milli> d = user1 - user0_;
   const long tuser = static_cast<long>(d.count());
-  const long tsys = clock_delta_to_ms(sys1 - sys0_);
+  long tsys = 0;
+  if (sys_time_known_)
+  {
+    if (sys1 == static_cast<clock_t>(-1))
+      sys_time_known_ = false;
+    else
+      tsys = clock_delta_to_ms(sys1 - sys0_);
+  }
 
   TestTimer::record(pending_hands_, tuser, tsys);
   pending_hands_ = 0;
@@ -185,7 +207,9 @@ void TestTimer::print_basic() const
       setprecision(2) << user_cum_ / static_cast<float>(count_) << "\n";
   }
 
-  if (sys_cum_ == 0)
+  if (!sys_time_known_)
+    cout << setw(19) << left << "Sys time (ms)" << ": " << "n/a" << "\n";
+  else if (sys_cum_ == 0)
     cout << setw(19) << left << "Sys time (ms)" << ": " << "zero" << "\n";
   else
   {
@@ -261,7 +285,10 @@ void TestTimer::print_hands(
         setw(12) << right << fixed << setprecision(2) << user_max_ << "\n";
   }
 
-  if (sys_cum_ == 0)
+  if (!sys_time_known_)
+    out << setw(21) << left << "Sys time (ms)" <<
+      setw(12) << right << "n/a" << "\n";
+  else if (sys_cum_ == 0)
     out << setw(21) << left << "Sys time (ms)" << 
       setw(12) << right << "zero" << "\n";
   else

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -46,6 +46,7 @@ class TestTimer
     double sys_max_;        ///< Max per-hand system time across batches (ms)
     long batch_count_;      ///< Number of completed batches
     int pending_hands_;     ///< Hands counted into the open start()/end() batch
+    bool sys_time_known_;   ///< False when clock() is unusable (e.g. wasm32)
 
     time_point<Clock> user0_;  ///< Wall-clock start time
     clock_t sys0_;             ///< CPU start time
@@ -57,6 +58,15 @@ class TestTimer
 
     /// Reset timer to zero.
     void reset();
+
+    /// Mark process-CPU (`clock()`) measurements as unavailable.
+    /// Used when `clock()` returns `(clock_t)-1` (seen under wasm32 Emscripten
+    /// pthreads, where the process CPU clock is epoch-based and overflows
+    /// 32-bit `clock_t`). Also a test seam.
+    void mark_sys_time_unavailable();
+
+    /// Whether process-CPU time is available for reporting.
+    bool sys_time_known() const;
 
     /// Set the name for this timer.
     /// @param s Name to display with timer results

--- a/library/tests/dtest.cpp
+++ b/library/tests/dtest.cpp
@@ -14,9 +14,52 @@
 #endif
 
 #include <api/dll.h>
+#include <system/parallel_boards.hpp>
 #include "testcommon.hpp"
 #include "args.hpp"
 #include "cst.hpp"
+
+#if defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+
+EM_JS(void, dtest_schedule_pthread_clean_exit, (int code), {
+  var exitCode = code;
+  var attempts = 100;
+  var finish = function () {
+    if (typeof PThread !== 'undefined') {
+      var workers = [].concat(
+        PThread.unusedWorkers || [],
+        PThread.runningWorkers || []);
+      var pending = workers.some(function (w) { return !w.loaded; });
+      if (pending && attempts-- > 0) {
+        setTimeout(finish, 0);
+        return;
+      }
+      if (PThread.terminateAllThreads)
+        PThread.terminateAllThreads();
+    }
+    if (typeof process !== 'undefined')
+      process.exit(exitCode);
+  };
+  // Node processes Worker messages before setImmediate callbacks.
+  if (typeof setImmediate === 'function')
+    setImmediate(finish);
+  else
+    setTimeout(finish, 0);
+});
+
+// Join C++ workers, let pending Worker "loaded" messages flush, then tear down
+// Emscripten pthread Workers and exit Node. Avoids ASSERTIONS noise of the form
+// `received "loaded" command from terminated worker` when -n exceeds the
+// precreated PTHREAD_POOL_SIZE.
+[[noreturn]] static void dtest_emscripten_clean_exit(const int code)
+{
+  dds::internal::shutdown_parallel_boards_pool();
+  dtest_schedule_pthread_clean_exit(code);
+  emscripten_exit_with_live_runtime();
+}
+#endif
+
 
 using std::cout;
 using std::endl;
@@ -40,6 +83,10 @@ int main(int argc, char * argv[])
 
   real_main(argc, argv);
 
+#if defined(__EMSCRIPTEN__)
+  dtest_emscripten_clean_exit(0);
+#else
   // Restore normal termination so destructors / atexit handlers run.
   exit(0);
+#endif
 }

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -327,3 +327,27 @@ TEST(ParallelAllBoards, ReusesWorkerThreadsAcrossConsecutiveCalls)
   // Assert: reuse must not create additional OS threads.
   EXPECT_EQ(created_after_reuse, created_after_warm);
 }
+
+
+TEST(ParallelAllBoards, ShutdownJoinsPoolAndAllowsRecreation)
+{
+  if (std::thread::hardware_concurrency() < 2)
+    GTEST_SKIP() << "Need at least 2 hardware threads";
+
+  constexpr int count = 32;
+  constexpr int workers = 4;
+  const auto noop = [](const int, const int) { return RETURN_NO_FAULT; };
+
+  ASSERT_EQ(parallel_all_boards_n(count, workers, noop), RETURN_NO_FAULT);
+  const auto created_before =
+    dds::internal::parallel_boards_worker_threads_created();
+  ASSERT_GE(created_before, static_cast<std::uint64_t>(workers));
+
+  dds::internal::shutdown_parallel_boards_pool();
+  dds::internal::shutdown_parallel_boards_pool();  // idempotent
+
+  ASSERT_EQ(parallel_all_boards_n(count, workers, noop), RETURN_NO_FAULT);
+  const auto created_after =
+    dds::internal::parallel_boards_worker_threads_created();
+  EXPECT_GE(created_after, created_before + static_cast<std::uint64_t>(workers));
+}

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -176,6 +176,21 @@ TEST(TestTimer, PrintHandsOmitsMinMaxByDefault)
   EXPECT_EQ(out.find("Max sys time (ms)"), std::string::npos);
 }
 
+TEST(TestTimer, PrintHandsShowsSysNaWhenClockUnavailable)
+{
+  // wasm32+pthread: clock() always returns -1 (process CPU clock is epoch-based
+  // and does not fit in 32-bit clock_t). That must not be printed as "zero".
+  TestTimer timer;
+  timer.mark_sys_time_unavailable();
+  timer.record(10, 100, 0);
+
+  const std::string out = capture_print_hands(timer, false, false);
+
+  EXPECT_NE(out.find("Sys time (ms)"), std::string::npos);
+  EXPECT_NE(out.find("n/a"), std::string::npos);
+  EXPECT_EQ(out.find("zero"), std::string::npos);
+}
+
 TEST(TestTimer, PrintHandsShowsMinWhenRequested)
 {
   TestTimer timer;

--- a/specs/build-system.md
+++ b/specs/build-system.md
@@ -58,8 +58,9 @@ than re-encoding toolchain knowledge.
   wanted** (`local_defines = DDS_LOCAL_DEFINES + DDS_SCHEDULER_DEFINE`). Off by
   default, these add zero cost.
 - **WASM link flags are centralised** in `wasm_compat.bzl` (`WASM_LINKOPTS`):
-  memory growth, 256 MB initial memory, and an 8 MB stack (DDS search recursion
-  overflows Emscripten's 64 KB default). WASM binaries must use these — see
+  memory growth, 256 MB initial memory, an 8 MB stack (DDS search recursion
+  overflows Emscripten's 64 KB default), and `PTHREAD_POOL_SIZE=8`. WASM
+  `wasm_cc_binary` targets also set `threads = "emscripten"` — see
   [wasm-emscripten](wasm-emscripten.md).
 - **The dependency graph is pinned in `MODULE.bazel`** (rules_cc, platforms,
   googletest, pybind11_bazel, rules_python, toolchains_llvm, apple_support, emsdk,

--- a/specs/system-concurrency.md
+++ b/specs/system-concurrency.md
@@ -1,7 +1,7 @@
 ---
 capability: system-concurrency
 owners: [system]
-last-updated: 2026-07-23
+last-updated: 2026-07-24
 ---
 
 # System & Concurrency
@@ -43,8 +43,12 @@ place so the search and API layers stay portable. It is internal — not part of
   threads; `workers == 1` stays on the calling thread. Concurrent multi-worker
   callers serialize on the pool, but the API is **not re-entrant** from inside
   `process_board` of another multi-worker run (that nests a second
-  `run_mu_` acquisition on a pool worker and deadlocks). Guarded by
-  `concurrency_validation_test` and `parallel_boards_test`.
+  `run_mu_` acquisition on a pool worker and deadlocks).
+  `dds::internal::shutdown_parallel_boards_pool()` joins and drops the pool
+  (idempotent; the next multi-worker call recreates it) — used before process
+  exit on Emscripten so pthread Workers are not torn down under live
+  `std::thread`s. Guarded by `concurrency_validation_test` and
+  `parallel_boards_test`.
 - **Result equivalence across thread counts is an invariant.** Solving the same
   boards single-threaded and multi-threaded must produce identical results;
   `max_threads_equivalence_test` and `context_equivalence_test*` guard this. Thread
@@ -83,8 +87,10 @@ place so the search and API layers stay portable. It is internal — not part of
 
 ## Known gaps / non-goals
 
-- **WASM builds are single-threaded** — the concurrency here assumes hosted
-  threads; the Emscripten build does not use them. See [wasm-emscripten](wasm-emscripten.md).
+- **Browser SharedArrayBuffer needs cross-origin isolation** — the Emscripten
+  pthread build works under Node without special headers; browsers require
+  COOP/COEP (see [web-mvp](web-mvp.md) / `web/serve_mvp.py`). See
+  [wasm-emscripten](wasm-emscripten.md).
 - This layer does not decide TT sizing or search policy; it schedules work and
   owns scratch memory. TT ownership/config belongs to [solver-context](solver-context.md) /
   [transposition-table](transposition-table.md).

--- a/specs/wasm-emscripten.md
+++ b/specs/wasm-emscripten.md
@@ -84,5 +84,5 @@ core solver builds and runs correctly under Emscripten.
 - Browser wiring, the site, MVP post-build JS patches (`web/patch_mvp_wasm.py`),
   COOP/COEP serving, and JS/e2e tests belong to [web-mvp](web-mvp.md); this
   capability provides the example modules, not the page.
-- `-pthread` + `ALLOW_MEMORY_GROWTH` emits an Emscripten advisory
-  (`-Wpthreads-mem-growth`); kept intentionally for DDS's large TT heaps.
+- `-pthread` + `ALLOW_MEMORY_GROWTH` is intentional for DDS TT heaps; the emcc
+  advisory is silenced with `-Wno-pthreads-mem-growth` in `WASM_LINKOPTS`.

--- a/specs/wasm-emscripten.md
+++ b/specs/wasm-emscripten.md
@@ -1,14 +1,14 @@
 ---
 capability: wasm-emscripten
 owners: [wasm]
-last-updated: 2026-07-19
+last-updated: 2026-07-24
 ---
 
 # WASM (Emscripten) Build
 
 > **Specs vs. docs.** Build commands and emsdk pinning live in
 > `docs/wasm_build.md`. This spec records what the WASM build covers, the
-> toolchain contract, and the single-thread assumption.
+> toolchain contract, and how multithreading is enabled.
 
 ## Purpose
 
@@ -37,19 +37,27 @@ core solver builds and runs correctly under Emscripten.
   downloaded/cached by Bazel (pinned in `MODULE.bazel`, currently `emsdk 5.0.7`).
   The transition is what makes the `//:build_wasm` config setting
   (`@platforms//cpu:wasm32`) active — see [build-system](build-system.md).
-- **WASM builds are single-threaded.** The Emscripten build does not use the host
-  threading in [system-concurrency](system-concurrency.md); solves run on one thread. Link flags come
-  from `WASM_LINKOPTS` ([build-system](build-system.md)) — notably an 8 MB stack, because DDS
-  search recursion overflows Emscripten's 64 KB default. Example binaries also
-  attach those flags via `EXAMPLES_LINKOPTS_WASM` in `examples/BUILD.bazel`.
-  `dtest` adds Node-oriented flags (`ENVIRONMENT=node`, `NODERAWFS`,
-  `EXIT_RUNTIME`) under the same `build_wasm` select.
+- **WASM builds use pthreads.** Every `wasm_cc_binary` sets
+  `threads = "emscripten"` so the toolchain passes `-pthread` / `USE_PTHREADS`
+  (SharedArrayBuffer + atomics). Shared link flags come from `WASM_LINKOPTS`
+  ([build-system](build-system.md)) — notably an 8 MB stack (DDS search recursion
+  overflows Emscripten's 64 KB default) and `PTHREAD_POOL_SIZE=8` so
+  [system-concurrency](system-concurrency.md) workers can start without blocking
+  the browser main thread. On-demand Workers beyond the pool are fine; Node
+  `dtest` joins the board pool and drains pending Worker messages before
+  `terminateAllThreads` / `process.exit` so high `-n` does not race
+  `EXIT_RUNTIME`. Example binaries attach those flags via
+  `EXAMPLES_LINKOPTS_WASM` in `examples/BUILD.bazel`. `dtest` adds Node-oriented
+  flags (`ENVIRONMENT=node,worker`, `NODERAWFS`) under the same `build_wasm`
+  select. Under Emscripten, `System::get_hardware` still overrides free-memory
+  estimates but uses `hardware_concurrency` for core count (no forced
+  single-core clamp).
 - **Correctness is checked two ways.** `calc_dd_table_pbn_test` is a native
   `cc_test` over the same example logic (fast feedback without a JS runtime); the
   `wasm_examples_system_test` py_test runs `calc_dd_table_pbn_wasm` and
-  `dtest_wasm` under Node end to end. `run_dtest_wasm_test` covers the Node
-  runner helpers. The `all` and `wasm_system_tests`
-  suites bundle these.
+  `dtest_wasm` under Node end to end (including a multi-thread `dtest -n 2` case).
+  `run_dtest_wasm_test` covers the Node runner helpers. The `all` and
+  `wasm_system_tests` suites bundle these.
 
 ## Key entry points
 
@@ -65,7 +73,6 @@ core solver builds and runs correctly under Emscripten.
 
 - **Only three examples are ported**, not the full [examples-cli](examples-cli.md) set.
   `dtest_wasm` is an additional harness port, not an example CLI.
-- **No threaded WASM** — single-thread only.
 - **No link-time LTO.** `-flto` applies at WASM compile time only
   ([build-system](build-system.md)); enabling it at link time was tried and
   reverted because the `emsdk 5.0.7` toolchain pinned in `MODULE.bazel` ships a
@@ -75,5 +82,7 @@ core solver builds and runs correctly under Emscripten.
   Bazel's hermetic sandbox. Revisit only if the emsdk packaging ships a
   populated LTO cache.
 - Browser wiring, the site, MVP post-build JS patches (`web/patch_mvp_wasm.py`),
-  and JS/e2e tests belong to [web-mvp](web-mvp.md); this capability provides the example
-  modules, not the page.
+  COOP/COEP serving, and JS/e2e tests belong to [web-mvp](web-mvp.md); this
+  capability provides the example modules, not the page.
+- `-pthread` + `ALLOW_MEMORY_GROWTH` emits an Emscripten advisory
+  (`-Wpthreads-mem-growth`); kept intentionally for DDS's large TT heaps.

--- a/specs/web-mvp.md
+++ b/specs/web-mvp.md
@@ -1,7 +1,7 @@
 ---
 capability: web-mvp
 owners: [web]
-last-updated: 2026-07-19
+last-updated: 2026-07-24
 ---
 
 # Web MVP
@@ -24,24 +24,34 @@ a full application.
 > capability-wide facts.
 
 - **A dedicated, modularised WASM module — not the example CLIs.** `dds_mvp_wasm`
-  (`wasm_cc_binary` over `dds_mvp_wasm_cc`, source `dds_mvp_wasm.cpp`) is built
-  with `WASM_MVP_LINKOPTS`: `MODULARIZE=1`, `EXPORT_NAME=createDdsModule`,
-  a single exported entry `_dds_mvp_calc_table` (plus `_malloc`/`_free`),
-  `EXPORTED_RUNTIME_METHODS=['ccall','getValue']`, and `ENVIRONMENT=web,node`. This
-  is distinct from [wasm-emscripten](wasm-emscripten.md)'s example ports — the MVP wants one small,
+  (`wasm_cc_binary` over `dds_mvp_wasm_cc`, source `dds_mvp_wasm.cpp`,
+  `threads = "emscripten"`) is built with `WASM_MVP_LINKOPTS`: `MODULARIZE=1`,
+  `EXPORT_NAME=createDdsModule`, a single exported entry `_dds_mvp_calc_table`
+  (plus `_malloc`/`_free`), `EXPORTED_RUNTIME_METHODS=['ccall','getValue']`, and
+  `ENVIRONMENT=web,worker,node`. This is distinct from
+  [wasm-emscripten](wasm-emscripten.md)'s example ports — the MVP wants one small,
   callable table function, not a CLI. Shared base flags come from `WASM_LINKOPTS`
-  ([build-system](build-system.md)).
+  ([build-system](build-system.md)), including pthreads / `PTHREAD_POOL_SIZE`.
 - **The page is a static trio plus JS glue.** `dds_mvp.html` / `dds_mvp.css` /
   `dds_mvp.js` load the module (`createDdsModule`), marshal a deal into WASM
   memory, call `dds_mvp_calc_table` via `ccall`, and read results with `getValue`.
-  `mvp_site` (`tests/mvp_site.py`) serves the site for system/e2e tests. Helper
-  scripts `gen_wasm_bin_js.py`, `patch_mvp_wasm.py`, `verify_wasm_js.py` generate
-  and sanity-check the JS/wasm glue.
+  `mvp_site` (`tests/mvp_site.py`) stages the site and provides
+  `make_isolated_http_handler` (COOP/COEP) for system/e2e tests and
+  `web/serve_mvp.py`. Helper scripts `gen_wasm_bin_js.py`, `patch_mvp_wasm.py`,
+  `verify_wasm_js.py` generate and sanity-check the JS/wasm glue.
+- **Browser solves require cross-origin isolation.** Pthread WASM needs
+  `SharedArrayBuffer`, which Chromium only exposes when
+  `Cross-Origin-Opener-Policy: same-origin` and
+  `Cross-Origin-Embedder-Policy: require-corp` are set. Serve with
+  `python3 web/serve_mvp.py` (not plain `http.server`). `file://` remains useful
+  for UI-only checks; instantiating the solver module for a solve needs HTTP +
+  those headers. Guarded by `dds_mvp_e2e_test` (`test_http_is_cross_origin_isolated`,
+  HTTP part-score / Enter-to-solve).
 - **Three test tiers, with suite membership as wired in BUILD:**
   - **Unit / JS** (`web_tests`): `dds_mvp_wasm_test` (native `cc_test` over the
     solve logic with `DDS_MVP_WASM_NO_MAIN`), `dds_mvp_js_test` (Node runs
     `dds_mvp.js` against `dds_mvp_test.mjs`), `wasm_scripts_test` (the Python
-    helper scripts).
+    helper scripts + isolation-header constants).
   - **System + e2e bundle** (`web_system_tests`): includes both
     `dds_mvp_wasm_system_test` (stages wasm artifacts and runs a Node smoke via
     `dds_mvp_wasm_node.mjs`) **and** `dds_mvp_e2e_test`.
@@ -63,9 +73,9 @@ a full application.
   once) instead of allocating a fresh [solver-context](solver-context.md) per
   call. Because the context is shared, it is **not safe for concurrent
   solves** — a future move to Web Workers would need one context per worker.
-- **The MVP's WASM inherits the single-thread assumption** of
-  [wasm-emscripten](wasm-emscripten.md) — which is what makes sharing that
-  single context safe today; results come from the same [dds-public-api](dds-public-api.md) core.
+  The MVP table path itself remains sequential over strains; batch/multi-hand
+  APIs under [wasm-emscripten](wasm-emscripten.md) can use pthreads via
+  [system-concurrency](system-concurrency.md).
 
 ## Key entry points
 
@@ -74,6 +84,7 @@ a full application.
   `web_tests` / `web_system_tests` / `web_e2e_tests` suites; `WASM_MVP_LINKOPTS`.
 - `web/dds_mvp_wasm.cpp` — the MVP native entry (`dds_mvp_calc_table`).
 - `web/{dds_mvp.html,dds_mvp.css,dds_mvp.js}` — the page and JS glue.
+- `web/serve_mvp.py` — local HTTP server with COOP/COEP.
 - `web/{gen_wasm_bin_js,patch_mvp_wasm,verify_wasm_js}.py` — build/patch helpers.
 
 ## Known gaps / non-goals

--- a/wasm/BUILD.bazel
+++ b/wasm/BUILD.bazel
@@ -6,6 +6,7 @@ load("//:CPPVARIABLES.bzl", "DDS_CPPOPTS", "DDS_LOCAL_DEFINES")
 wasm_cc_binary(
     name = "solve_board_wasm",
     cc_target = "//examples:solve_board",
+    threads = "emscripten",
     outputs = [
         "solve_board.js",
         "solve_board.wasm",
@@ -15,6 +16,7 @@ wasm_cc_binary(
 wasm_cc_binary(
     name = "analyse_play_bin_wasm",
     cc_target = "//examples:AnalysePlayBin",
+    threads = "emscripten",
     outputs = [
         "AnalysePlayBin.js",
         "AnalysePlayBin.wasm",
@@ -24,6 +26,7 @@ wasm_cc_binary(
 wasm_cc_binary(
     name = "calc_dd_table_pbn_wasm",
     cc_target = "//examples:calc_dd_table_pbn",
+    threads = "emscripten",
     outputs = [
         "calc_dd_table_pbn.js",
         "calc_dd_table_pbn.wasm",
@@ -34,13 +37,14 @@ wasm_cc_binary(
 wasm_cc_binary(
     name = "dtest_wasm",
     cc_target = "//library/tests:dtest",
+    threads = "emscripten",
     outputs = [
         "dtest.js",
         "dtest.wasm",
     ],
 )
 
-# `bazel run //wasm:run_dtest_wasm -- -f hands/list1.txt -s solve -n 1`
+# `bazel run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2`
 py_binary(
     name = "run_dtest_wasm",
     srcs = ["run_dtest_wasm.py"],
@@ -93,6 +97,7 @@ py_test(
         ":calc_dd_table_pbn_wasm",
         ":dtest_wasm",
         "//hands:list1.txt",
+        "//hands:list2.txt",
     ],
 )
 

--- a/wasm/tests/test_wasm_examples_system.py
+++ b/wasm/tests/test_wasm_examples_system.py
@@ -58,6 +58,49 @@ class WasmExamplesSystemTest(unittest.TestCase):
         self.assertIn("Number of hands", proc.stdout)
         self.assertNotIn("ERROR", proc.stdout + proc.stderr)
 
+    def test_dtest_wasm_solve_list2_multithreaded(self) -> None:
+        """Threaded WASM must accept -n > 1 (std::thread / SharedArrayBuffer)."""
+        js = rlocation("wasm/dtest.js")
+        hands = rlocation("hands/list2.txt")
+        proc = subprocess.run(
+            ["node", str(js), "-f", str(hands), "-s", "solve", "-n", "2"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+            cwd=str(js.parent),
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        self.assertIn("dtest worker threads: 2", proc.stdout)
+        self.assertIn("Number of hands", proc.stdout)
+        self.assertNotIn("ERROR", proc.stdout + proc.stderr)
+
+    def test_dtest_wasm_calc_high_thread_count_no_terminated_workers(self) -> None:
+        """Clean pthread shutdown must not race Worker 'loaded' vs terminate."""
+        js = rlocation("wasm/dtest.js")
+        hands = rlocation("hands/list2.txt")
+        proc = subprocess.run(
+            ["node", str(js), "-f", str(hands), "-s", "calc", "-n", "16"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+            cwd=str(js.parent),
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        self.assertIn("dtest worker threads: 16", proc.stdout)
+        self.assertIn("Number of hands", proc.stdout)
+        self.assertNotIn("terminated worker", proc.stderr)
+        self.assertNotIn("ERROR", proc.stdout + proc.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wasm_compat.bzl
+++ b/wasm_compat.bzl
@@ -1,6 +1,8 @@
 """Shared attributes for WebAssembly (Emscripten) builds."""
 
 # Emscripten link flags for cc_binary targets wrapped by wasm_cc_binary.
+# Pair with wasm_cc_binary(threads = "emscripten") so the toolchain also
+# passes -pthread / USE_PTHREADS (SharedArrayBuffer + atomics).
 WASM_LINKOPTS = [
     "-sWASM=1",
     "-fwasm-exceptions",
@@ -8,4 +10,9 @@ WASM_LINKOPTS = [
     "-sINITIAL_MEMORY=268435456",
     # DDS search recursion needs more than Emscripten's 64KB default stack.
     "-sSTACK_SIZE=8388608",
+    # Pre-spawn a modest worker pool for browser responsiveness. Counts above
+    # this still allocate on demand; Node CLIs must shut the pool down cleanly
+    # before exit so pending Worker "loaded" messages are not raced with
+    # terminateAllThreads.
+    "-sPTHREAD_POOL_SIZE=8",
 ]

--- a/wasm_compat.bzl
+++ b/wasm_compat.bzl
@@ -6,6 +6,9 @@
 WASM_LINKOPTS = [
     "-sWASM=1",
     "-fwasm-exceptions",
+    # Growth + pthreads is intentional for DDS TT heaps; silence the advisory
+    # about slower non-wasm (JS) paths when the SharedArrayBuffer grows.
+    "-Wno-pthreads-mem-growth",
     "-sALLOW_MEMORY_GROWTH=1",
     "-sINITIAL_MEMORY=268435456",
     # DDS search recursion needs more than Emscripten's 64KB default stack.

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -5,12 +5,13 @@ load("//:CPPVARIABLES.bzl", "DDS_CPPOPTS", "DDS_LINKOPTS", "DDS_LOCAL_DEFINES")
 load("//:wasm_compat.bzl", "WASM_LINKOPTS")
 
 # Emscripten flags for the browser MVP (modularized, no auto-run main).
+# ENVIRONMENT includes worker for pthread bootstrap; Node stays for system tests.
 WASM_MVP_LINKOPTS = WASM_LINKOPTS + [
     "-sMODULARIZE=1",
     "-sEXPORT_NAME=createDdsModule",
     "-sEXPORTED_FUNCTIONS=['_dds_mvp_calc_table','_malloc','_free']",
     "-sEXPORTED_RUNTIME_METHODS=['ccall','getValue']",
-    "-sENVIRONMENT=web,node",
+    "-sENVIRONMENT=web,worker,node",
 ]
 
 cc_binary(
@@ -32,6 +33,7 @@ cc_binary(
 wasm_cc_binary(
     name = "dds_mvp_wasm",
     cc_target = ":dds_mvp_wasm_cc",
+    threads = "emscripten",
     outputs = [
         "dds_mvp_wasm.js",
         "dds_mvp_wasm.wasm",
@@ -72,6 +74,7 @@ py_test(
         "patch_mvp_wasm.py",
         "verify_wasm_js.py",
     ],
+    deps = [":mvp_site"],
 )
 
 py_test(

--- a/web/dds_mvp.html
+++ b/web/dds_mvp.html
@@ -7,9 +7,10 @@
      https://opensource.org/licenses/MIT
 
      Build WASM (from repo root): ./web/update_wasm.sh
-     Then open dds_mvp.html (file:// is OK). Hard-refresh if you rebuilt (Cmd+Shift+R).
-     Or serve this directory:
-       python3 -m http.server 8080 --directory web
+     Serve with cross-origin isolation (required for WASM threads):
+       python3 web/serve_mvp.py
+     Then open http://127.0.0.1:8080/dds_mvp.html
+     (file:// UI works; solving needs SharedArrayBuffer via HTTP + COOP/COEP.)
 -->
 
 <html lang="en">

--- a/web/patch_mvp_wasm.py
+++ b/web/patch_mvp_wasm.py
@@ -19,15 +19,16 @@ from pathlib import Path
 # Keep in sync with bazel_dep(name = "emsdk", version = "...") in MODULE.bazel.
 EXPECTED_EMSDK_BAZEL_DEP_VERSION = "5.0.7"
 
-# Emscripten ~3.1.x (emsdk 5.0.7): var isFileURI = (filename) => filename.startsWith('file://');
+# Emscripten 5.x (emsdk 5.0.7): var isFileURI = filename => filename.startsWith("file://");
+# Older emsdk also emitted parentheses around the parameter.
 UNPATCHED_IS_FILE_URI = re.compile(
-    r"var\s+isFileURI\s*=\s*\(\s*(\w+)\s*\)\s*=>\s*"
+    r"var\s+isFileURI\s*=\s*(?:\(\s*)?(\w+)(?:\s*\))?\s*=>\s*"
     r"\1\.startsWith\(\s*['\"]file://['\"]\s*\)\s*;",
 )
 
 # Already patched by a previous run of this script.
 PATCHED_IS_FILE_URI = re.compile(
-    r"var\s+isFileURI\s*=\s*\(\s*(\w+)\s*\)\s*=>\s*"
+    r"var\s+isFileURI\s*=\s*(?:\(\s*)?(\w+)(?:\s*\))?\s*=>\s*"
     r"\(\s*typeof\s+\1\s*===\s*['\"]string['\"]",
 )
 

--- a/web/serve_mvp.py
+++ b/web/serve_mvp.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Serve web/ with COOP/COEP so SharedArrayBuffer / WASM pthreads work."""
+from __future__ import annotations
+
+import argparse
+import http.server
+import sys
+from pathlib import Path
+
+# Allow `python3 web/serve_mvp.py` from the repo root without installing a package.
+_TESTS = Path(__file__).resolve().parent / "tests"
+if str(_TESTS) not in sys.path:
+    sys.path.insert(0, str(_TESTS))
+
+from mvp_site import CROSS_ORIGIN_ISOLATION_HEADERS, make_isolated_http_handler  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--directory",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="Directory to serve (default: web/)",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args()
+
+    directory = args.directory.resolve()
+    if not (directory / "dds_mvp.html").is_file():
+        print(f"error: {directory}/dds_mvp.html not found", file=sys.stderr)
+        return 1
+
+    handler = make_isolated_http_handler(directory, quiet=False)
+
+    httpd = http.server.ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"Serving {directory} at http://{args.host}:{args.port}/dds_mvp.html")
+    print(
+        "Cross-origin isolation:",
+        ", ".join(f"{k}: {v}" for k, v in CROSS_ORIGIN_ISOLATION_HEADERS.items()),
+    )
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/tests/mvp_site.py
+++ b/web/tests/mvp_site.py
@@ -89,7 +89,7 @@ def make_isolated_http_handler(
                 self.send_header(key, value)
             super().end_headers()
 
-        def log_message(self, format: str, *args) -> None:  # noqa: A003
+        def log_message(self, format: str, *args) -> None:  # noqa: A002
             if not quiet:
                 super().log_message(format, *args)
 

--- a/web/tests/mvp_site.py
+++ b/web/tests/mvp_site.py
@@ -1,12 +1,19 @@
 """Stage a self-contained DDS MVP site directory for tests."""
 from __future__ import annotations
 
+import http.server
 import importlib.util
 import os
 import shutil
 from pathlib import Path
 
 STATIC_FILES = ("dds_mvp.html", "dds_mvp.css", "dds_mvp.js")
+
+# Required for SharedArrayBuffer / WASM pthreads in Chromium.
+CROSS_ORIGIN_ISOLATION_HEADERS = {
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Embedder-Policy": "require-corp",
+}
 
 
 def runfiles_root() -> Path:
@@ -63,3 +70,27 @@ def stage_mvp_site(dest: Path) -> Path:
         encoding="utf-8",
     )
     return dest
+
+
+def make_isolated_http_handler(
+    directory: Path,
+    *,
+    quiet: bool = True,
+) -> type[http.server.SimpleHTTPRequestHandler]:
+    """HTTP handler that serves *directory* with cross-origin isolation headers."""
+    root = str(directory)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, request, client_address, server) -> None:
+            super().__init__(request, client_address, server, directory=root)
+
+        def end_headers(self) -> None:
+            for key, value in CROSS_ORIGIN_ISOLATION_HEADERS.items():
+                self.send_header(key, value)
+            super().end_headers()
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A003
+            if not quiet:
+                super().log_message(format, *args)
+
+    return Handler

--- a/web/tests/test_mvp_e2e.py
+++ b/web/tests/test_mvp_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end browser tests for web/dds_mvp.html (file:// and HTTP)."""
+"""End-to-end browser tests for web/dds_mvp.html (file:// UI and isolated HTTP)."""
 from __future__ import annotations
 
 import http.server
@@ -11,7 +11,7 @@ import threading
 import unittest
 from pathlib import Path
 
-from mvp_site import stage_mvp_site
+from mvp_site import CROSS_ORIGIN_ISOLATION_HEADERS, make_isolated_http_handler, stage_mvp_site
 
 try:
     from playwright.sync_api import sync_playwright
@@ -52,16 +52,6 @@ def _ensure_playwright_chromium(browsers_dir: Path) -> None:
         )
 
 
-def _make_http_handler(directory: Path) -> type[http.server.SimpleHTTPRequestHandler]:
-    root = str(directory)
-
-    class Handler(http.server.SimpleHTTPRequestHandler):
-        def __init__(self, request, client_address, server) -> None:
-            super().__init__(request, client_address, server, directory=root)
-
-    return Handler
-
-
 class _HttpSite:
     def __init__(self, directory: Path) -> None:
         self._directory = directory
@@ -72,7 +62,7 @@ class _HttpSite:
     def __enter__(self) -> _HttpSite:
         self._httpd = http.server.ThreadingHTTPServer(
             ("127.0.0.1", 0),
-            _make_http_handler(self._directory),
+            make_isolated_http_handler(self._directory),
         )
         port = self._httpd.server_address[1]
         self.url = f"http://127.0.0.1:{port}/dds_mvp.html"
@@ -283,16 +273,36 @@ class DdsMvpHtmlE2eTest(unittest.TestCase):
         finally:
             page.close()
 
-    def test_file_url_part_score_table(self) -> None:
-        url = self.site_dir.joinpath("dds_mvp.html").as_uri()
-        page, errors = self._open_page(url)
-        try:
-            self._fill_part_score_deal(page)
-            self._run_double_dummy(page)
-            self._assert_part_score_table(page)
-            self.assertEqual(errors, [])
-        finally:
-            page.close()
+    def test_http_is_cross_origin_isolated(self) -> None:
+        with _HttpSite(self.site_dir) as site:
+            page, errors = self._open_page(site.url)
+            try:
+                self.assertTrue(page.evaluate("() => window.crossOriginIsolated"))
+                self.assertTrue(
+                    page.evaluate("() => typeof SharedArrayBuffer === 'function'")
+                )
+                headers = page.evaluate(
+                    """async () => {
+                      const res = await fetch(location.href, { cache: 'no-store' });
+                      return {
+                        coop: res.headers.get('Cross-Origin-Opener-Policy'),
+                        coep: res.headers.get('Cross-Origin-Embedder-Policy'),
+                      };
+                    }"""
+                )
+                self.assertEqual(
+                    headers["coop"], CROSS_ORIGIN_ISOLATION_HEADERS[
+                        "Cross-Origin-Opener-Policy"
+                    ]
+                )
+                self.assertEqual(
+                    headers["coep"], CROSS_ORIGIN_ISOLATION_HEADERS[
+                        "Cross-Origin-Embedder-Policy"
+                    ]
+                )
+                self.assertEqual(errors, [])
+            finally:
+                page.close()
 
     def test_http_part_score_table(self) -> None:
         with _HttpSite(self.site_dir) as site:
@@ -318,26 +328,28 @@ class DdsMvpHtmlE2eTest(unittest.TestCase):
             page.close()
 
     def test_enter_runs_double_dummy_after_loading_a_complete_deal(self) -> None:
-        page, errors = self._open_page(self.site_dir.joinpath("dds_mvp.html").as_uri())
-        try:
-            self._fill_part_score_deal(page)
+        # Solving needs SharedArrayBuffer → cross-origin isolation → HTTP only.
+        with _HttpSite(self.site_dir) as site:
+            page, errors = self._open_page(site.url)
+            try:
+                self._fill_part_score_deal(page)
 
-            page.wait_for_function(
-                "() => document.activeElement && document.activeElement.id === 'double-dummy-it'"
-            )
-            page.keyboard.press("Enter")
-            page.wait_for_function(
-                """() => {
-                const cell = document.getElementById('result-table').rows[1].cells[1];
-                return cell && /^\\d+$/.test(cell.textContent.trim());
-              }""",
-                timeout=120_000,
-            )
+                page.wait_for_function(
+                    "() => document.activeElement && document.activeElement.id === 'double-dummy-it'"
+                )
+                page.keyboard.press("Enter")
+                page.wait_for_function(
+                    """() => {
+                    const cell = document.getElementById('result-table').rows[1].cells[1];
+                    return cell && /^\\d+$/.test(cell.textContent.trim());
+                  }""",
+                    timeout=120_000,
+                )
 
-            self._assert_part_score_table(page)
-            self.assertEqual(errors, [])
-        finally:
-            page.close()
+                self._assert_part_score_table(page)
+                self.assertEqual(errors, [])
+            finally:
+                page.close()
 
     def test_double_dummy_disabled_on_incomplete_deal(self) -> None:
         page, errors = self._open_page(self.site_dir.joinpath("dds_mvp.html").as_uri())

--- a/web/tests/test_wasm_scripts.py
+++ b/web/tests/test_wasm_scripts.py
@@ -26,6 +26,9 @@ gen_wasm_bin_js = _load_module("gen_wasm_bin_js")
 verify_wasm_js = _load_module("verify_wasm_js")
 
 UNPATCHED_LINE = (
+    'var isFileURI = filename => filename.startsWith("file://");\n'
+)
+UNPATCHED_LINE_PAREN = (
     "var isFileURI = (filename) => filename.startsWith('file://');\n"
 )
 
@@ -40,6 +43,11 @@ class PatchMvpWasmTest(unittest.TestCase):
         updated, code = patch_mvp_wasm.patch_text(UNPATCHED_LINE)
         self.assertEqual(code, 0)
         self.assertNotEqual(updated, UNPATCHED_LINE)
+        self.assertRegex(updated, patch_mvp_wasm.PATCHED_IS_FILE_URI)
+
+    def test_patch_text_replaces_parenthesized_param(self) -> None:
+        updated, code = patch_mvp_wasm.patch_text(UNPATCHED_LINE_PAREN)
+        self.assertEqual(code, 0)
         self.assertRegex(updated, patch_mvp_wasm.PATCHED_IS_FILE_URI)
 
     def test_patch_text_idempotent(self) -> None:
@@ -147,6 +155,20 @@ class VerifyWasmJsTest(unittest.TestCase):
         )
         self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
         self.assertIn("compile OK", proc.stdout)
+
+
+class IsolationHeadersTest(unittest.TestCase):
+    def test_cross_origin_isolation_headers(self) -> None:
+        from mvp_site import CROSS_ORIGIN_ISOLATION_HEADERS
+
+        self.assertEqual(
+            CROSS_ORIGIN_ISOLATION_HEADERS["Cross-Origin-Opener-Policy"],
+            "same-origin",
+        )
+        self.assertEqual(
+            CROSS_ORIGIN_ISOLATION_HEADERS["Cross-Origin-Embedder-Policy"],
+            "require-corp",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Link Emscripten targets with -pthread, serve the MVP under COOP/COEP, join the board pool before exit so high -n does not race Worker teardown, and have dtest report sys time as n/a when clock() is unusable on wasm32.