### PR TITLE
Declare UTF-8 in the MVP HTML so suit glyphs render correctly.

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -143,6 +143,7 @@ py_test(
 test_suite(
     name = "web_tests",
     tests = [
+        ":dds_mvp_html_test",
         ":dds_mvp_js_test",
         ":dds_mvp_wasm_test",
         ":wasm_scripts_test",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -75,6 +75,14 @@ py_test(
 )
 
 py_test(
+    name = "dds_mvp_html_test",
+    size = "small",
+    main = "tests/test_mvp_html.py",
+    srcs = ["tests/test_mvp_html.py"],
+    data = ["dds_mvp.html"],
+)
+
+py_test(
     name = "dds_mvp_js_test",
     size = "small",
     timeout = "short",

--- a/web/dds_mvp.html
+++ b/web/dds_mvp.html
@@ -14,6 +14,7 @@
 
 <html lang="en">
 <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="dds_mvp.css">
     <title>
         DDS MVP

--- a/web/tests/test_mvp_e2e.py
+++ b/web/tests/test_mvp_e2e.py
@@ -298,6 +298,11 @@ class DdsMvpHtmlE2eTest(unittest.TestCase):
         with _HttpSite(self.site_dir) as site:
             page, errors = self._open_page(site.url)
             try:
+                self.assertEqual(
+                    page.evaluate("() => document.characterSet"),
+                    "UTF-8",
+                    msg="HTTP must decode HTML as UTF-8 so suit glyphs are not mojibake",
+                )
                 self._fill_part_score_deal(page)
                 self._run_double_dummy(page)
                 self._assert_part_score_table(page)

--- a/web/tests/test_mvp_html.py
+++ b/web/tests/test_mvp_html.py
@@ -1,0 +1,43 @@
+"""Static checks for web/dds_mvp.html encoding."""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+WEB_ROOT = Path(__file__).resolve().parents[1]
+HTML_PATH = WEB_ROOT / "dds_mvp.html"
+
+
+class DdsMvpHtmlCharsetTest(unittest.TestCase):
+    def test_declares_utf8_charset_within_first_1024_bytes(self) -> None:
+        # Browsers only honor <meta charset> in the first 1024 bytes. Without it,
+        # servers that send Content-Type: text/html (no charset) may decode
+        # suit glyphs (♠♥♦♣) as Latin-1/Windows-1252 mojibake.
+        raw = HTML_PATH.read_bytes()
+        prefix = raw[:1024].lower()
+        self.assertRegex(
+            prefix,
+            rb'<meta\s+charset\s*=\s*["\']?utf-8["\']?\s*/?>',
+            msg="dds_mvp.html must declare UTF-8 early so suit symbols render",
+        )
+
+    def test_meta_charset_is_first_in_head(self) -> None:
+        text = HTML_PATH.read_text(encoding="utf-8")
+        head_match = re.search(r"<head\b[^>]*>(.*?)</head>", text, re.I | re.S)
+        self.assertIsNotNone(head_match)
+        head_inner = head_match.group(1).lstrip()
+        self.assertRegex(
+            head_inner,
+            r'(?is)^<meta\s+charset\s*=\s*["\']?utf-8["\']?\s*/?>',
+            msg="<meta charset=utf-8> must be the first tag in <head>",
+        )
+
+    def test_html_contains_utf8_suit_glyphs(self) -> None:
+        text = HTML_PATH.read_text(encoding="utf-8")
+        for glyph in ("♠", "♥", "♦", "♣"):
+            self.assertIn(glyph, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Servers that omit charset from Content-Type were decoding ♠♥♦♣ as Latin-1 mojibake; pin encoding in <head> and cover it with tests.