### PR TITLE
Catch process_board exceptions in the board worker pool.

### DIFF
--- a/library/src/system/parallel_boards.cpp
+++ b/library/src/system/parallel_boards.cpp
@@ -176,11 +176,11 @@ private:
         catch (...)
         {
           // process_board must not leave the pool hanging or abort the process
-          // via std::terminate. Record a fault and fall through to the finished
-          // accounting below so cv_done_ is always signaled for this worker.
-          int expected = RETURN_NO_FAULT;
-          local.first_error->compare_exchange_strong(
-            expected, RETURN_UNKNOWN_FAULT, std::memory_order_relaxed);
+          // via std::terminate. Any throw maps the run to RETURN_UNKNOWN_FAULT
+          // (even if another worker already recorded a non-success return code),
+          // then fall through to finished accounting so cv_done_ is signaled.
+          local.first_error->store(
+            RETURN_UNKNOWN_FAULT, std::memory_order_relaxed);
         }
         // Account completion under mu_ so (1) the predicate change cannot race
         // with cv_done_.wait's check-and-sleep (lost wakeup) and (2) unlocking

--- a/library/src/system/parallel_boards.cpp
+++ b/library/src/system/parallel_boards.cpp
@@ -149,26 +149,38 @@ private:
       // only the selected prefix participates and signals completion.
       if (worker_id < local.workers)
       {
-        for (;;)
+        try
         {
-          const int slot = local.next->fetch_add(1, std::memory_order_relaxed);
-          if (slot >= local.count ||
-              local.first_error->load(std::memory_order_relaxed) != RETURN_NO_FAULT)
+          for (;;)
           {
-            break;
+            const int slot = local.next->fetch_add(1, std::memory_order_relaxed);
+            if (slot >= local.count ||
+                local.first_error->load(std::memory_order_relaxed) != RETURN_NO_FAULT)
+            {
+              break;
+            }
+            const int bno =
+              local.use_order
+                ? (*local.order)[static_cast<unsigned>(slot)]
+                : slot;
+            const int rc = (*local.process_board)(worker_id, bno);
+            if (rc != RETURN_NO_FAULT)
+            {
+              int expected = RETURN_NO_FAULT;
+              local.first_error->compare_exchange_strong(
+                expected, rc, std::memory_order_relaxed);
+              break;
+            }
           }
-          const int bno =
-            local.use_order
-              ? (*local.order)[static_cast<unsigned>(slot)]
-              : slot;
-          const int rc = (*local.process_board)(worker_id, bno);
-          if (rc != RETURN_NO_FAULT)
-          {
-            int expected = RETURN_NO_FAULT;
-            local.first_error->compare_exchange_strong(
-              expected, rc, std::memory_order_relaxed);
-            break;
-          }
+        }
+        catch (...)
+        {
+          // process_board must not leave the pool hanging or abort the process
+          // via std::terminate. Record a fault and fall through to the finished
+          // accounting below so cv_done_ is always signaled for this worker.
+          int expected = RETURN_NO_FAULT;
+          local.first_error->compare_exchange_strong(
+            expected, RETURN_UNKNOWN_FAULT, std::memory_order_relaxed);
         }
         // Account completion under mu_ so (1) the predicate change cannot race
         // with cv_done_.wait's check-and-sleep (lost wakeup) and (2) unlocking

--- a/library/src/system/parallel_boards.hpp
+++ b/library/src/system/parallel_boards.hpp
@@ -38,6 +38,9 @@ auto resolve_worker_count(int max_threads, int count) -> int;
  *        non-null, the vector must remain valid and must not be mutated until
  *        this function returns because worker threads read it concurrently.
  * @return First non-success code from @p process_board, or RETURN_NO_FAULT.
+ *         If @p process_board throws during a multi-worker run, the exception is
+ *         caught on the worker, the run returns RETURN_UNKNOWN_FAULT, and the
+ *         pool stays usable. Single-worker runs leave exceptions to the caller.
  *
  * Multi-worker runs use a process-local persistent thread pool so consecutive
  * calls reuse OS threads instead of create/join each time. Single-worker runs

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -237,11 +237,15 @@ TEST(ParallelAllBoards, ProcessBoardExceptionDoesNotHangCaller)
 
   // packaged_task owns the shared state; if wait times out we can detach the
   // thread without UAF when locals here are destroyed (unlike a promise
-  // captured by reference).
+  // captured by reference). Define count/workers inside the lambda so MSVC
+  // does not require a capture (C3493) and clang does not warn about an
+  // unnecessary one (-Wunused-lambda-capture).
   std::packaged_task<int()> task([] {
+    constexpr int board_count = 8;
+    constexpr int worker_count = 2;
     return parallel_all_boards_n(
-      count,
-      workers,
+      board_count,
+      worker_count,
       [](const int, const int bno) -> int {
         if (bno == 0)
           throw std::runtime_error("process_board failed");
@@ -275,8 +279,6 @@ TEST(ParallelAllBoards, ProcessBoardExceptionOverridesPriorReturnCode)
   if (std::thread::hardware_concurrency() < 2)
     GTEST_SKIP() << "Need at least 2 hardware threads";
 
-  constexpr int count = 2;
-  constexpr int workers = 2;
   constexpr auto deadline = std::chrono::seconds(10);
 
   // Heap-backed sync so a timeout detach cannot UAF stack atomics.
@@ -288,9 +290,11 @@ TEST(ParallelAllBoards, ProcessBoardExceptionOverridesPriorReturnCode)
   const auto sync = std::make_shared<Sync>();
 
   std::packaged_task<int()> task([sync] {
+    constexpr int board_count = 2;
+    constexpr int worker_count = 2;
     return parallel_all_boards_n(
-      count,
-      workers,
+      board_count,
+      worker_count,
       [sync](const int, const int bno) -> int {
         if (bno == 0)
         {

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <future>
 #include <new>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -219,6 +220,49 @@ TEST(ParallelAllBoards, FailFastReturnsFirstError)
 
   // Assert
   EXPECT_EQ(result, RETURN_TOO_MANY_BOARDS);
+}
+
+TEST(ParallelAllBoards, ProcessBoardExceptionDoesNotHangCaller)
+{
+  // If process_board throws on a pool worker, that worker must still account
+  // completion and wake cv_done_; otherwise the caller waits forever (or the
+  // process aborts via std::terminate when the exception leaves the thread).
+  if (std::thread::hardware_concurrency() < 2)
+    GTEST_SKIP() << "Need at least 2 hardware threads";
+
+  constexpr int count = 8;
+  constexpr int workers = 2;
+  constexpr auto deadline = std::chrono::seconds(10);
+
+  std::promise<int> done;
+  std::future<int> fut = done.get_future();
+  std::thread caller([&] {
+    const int rc = parallel_all_boards_n(
+      count,
+      workers,
+      [](const int, const int bno) -> int {
+        if (bno == 0)
+          throw std::runtime_error("process_board failed");
+        return RETURN_NO_FAULT;
+      });
+    done.set_value(rc);
+  });
+
+  const bool ready = fut.wait_for(deadline) == std::future_status::ready;
+  if (!ready)
+  {
+    caller.detach();
+    FAIL() << "caller hung after process_board threw on a pool worker";
+  }
+  caller.join();
+
+  EXPECT_EQ(fut.get(), RETURN_UNKNOWN_FAULT);
+
+  // Pool workers must remain usable after the exceptional run.
+  EXPECT_EQ(
+    parallel_all_boards_n(
+      count, workers, [](const int, const int) { return RETURN_NO_FAULT; }),
+    RETURN_NO_FAULT);
 }
 
 TEST(ParallelAllBoards, ConcurrentCallersBothCompleteAndProcessAllBoards)

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <functional>
 #include <future>
+#include <memory>
 #include <new>
 #include <stdexcept>
 #include <thread>
@@ -234,10 +235,11 @@ TEST(ParallelAllBoards, ProcessBoardExceptionDoesNotHangCaller)
   constexpr int workers = 2;
   constexpr auto deadline = std::chrono::seconds(10);
 
-  std::promise<int> done;
-  std::future<int> fut = done.get_future();
-  std::thread caller([&] {
-    const int rc = parallel_all_boards_n(
+  // packaged_task owns the shared state; if wait times out we can detach the
+  // thread without UAF when locals here are destroyed (unlike a promise
+  // captured by reference).
+  std::packaged_task<int()> task([] {
+    return parallel_all_boards_n(
       count,
       workers,
       [](const int, const int bno) -> int {
@@ -245,8 +247,9 @@ TEST(ParallelAllBoards, ProcessBoardExceptionDoesNotHangCaller)
           throw std::runtime_error("process_board failed");
         return RETURN_NO_FAULT;
       });
-    done.set_value(rc);
   });
+  std::future<int> fut = task.get_future();
+  std::thread caller(std::move(task));
 
   const bool ready = fut.wait_for(deadline) == std::future_status::ready;
   if (!ready)
@@ -263,6 +266,59 @@ TEST(ParallelAllBoards, ProcessBoardExceptionDoesNotHangCaller)
     parallel_all_boards_n(
       count, workers, [](const int, const int) { return RETURN_NO_FAULT; }),
     RETURN_NO_FAULT);
+}
+
+TEST(ParallelAllBoards, ProcessBoardExceptionOverridesPriorReturnCode)
+{
+  // Contract: any thrown exception maps the run to RETURN_UNKNOWN_FAULT, even
+  // when another worker has already recorded a non-success return code.
+  if (std::thread::hardware_concurrency() < 2)
+    GTEST_SKIP() << "Need at least 2 hardware threads";
+
+  constexpr int count = 2;
+  constexpr int workers = 2;
+  constexpr auto deadline = std::chrono::seconds(10);
+
+  // Heap-backed sync so a timeout detach cannot UAF stack atomics.
+  struct Sync
+  {
+    std::atomic<bool> board1_started{false};
+    std::atomic<bool> board0_returned_error{false};
+  };
+  const auto sync = std::make_shared<Sync>();
+
+  std::packaged_task<int()> task([sync] {
+    return parallel_all_boards_n(
+      count,
+      workers,
+      [sync](const int, const int bno) -> int {
+        if (bno == 0)
+        {
+          while (!sync->board1_started.load(std::memory_order_acquire))
+            std::this_thread::yield();
+          sync->board0_returned_error.store(true, std::memory_order_release);
+          return RETURN_TOO_MANY_BOARDS;
+        }
+        sync->board1_started.store(true, std::memory_order_release);
+        while (!sync->board0_returned_error.load(std::memory_order_acquire))
+          std::this_thread::yield();
+        // Let the other worker's compare_exchange publish first_error first.
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        throw std::runtime_error("process_board failed after prior error");
+      });
+  });
+  std::future<int> fut = task.get_future();
+  std::thread caller(std::move(task));
+
+  const bool ready = fut.wait_for(deadline) == std::future_status::ready;
+  if (!ready)
+  {
+    caller.detach();
+    FAIL() << "caller hung when exception raced with a prior return code";
+  }
+  caller.join();
+
+  EXPECT_EQ(fut.get(), RETURN_UNKNOWN_FAULT);
 }
 
 TEST(ParallelAllBoards, ConcurrentCallersBothCompleteAndProcessAllBoards)

--- a/specs/system-concurrency.md
+++ b/specs/system-concurrency.md
@@ -1,7 +1,7 @@
 ---
 capability: system-concurrency
 owners: [system]
-last-updated: 2026-07-23
+last-updated: 2026-07-24
 ---
 
 # System & Concurrency
@@ -38,7 +38,12 @@ place so the search and API layers stay portable. It is internal — not part of
   duplicates) to control dispatch priority; a malformed `order` **falls back to
   index order** rather than rejecting. Each `process_board(worker_id, bno)` must
   return `RETURN_NO_FAULT` (1) on success. The function returns the **first
-  non-success code** encountered (or `RETURN_NO_FAULT`). Multi-worker runs use a
+  non-success code** encountered (or `RETURN_NO_FAULT`). If `process_board`
+  throws during a multi-worker run, the worker catches it, the run returns
+  `RETURN_UNKNOWN_FAULT`, and the pool remains usable (an uncaught throw would
+  otherwise abort via `std::terminate` / leave the caller waiting on
+  completion). Single-worker runs leave exceptions to the caller. Multi-worker
+  runs use a
   process-local persistent thread pool (grow-only) so consecutive calls reuse OS
   threads; `workers == 1` stays on the calling thread. Concurrent multi-worker
   callers serialize on the pool, but the API is **not re-entrant** from inside


### PR DESCRIPTION
An uncaught throw on a pool thread aborted via std::terminate and skipped completion signaling; map it to RETURN_UNKNOWN_FAULT and keep the pool usable.