### PR TITLE
Cap WASM parallel workers under a heap budget, Emscripten-only.

### DIFF
--- a/library/src/system/parallel_boards.cpp
+++ b/library/src/system/parallel_boards.cpp
@@ -18,6 +18,9 @@
 #include <thread>
 #include <vector>
 
+#if defined(__EMSCRIPTEN__)
+#include <api/dds.h>
+#endif
 #include <api/dll.h>
 
 
@@ -237,6 +240,18 @@ auto default_pool() -> std::shared_ptr<BoardWorkerPool>
 }  // namespace
 
 
+auto clamp_workers_to_memory_budget(
+  const int workers,
+  const int budget_mb,
+  const int per_worker_mb) -> int
+{
+  const int safe_workers = std::max(1, workers);
+  if (budget_mb <= 0 || per_worker_mb <= 0)
+    return safe_workers;
+  return std::max(1, std::min(safe_workers, budget_mb / per_worker_mb));
+}
+
+
 auto resolve_worker_count(
   const int max_threads,
   const int count) -> int
@@ -247,7 +262,19 @@ auto resolve_worker_count(
     const unsigned hw = std::thread::hardware_concurrency();
     workers = hw > 0 ? static_cast<int>(hw) : 1;
   }
-  return std::max(1, std::min(workers, count));
+  workers = std::max(1, std::min(workers, count));
+
+  // Parallel workers each keep a Large TT (via SolverContext). Under
+  // Emscripten the wasm32 heap cannot grow past ~2 GiB; uncapped auto
+  // (= HW concurrency) OOMs large multi-board batches. Native builds keep
+  // the uncapped count — this block must stay __EMSCRIPTEN__-only.
+#if defined(__EMSCRIPTEN__)
+  constexpr int kHeapBudgetMB = 1400;
+  constexpr int kPerWorkerMB = THREADMEM_LARGE_DEF_MB + 24;
+  workers = clamp_workers_to_memory_budget(workers, kHeapBudgetMB, kPerWorkerMB);
+#endif
+
+  return workers;
 }
 
 

--- a/library/src/system/parallel_boards.hpp
+++ b/library/src/system/parallel_boards.hpp
@@ -15,6 +15,23 @@
 
 
 /**
+ * @brief Clamp a worker count to a memory budget (MB).
+ *
+ * Each parallel worker owns a SolverContext with a Large transposition table
+ * plus stack; under Emscripten the wasm32 heap tops out near 2 GiB.
+ * resolve_worker_count applies this only when __EMSCRIPTEN__ is defined.
+ *
+ * @param workers Requested workers (values < 1 become 1)
+ * @param budget_mb Total MB available for worker TT/stack footprints
+ * @param per_worker_mb Assumed MB cost of one worker
+ * @return workers clamped to max(1, budget_mb / per_worker_mb)
+ */
+auto clamp_workers_to_memory_budget(
+  int workers,
+  int budget_mb,
+  int per_worker_mb) -> int;
+
+/**
  * @brief Resolve the number of worker threads to use.
  *
  * @param max_threads Requested cap; <= 0 means "auto" (use hardware concurrency).

--- a/library/tests/system/worker_count_test.cpp
+++ b/library/tests/system/worker_count_test.cpp
@@ -2,12 +2,14 @@
 /// @brief Unit tests for resolve_worker_count (batch worker-count resolution).
 ///
 /// Validates the shared helper that maps an optional max_threads cap and a work
-/// item count onto the number of worker threads to use.
+/// item count onto the number of worker threads to use. The WASM heap worker
+/// budget is applied only under Emscripten; native builds must stay uncapped.
 
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <thread>
 
+#include <api/dds.h>
 #include <system/parallel_boards.hpp>
 
 namespace
@@ -47,3 +49,45 @@ TEST(ResolveWorkerCount, SingleItemAlwaysOneWorker)
   EXPECT_EQ(resolve_worker_count(16, 1), 1);
   EXPECT_EQ(resolve_worker_count(1, 1), 1);
 }
+
+TEST(ClampWorkersToMemoryBudget, CapsByBudgetPerWorker)
+{
+  constexpr int kPerWorkerMB = THREADMEM_LARGE_DEF_MB + 24;
+  EXPECT_EQ(clamp_workers_to_memory_budget(18, 1400, kPerWorkerMB), 11);
+  EXPECT_EQ(clamp_workers_to_memory_budget(4, 1400, kPerWorkerMB), 4);
+  EXPECT_EQ(clamp_workers_to_memory_budget(0, 1400, kPerWorkerMB), 1);
+  EXPECT_EQ(clamp_workers_to_memory_budget(8, 100, 200), 1);
+}
+
+TEST(ClampWorkersToMemoryBudget, PlatformCapMatchesWasmBudgetConstants)
+{
+  // Document the Emscripten budget used by resolve_worker_count so a quiet
+  // change to THREADMEM_* cannot silently re-OOM large WASM batches.
+  constexpr int kHeapBudgetMB = 1400;
+  constexpr int kPerWorkerMB = THREADMEM_LARGE_DEF_MB + 24;
+  constexpr int kExpectedCap = kHeapBudgetMB / kPerWorkerMB;
+  static_assert(kExpectedCap >= 1);
+  EXPECT_EQ(kExpectedCap, 11);
+  EXPECT_EQ(
+    clamp_workers_to_memory_budget(64, kHeapBudgetMB, kPerWorkerMB),
+    kExpectedCap);
+}
+
+#if defined(__EMSCRIPTEN__)
+TEST(ResolveWorkerCount, WasmMemoryCapLimitsAutoWorkers)
+{
+  constexpr int kHeapBudgetMB = 1400;
+  constexpr int kPerWorkerMB = THREADMEM_LARGE_DEF_MB + 24;
+  const int mem_cap = kHeapBudgetMB / kPerWorkerMB;
+  EXPECT_EQ(resolve_worker_count(0, 5000), std::min(auto_workers(5000), mem_cap));
+  EXPECT_EQ(resolve_worker_count(64, 5000), mem_cap);
+}
+#else
+TEST(ResolveWorkerCount, NativeBuildsDoNotApplyWasmMemoryCap)
+{
+  // Explicit high caps must remain uncapped on native hosts; the WASM heap
+  // budget is Emscripten-only (#if defined(__EMSCRIPTEN__)).
+  EXPECT_EQ(resolve_worker_count(64, 5000), 64);
+  EXPECT_EQ(resolve_worker_count(0, 5000), auto_workers(5000));
+}
+#endif


### PR DESCRIPTION
Do not request more than 2GB RAM from WASM, its limit. The messages generated upon exceeding it are apparently harmless, but best to avoid them. 

```
$ bazel run //wasm:run_dtest_wasm -- -f hands/list1000.txt -s calc
```

…
```
Cannot enlarge memory, requested 2150969344 bytes, but the limit is 2147483648 bytes!
```
…

Keep the clamp behind __EMSCRIPTEN__ so native resolve_worker_count stays uncapped.
```