### PR TITLE
Silence Homebrew aws/tap trust warnings on macOS CI

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -20,7 +20,11 @@ jobs:
 
       # Install Doxygen, to generate documentation
       - name: Install Doxygen
-        run: brew install doxygen
+        run: |
+          # GitHub macOS runners ship aws/tap untrusted under Homebrew 6;
+          # untap it so brew install does not warn on every run.
+          brew untap aws/tap || true
+          brew install doxygen
 
       # Prefetch external repos (emsdk via //..., LLVM); retry network flakes only
       - name: Prefetch external repos


### PR DESCRIPTION
## Summary
- Untap the untrusted `aws/tap` that ships on GitHub-hosted macOS runners before `brew install doxygen`, so Homebrew 6 no longer emits tap-trust warnings on every macOS CI run.

## Test plan
- [ ] Confirm macOS CI `Install Doxygen` step no longer annotates `aws/tap` trust warnings
- [ ] Confirm `doxygen` still installs and the rest of the macOS workflow passes


Made with [Cursor](https://cursor.com)