### PR TITLE
docs: recommend bazelisk for Python tests instead of raw pytest

### DIFF
--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -40,23 +40,11 @@ For wheel packaging, the extension is also copied into the package as `dds3/_dds
 python -m venv venv
 source venv/bin/activate
 
-# Install pytest (if not already installed)
-pip install pytest
-```
-
-### Running Unit Tests
 ```bash
-# Set PYTHONPATH to include source package and top-level extension fallback
-export PYTHONPATH=python:bazel-bin/python
-
-# Run Bazel smoke test for Python bindings
-bazel test //python:python_interface_smoke_test
-
-# Or use pytest directly
-pytest python/tests/ -v
-
-# Run specific test file
-pytest python/tests/test_solve_board.py -v
+# Run all Python tests via Bazelisk (recommended)
+bazelisk test //python/...
+# Run a specific test
+bazelisk test //python:solve_board_test
 ```
 
 ### Test Coverage


### PR DESCRIPTION
The Running Unit Tests section recommended raw `pytest` with manual 
`PYTHONPATH` setup, which fails on Python 3.12 due to missing `iniconfig` 
and `PyThreadState_GetUnchecked` symbol errors when loading `_dds3.so`.

Replace with `bazelisk test //python/...` which handles the Python 
extension path automatically and works out of the box.

Tested on Linux (Python 3.12, Ubuntu 24.04).