### PR TITLE
Bug fix: bazel-bin/library/tests/dtest -f NNNN did not work when invoked from the repo root

### DIFF
--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -197,6 +197,9 @@ void SetDefaults()
 }
 
 
+namespace
+{
+
 bool is_absolute_path(const string& path)
 {
   if (path.empty())
@@ -305,6 +308,8 @@ string absolute_path_logical(const string& path)
     return normalize_logical_path(string(cwd));
   return normalize_logical_path(string(cwd) + "/" + path);
 }
+
+}  // namespace
 
 
 string resolve_dtest_input_file(

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -432,8 +432,9 @@ void read_args(
 
         cout << "Input file '" << optarg << "' not found\n";
         cout << "Also tried hands/list" << optarg <<
-          ".txt under the current directory and relative to the "
-          "dtest binary\n";
+          ".txt under the current directory, "
+          "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
+          "and relative to the dtest binary\n";
         nextToken -= 2;
         errFlag = true;
         break;

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -20,6 +20,12 @@
 #include <cstring>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "args.hpp"
 #include "cst.hpp"
 
@@ -96,7 +102,9 @@ void usage(
   cout <<
     "Usage: " << basename << " [options]\n\n" <<
     "-f, --file s       Input file, or the number n;\n" <<
-    "                   '100' means ../hands/list100.txt).\n" <<
+    "                   '100' means hands/list100.txt under the current\n" <<
+    "                   directory, else ../../../hands/list100.txt relative\n" <<
+    "                   to the dtest binary (bazel-bin/library/tests/).\n" <<
     "                   (Default: input.txt)\n" <<
     "\n" <<
     "-s, --solver       One of: solve, calc, play, par, dealerpar.\n" <<
@@ -187,6 +195,154 @@ void SetDefaults()
 }
 
 
+bool is_absolute_path(const string& path)
+{
+  if (path.empty())
+    return false;
+#ifdef _WIN32
+  return path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
+    path[1] == ':';
+#else
+  return path[0] == '/' || path[0] == '\\';
+#endif
+}
+
+
+// Collapse "." / ".." path segments without resolving symlinks.
+string normalize_logical_path(const string& path)
+{
+  if (path.empty())
+    return path;
+
+  const bool absolute = is_absolute_path(path);
+  string drive;
+  size_t start = 0;
+#ifdef _WIN32
+  if (absolute && path.size() >= 2 && path[1] == ':')
+  {
+    drive = path.substr(0, 2);
+    start = 2;
+    if (start < path.size() && (path[start] == '/' || path[start] == '\\'))
+      ++start;
+  }
+#else
+  if (absolute)
+    start = 1;
+#endif
+
+  vector<string> parts;
+  string cur;
+  auto flush = [&]()
+  {
+    if (cur.empty())
+      return;
+    if (cur == ".")
+    {
+      cur.clear();
+      return;
+    }
+    if (cur == "..")
+    {
+      if (!parts.empty())
+        parts.pop_back();
+      else if (!absolute)
+        parts.push_back("..");
+      cur.clear();
+      return;
+    }
+    parts.push_back(cur);
+    cur.clear();
+  };
+
+  for (size_t i = start; i < path.size(); ++i)
+  {
+    const char c = path[i];
+    if (c == '/' || c == '\\')
+      flush();
+    else
+      cur.push_back(c);
+  }
+  flush();
+
+  string out = drive;
+  if (absolute)
+#ifdef _WIN32
+    out += '\\';
+#else
+    out += '/';
+#endif
+
+  for (size_t i = 0; i < parts.size(); ++i)
+  {
+    if (i > 0)
+      out += '/';
+    out += parts[i];
+  }
+  if (absolute && parts.empty())
+    return out.empty() ? string("/") : out;
+  return out.empty() ? string(".") : out;
+}
+
+
+// Logical absolute path for argv0 without resolving symlinks (so climbing out
+// of bazel-bin still lands on the workspace, not the execroot).
+string absolute_path_logical(const string& path)
+{
+  if (is_absolute_path(path))
+    return normalize_logical_path(path);
+
+  char cwd[4096];
+#ifdef _WIN32
+  if (_getcwd(cwd, static_cast<int>(sizeof(cwd))) == nullptr)
+    return normalize_logical_path(path);
+#else
+  if (getcwd(cwd, sizeof(cwd)) == nullptr)
+    return normalize_logical_path(path);
+#endif
+  if (path.empty())
+    return normalize_logical_path(string(cwd));
+  return normalize_logical_path(string(cwd) + "/" + path);
+}
+
+
+string resolve_dtest_input_file(
+  const string& arg,
+  const string& argv0)
+{
+  struct stat buffer;
+  if (stat(arg.c_str(), &buffer) == 0)
+    return arg;
+
+  const string list_name = "list" + arg + ".txt";
+  const string cwd_candidate = "hands/" + list_name;
+  if (stat(cwd_candidate.c_str(), &buffer) == 0)
+    return cwd_candidate;
+
+  // Climb parents in the path *string* (do not use "/../" with stat — that
+  // follows a bazel-bin symlink into the execroot and misses the workspace
+  // hands/ directory). bazel-bin/library/tests → three levels up to repo root.
+  const string abs_argv0 = absolute_path_logical(argv0);
+  size_t slash = abs_argv0.find_last_of("\\/");
+  if (slash == string::npos)
+    return string();
+
+  string dir = abs_argv0.substr(0, slash);
+  for (unsigned i = 0; i < 3; ++i)
+  {
+    slash = dir.find_last_of("\\/");
+    if (slash == string::npos)
+      return string();
+    dir = (slash == 0) ? dir.substr(0, 1) : dir.substr(0, slash);
+  }
+
+  const string bin_candidate = dir + "/hands/" + list_name;
+  if (stat(bin_candidate.c_str(), &buffer) == 0)
+    return bin_candidate;
+
+  return string();
+}
+
+
 void print_options()
 {
   cout << left;
@@ -229,31 +385,29 @@ void read_args(
   bool errFlag = false, matchFlag;
   string stmp;
   char * ctmp;
-  struct stat buffer;
 
   while ((c = GetNextArgToken(argc, argv)) > 0)
   {
     switch(c - 1)
     {
       case OPT_FILE:
-        if (stat(optarg, &buffer) == 0)
+      {
+        const string resolved =
+          resolve_dtest_input_file(string(optarg), string(argv[0]));
+        if (!resolved.empty())
         {
-          options.fname_ = string(optarg);
-          break;
-        }
-
-        stmp = "../hands/list" + string(optarg) + ".txt";
-        if (stat(stmp.c_str(), &buffer) == 0)
-        {
-          options.fname_ = stmp;
+          options.fname_ = resolved;
           break;
         }
 
         cout << "Input file '" << optarg << "' not found\n";
-        cout << "Input file '" << stmp << "' not found\n";
+        cout << "Also tried hands/list" << optarg <<
+          ".txt under the current directory and relative to the "
+          "dtest binary\n";
         nextToken -= 2;
         errFlag = true;
         break;
+      }
 
       case OPT_SOLVER:
         matchFlag = false;

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -269,22 +269,24 @@ string normalize_logical_path(const string& path)
   }
   flush();
 
+#ifdef _WIN32
+  const char sep = '\\';
+#else
+  const char sep = '/';
+#endif
+
   string out = drive;
   if (absolute)
-#ifdef _WIN32
-    out += '\\';
-#else
-    out += '/';
-#endif
+    out += sep;
 
   for (size_t i = 0; i < parts.size(); ++i)
   {
     if (i > 0)
-      out += '/';
+      out += sep;
     out += parts[i];
   }
   if (absolute && parts.empty())
-    return out.empty() ? string("/") : out;
+    return out.empty() ? string(1, sep) : out;
   return out.empty() ? string(".") : out;
 }
 

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -200,13 +200,54 @@ void SetDefaults()
 namespace
 {
 
+#ifdef _WIN32
+bool is_unc_path(const string& path)
+{
+  if (path.size() < 5)
+    return false;
+  const bool unc_slash =
+    (path[0] == '\\' && path[1] == '\\') ||
+    (path[0] == '/' && path[1] == '/');
+  if (!unc_slash)
+    return false;
+
+  size_t i = 2;
+  while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
+    ++i;
+  if (i >= path.size())
+    return false;
+
+  const size_t server_start = i;
+  while (i < path.size() && path[i] != '\\' && path[i] != '/')
+    ++i;
+  if (i == server_start || i >= path.size())
+    return false;
+
+  while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
+    ++i;
+  if (i >= path.size())
+    return false;
+
+  const size_t share_start = i;
+  while (i < path.size() && path[i] != '\\' && path[i] != '/')
+    ++i;
+  return i > share_start;
+}
+#endif
+
+
 bool is_absolute_path(const string& path)
 {
   if (path.empty())
     return false;
 #ifdef _WIN32
-  return path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
-    path[1] == ':';
+  if (is_unc_path(path))
+    return true;
+  // Drive-rooted absolute: "C:\..." or "C:/...". "C:foo" is drive-relative.
+  return path.size() >= 3 &&
+    std::isalpha(static_cast<unsigned char>(path[0])) &&
+    path[1] == ':' &&
+    (path[2] == '\\' || path[2] == '/');
 #else
   return path[0] == '/';
 #endif
@@ -223,7 +264,27 @@ string normalize_logical_path(const string& path)
   string drive;
   size_t start = 0;
 #ifdef _WIN32
-  if (absolute && path.size() >= 2 && path[1] == ':')
+  if (absolute && is_unc_path(path))
+  {
+    size_t i = 2;
+    while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
+      ++i;
+    const size_t server_start = i;
+    while (i < path.size() && path[i] != '\\' && path[i] != '/')
+      ++i;
+    const string server = path.substr(server_start, i - server_start);
+    while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
+      ++i;
+    const size_t share_start = i;
+    while (i < path.size() && path[i] != '\\' && path[i] != '/')
+      ++i;
+    const string share = path.substr(share_start, i - share_start);
+    drive = string("\\\\") + server + "\\" + share;
+    start = i;
+    if (start < path.size() && (path[start] == '/' || path[start] == '\\'))
+      ++start;
+  }
+  else if (absolute && path.size() >= 2 && path[1] == ':')
   {
     drive = path.substr(0, 2);
     start = 2;
@@ -276,12 +337,22 @@ string normalize_logical_path(const string& path)
 #endif
 
   string out = drive;
+#ifdef _WIN32
+  const bool unc = absolute && drive.size() >= 2 && drive[0] == '\\';
+  if (absolute && !unc)
+    out += sep;
+#else
   if (absolute)
     out += sep;
+#endif
 
   for (size_t i = 0; i < parts.size(); ++i)
   {
+#ifdef _WIN32
+    if (i > 0 || unc)
+#else
     if (i > 0)
+#endif
       out += sep;
     out += parts[i];
   }
@@ -306,12 +377,37 @@ string absolute_path_logical(const string& path)
   if (getcwd(cwd, sizeof(cwd)) == nullptr)
     return normalize_logical_path(path);
 #endif
+
+#ifdef _WIN32
+  // Drive-relative "C:foo": resolve against cwd when cwd is on the same drive.
+  if (path.size() >= 2 &&
+    std::isalpha(static_cast<unsigned char>(path[0])) &&
+    path[1] == ':')
+  {
+    const string cwd_s(cwd);
+    if (cwd_s.size() >= 2 &&
+      std::tolower(static_cast<unsigned char>(cwd_s[0])) ==
+        std::tolower(static_cast<unsigned char>(path[0])) &&
+      cwd_s[1] == ':')
+    {
+      return normalize_logical_path(cwd_s + "/" + path.substr(2));
+    }
+    return normalize_logical_path(path);
+  }
+#endif
+
   if (path.empty())
     return normalize_logical_path(string(cwd));
   return normalize_logical_path(string(cwd) + "/" + path);
 }
 
 }  // namespace
+
+
+bool is_dtest_absolute_path(const string& path)
+{
+  return is_absolute_path(path);
+}
 
 
 string resolve_dtest_input_file(

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -337,7 +337,8 @@ string resolve_dtest_input_file(
     string base(dir);
     while (base.size() > 1 && (base.back() == '/' || base.back() == '\\'))
       base.pop_back();
-    const string candidate = base + "/hands/" + list_name;
+    const string candidate =
+      normalize_logical_path(base + "/hands/" + list_name);
     if (stat(candidate.c_str(), &buffer) == 0)
       return candidate;
     return string();
@@ -365,7 +366,8 @@ string resolve_dtest_input_file(
     dir = (slash == 0) ? dir.substr(0, 1) : dir.substr(0, slash);
   }
 
-  const string bin_candidate = dir + "/hands/" + list_name;
+  const string bin_candidate =
+    normalize_logical_path(dir + "/hands/" + list_name);
   if (stat(bin_candidate.c_str(), &buffer) == 0)
     return bin_candidate;
 

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -243,6 +243,12 @@ bool is_absolute_path(const string& path)
 #ifdef _WIN32
   if (is_unc_path(path))
     return true;
+  // Current-drive rooted: "\foo" or "/foo" (single leading separator, not UNC).
+  if ((path[0] == '\\' || path[0] == '/') &&
+    (path.size() == 1 || (path[1] != '\\' && path[1] != '/')))
+  {
+    return true;
+  }
   // Drive-rooted absolute: "C:\..." or "C:/...". "C:foo" is drive-relative.
   return path.size() >= 3 &&
     std::isalpha(static_cast<unsigned char>(path[0])) &&
@@ -290,6 +296,11 @@ string normalize_logical_path(const string& path)
     start = 2;
     if (start < path.size() && (path[start] == '/' || path[start] == '\\'))
       ++start;
+  }
+  else if (absolute && (path[0] == '\\' || path[0] == '/'))
+  {
+    // Current-drive rooted without a drive letter; keep a leading separator.
+    start = 1;
   }
 #else
   if (absolute)
@@ -367,7 +378,23 @@ string normalize_logical_path(const string& path)
 string absolute_path_logical(const string& path)
 {
   if (is_absolute_path(path))
+  {
+#ifdef _WIN32
+    // Current-drive rooted "\foo" → "X:\foo" using the cwd drive letter.
+    if ((path[0] == '\\' || path[0] == '/') &&
+      (path.size() == 1 || (path[1] != '\\' && path[1] != '/')))
+    {
+      char cwd[4096];
+      if (_getcwd(cwd, static_cast<int>(sizeof(cwd))) != nullptr &&
+        std::isalpha(static_cast<unsigned char>(cwd[0])) &&
+        cwd[1] == ':')
+      {
+        return normalize_logical_path(string(1, cwd[0]) + ":" + path);
+      }
+    }
+#endif
     return normalize_logical_path(path);
+  }
 
   char cwd[4096];
 #ifdef _WIN32

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -17,14 +17,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
-#include <cstring>
-#include <sys/stat.h>
-
-#ifdef _WIN32
-#include <direct.h>
-#else
-#include <unistd.h>
-#endif
+#include <filesystem>
+#include <system_error>
 
 #include "args.hpp"
 #include "cst.hpp"
@@ -36,6 +30,7 @@ using std::right;
 using std::left;
 using std::vector;
 using std::string;
+namespace fs = std::filesystem;
 
 
 extern OptionsType options;
@@ -94,10 +89,7 @@ bool ParseRound();
 void usage(
   const char base[])
 {
-  string basename(base);
-  const size_t l = basename.find_last_of("\\/");
-  if (l != string::npos)
-    basename.erase(0, l+1);
+  const string basename = fs::path(base).filename().string();
 
   cout <<
     "Usage: " << basename << " [options]\n\n" <<
@@ -265,111 +257,14 @@ string normalize_logical_path(const string& path)
 {
   if (path.empty())
     return path;
+  return fs::path(path).lexically_normal().make_preferred().string();
+}
 
-  const bool absolute = is_absolute_path(path);
-  string drive;
-  size_t start = 0;
-#ifdef _WIN32
-  if (absolute && is_unc_path(path))
-  {
-    size_t i = 2;
-    while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
-      ++i;
-    const size_t server_start = i;
-    while (i < path.size() && path[i] != '\\' && path[i] != '/')
-      ++i;
-    const string server = path.substr(server_start, i - server_start);
-    while (i < path.size() && (path[i] == '\\' || path[i] == '/'))
-      ++i;
-    const size_t share_start = i;
-    while (i < path.size() && path[i] != '\\' && path[i] != '/')
-      ++i;
-    const string share = path.substr(share_start, i - share_start);
-    drive = string("\\\\") + server + "\\" + share;
-    start = i;
-    if (start < path.size() && (path[start] == '/' || path[start] == '\\'))
-      ++start;
-  }
-  else if (absolute && path.size() >= 2 && path[1] == ':')
-  {
-    drive = path.substr(0, 2);
-    start = 2;
-    if (start < path.size() && (path[start] == '/' || path[start] == '\\'))
-      ++start;
-  }
-  else if (absolute && (path[0] == '\\' || path[0] == '/'))
-  {
-    // Current-drive rooted without a drive letter; keep a leading separator.
-    start = 1;
-  }
-#else
-  if (absolute)
-    start = 1;
-#endif
 
-  vector<string> parts;
-  string cur;
-  auto flush = [&]()
-  {
-    if (cur.empty())
-      return;
-    if (cur == ".")
-    {
-      cur.clear();
-      return;
-    }
-    if (cur == "..")
-    {
-      if (!parts.empty())
-        parts.pop_back();
-      else if (!absolute)
-        parts.push_back("..");
-      cur.clear();
-      return;
-    }
-    parts.push_back(cur);
-    cur.clear();
-  };
-
-  for (size_t i = start; i < path.size(); ++i)
-  {
-    const char c = path[i];
-    if (c == '/' || c == '\\')
-      flush();
-    else
-      cur.push_back(c);
-  }
-  flush();
-
-#ifdef _WIN32
-  const char sep = '\\';
-#else
-  const char sep = '/';
-#endif
-
-  string out = drive;
-#ifdef _WIN32
-  const bool unc = absolute && drive.size() >= 2 && drive[0] == '\\';
-  if (absolute && !unc)
-    out += sep;
-#else
-  if (absolute)
-    out += sep;
-#endif
-
-  for (size_t i = 0; i < parts.size(); ++i)
-  {
-#ifdef _WIN32
-    if (i > 0 || unc)
-#else
-    if (i > 0)
-#endif
-      out += sep;
-    out += parts[i];
-  }
-  if (absolute && parts.empty())
-    return out.empty() ? string(1, sep) : out;
-  return out.empty() ? string(".") : out;
+bool path_exists(const fs::path& path)
+{
+  std::error_code ec;
+  return fs::exists(path, ec);
 }
 
 
@@ -377,33 +272,26 @@ string normalize_logical_path(const string& path)
 // of bazel-bin still lands on the workspace, not the execroot).
 string absolute_path_logical(const string& path)
 {
+  std::error_code ec;
+  const fs::path cwd = fs::current_path(ec);
+
   if (is_absolute_path(path))
   {
 #ifdef _WIN32
     // Current-drive rooted "\foo" → "X:\foo" using the cwd drive letter.
+    // std::filesystem treats these as relative (no root-name), so handle here.
     if ((path[0] == '\\' || path[0] == '/') &&
       (path.size() == 1 || (path[1] != '\\' && path[1] != '/')))
     {
-      char cwd[4096];
-      if (_getcwd(cwd, static_cast<int>(sizeof(cwd))) != nullptr &&
-        std::isalpha(static_cast<unsigned char>(cwd[0])) &&
-        cwd[1] == ':')
-      {
-        return normalize_logical_path(string(1, cwd[0]) + ":" + path);
-      }
+      if (!ec && cwd.has_root_name())
+        return normalize_logical_path(cwd.root_name().string() + path);
     }
 #endif
     return normalize_logical_path(path);
   }
 
-  char cwd[4096];
-#ifdef _WIN32
-  if (_getcwd(cwd, static_cast<int>(sizeof(cwd))) == nullptr)
+  if (ec)
     return normalize_logical_path(path);
-#else
-  if (getcwd(cwd, sizeof(cwd)) == nullptr)
-    return normalize_logical_path(path);
-#endif
 
 #ifdef _WIN32
   // Drive-relative "C:foo": resolve against cwd when cwd is on the same drive.
@@ -411,21 +299,21 @@ string absolute_path_logical(const string& path)
     std::isalpha(static_cast<unsigned char>(path[0])) &&
     path[1] == ':')
   {
-    const string cwd_s(cwd);
+    const string cwd_s = cwd.string();
     if (cwd_s.size() >= 2 &&
       std::tolower(static_cast<unsigned char>(cwd_s[0])) ==
         std::tolower(static_cast<unsigned char>(path[0])) &&
       cwd_s[1] == ':')
     {
-      return normalize_logical_path(cwd_s + "/" + path.substr(2));
+      return normalize_logical_path((cwd / path.substr(2)).string());
     }
     return normalize_logical_path(path);
   }
 #endif
 
   if (path.empty())
-    return normalize_logical_path(string(cwd));
-  return normalize_logical_path(string(cwd) + "/" + path);
+    return normalize_logical_path(cwd.string());
+  return normalize_logical_path((cwd / path).string());
 }
 
 }  // namespace
@@ -441,13 +329,14 @@ string resolve_dtest_input_file(
   const string& arg,
   const string& argv0)
 {
-  struct stat buffer;
-  if (stat(arg.c_str(), &buffer) == 0)
+  if (path_exists(arg))
     return arg;
 
   const string list_name = "list" + arg + ".txt";
-  const string cwd_candidate = "hands/" + list_name;
-  if (stat(cwd_candidate.c_str(), &buffer) == 0)
+  // Keep generic separators so cwd hits match the documented hands/listN.txt form.
+  const string cwd_candidate =
+    (fs::path("hands") / list_name).generic_string();
+  if (path_exists(cwd_candidate))
     return cwd_candidate;
 
   // bazel run moves CWD into the runfiles tree; it exports the invoke-time
@@ -457,12 +346,9 @@ string resolve_dtest_input_file(
     const char* dir = std::getenv(env_name);
     if (dir == nullptr || dir[0] == '\0')
       return string();
-    string base(dir);
-    while (base.size() > 1 && (base.back() == '/' || base.back() == '\\'))
-      base.pop_back();
-    const string candidate =
-      normalize_logical_path(base + "/hands/" + list_name);
-    if (stat(candidate.c_str(), &buffer) == 0)
+    const string candidate = normalize_logical_path(
+      (fs::path(dir) / "hands" / list_name).string());
+    if (path_exists(candidate))
       return candidate;
     return string();
   };
@@ -472,26 +358,22 @@ string resolve_dtest_input_file(
   if (const string found = from_env_dir("BUILD_WORKSPACE_DIRECTORY"); !found.empty())
     return found;
 
-  // Climb parents in the path *string* (do not use "/../" with stat — that
-  // follows a bazel-bin symlink into the execroot and misses the workspace
-  // hands/ directory). bazel-bin/library/tests → three levels up to repo root.
-  const string abs_argv0 = absolute_path_logical(argv0);
-  size_t slash = abs_argv0.find_last_of("\\/");
-  if (slash == string::npos)
-    return string();
-
-  string dir = abs_argv0.substr(0, slash);
-  for (unsigned i = 0; i < 3; ++i)
+  // Climb parents in the path *string* (do not use "/../" with filesystem
+  // resolution — that follows a bazel-bin symlink into the execroot and misses
+  // the workspace hands/ directory). bazel-bin/library/tests/dtest → four
+  // parent_path steps to the repo root.
+  fs::path dir(absolute_path_logical(argv0));
+  for (unsigned i = 0; i < 4; ++i)
   {
-    slash = dir.find_last_of("\\/");
-    if (slash == string::npos)
+    const fs::path parent = dir.parent_path();
+    if (parent.empty())
       return string();
-    dir = (slash == 0) ? dir.substr(0, 1) : dir.substr(0, slash);
+    dir = parent;
   }
 
   const string bin_candidate =
-    normalize_logical_path(dir + "/hands/" + list_name);
-  if (stat(bin_candidate.c_str(), &buffer) == 0)
+    normalize_logical_path((dir / "hands" / list_name).string());
+  if (path_exists(bin_candidate))
     return bin_candidate;
 
   return string();

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -103,8 +103,10 @@ void usage(
     "Usage: " << basename << " [options]\n\n" <<
     "-f, --file s       Input file, or the number n;\n" <<
     "                   '100' means hands/list100.txt under the current\n" <<
-    "                   directory, else ../../../hands/list100.txt relative\n" <<
-    "                   to the dtest binary (bazel-bin/library/tests/).\n" <<
+    "                   directory (or BUILD_WORKING_DIRECTORY /\n" <<
+    "                   BUILD_WORKSPACE_DIRECTORY under bazel run), else\n" <<
+    "                   relative to the dtest binary\n" <<
+    "                   (bazel-bin/library/tests/).\n" <<
     "                   (Default: input.txt)\n" <<
     "\n" <<
     "-s, --solver       One of: solve, calc, play, par, dealerpar.\n" <<
@@ -317,6 +319,27 @@ string resolve_dtest_input_file(
   const string cwd_candidate = "hands/" + list_name;
   if (stat(cwd_candidate.c_str(), &buffer) == 0)
     return cwd_candidate;
+
+  // bazel run moves CWD into the runfiles tree; it exports the invoke-time
+  // shell cwd and the workspace root so we can still find hands/.
+  auto from_env_dir = [&](const char* env_name) -> string
+  {
+    const char* dir = std::getenv(env_name);
+    if (dir == nullptr || dir[0] == '\0')
+      return string();
+    string base(dir);
+    while (base.size() > 1 && (base.back() == '/' || base.back() == '\\'))
+      base.pop_back();
+    const string candidate = base + "/hands/" + list_name;
+    if (stat(candidate.c_str(), &buffer) == 0)
+      return candidate;
+    return string();
+  };
+
+  if (const string found = from_env_dir("BUILD_WORKING_DIRECTORY"); !found.empty())
+    return found;
+  if (const string found = from_env_dir("BUILD_WORKSPACE_DIRECTORY"); !found.empty())
+    return found;
 
   // Climb parents in the path *string* (do not use "/../" with stat — that
   // follows a bazel-bin symlink into the execroot and misses the workspace

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -264,7 +264,9 @@ string normalize_logical_path(const string& path)
 bool path_exists(const fs::path& path)
 {
   std::error_code ec;
-  return fs::exists(path, ec);
+  // -f / resolve_dtest_input_file expect a readable input *file*; directories
+  // must not count (exists() is true for them and leads to a later parse error).
+  return fs::is_regular_file(path, ec);
 }
 
 

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -208,7 +208,7 @@ bool is_absolute_path(const string& path)
   return path.size() >= 2 && std::isalpha(static_cast<unsigned char>(path[0])) &&
     path[1] == ':';
 #else
-  return path[0] == '/' || path[0] == '\\';
+  return path[0] == '/';
 #endif
 }
 

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -9,9 +9,11 @@
 
 #pragma once
 
+#include <string>
+
 /// @file args.hpp
 /// @brief Command-line argument parsing for test utilities.
-/// 
+///
 /// Provides functions to parse and validate command-line options
 /// for the dtest driver program. Options include:
 /// - Input file specification
@@ -28,6 +30,16 @@ void usage(
 
 /// Print current option values.
 void print_options();
+
+/// Resolve `-f` / `--file` to an existing path.
+///
+/// Order: (1) `arg` as a literal path; (2) `hands/list{arg}.txt` under the
+/// current working directory; (3) `../../../hands/list{arg}.txt` relative to
+/// the directory of `argv0` (the usual `bazel-bin/library/tests/dtest` layout).
+/// @return Resolved path, or empty if nothing exists
+std::string resolve_dtest_input_file(
+    const std::string& arg,
+    const std::string& argv0);
 
 /// Parse command-line arguments into global options.
 /// @param argc Argument count from main()

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -31,13 +31,14 @@ void usage(
 /// Print current option values.
 void print_options();
 
-/// Resolve `-f` / `--file` to an existing path.
+/// Resolve `-f` / `--file` to an existing regular file.
 ///
 /// Order: (1) `arg` as a literal path; (2) `hands/list{arg}.txt` under the
 /// current working directory; (3) the same under `BUILD_WORKING_DIRECTORY` /
 /// `BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`); (4) relative to the
 /// directory of `argv0` (the usual `bazel-bin/library/tests/dtest` layout).
-/// @return Resolved path, or empty if nothing exists
+/// Directories are not accepted (avoids treating e.g. `-f hands` as a file).
+/// @return Resolved path, or empty if no regular file is found
 std::string resolve_dtest_input_file(
     const std::string& arg,
     const std::string& argv0);

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -42,9 +42,10 @@ std::string resolve_dtest_input_file(
     const std::string& arg,
     const std::string& argv0);
 
-/// True for a rooted absolute path: POSIX `/...`, Windows `C:\...` / `C:/...`,
-/// or UNC `\\server\share\...` / `//server/share/...`. Drive-relative forms
-/// like `C:bin\dtest` are not absolute.
+/// True for a rooted absolute path: POSIX `/...`; Windows drive-rooted
+/// `C:\...` / `C:/...`, current-drive rooted `\...` / `/...`, or UNC
+/// `\\server\share\...` / `//server/share/...`. Drive-relative forms like
+/// `C:bin\dtest` are not absolute.
 bool is_dtest_absolute_path(const std::string& path);
 
 /// Parse command-line arguments into global options.

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -34,8 +34,9 @@ void print_options();
 /// Resolve `-f` / `--file` to an existing path.
 ///
 /// Order: (1) `arg` as a literal path; (2) `hands/list{arg}.txt` under the
-/// current working directory; (3) `../../../hands/list{arg}.txt` relative to
-/// the directory of `argv0` (the usual `bazel-bin/library/tests/dtest` layout).
+/// current working directory; (3) the same under `BUILD_WORKING_DIRECTORY` /
+/// `BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`); (4) relative to the
+/// directory of `argv0` (the usual `bazel-bin/library/tests/dtest` layout).
 /// @return Resolved path, or empty if nothing exists
 std::string resolve_dtest_input_file(
     const std::string& arg,

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -42,6 +42,11 @@ std::string resolve_dtest_input_file(
     const std::string& arg,
     const std::string& argv0);
 
+/// True for a rooted absolute path: POSIX `/...`, Windows `C:\...` / `C:/...`,
+/// or UNC `\\server\share\...` / `//server/share/...`. Drive-relative forms
+/// like `C:bin\dtest` are not absolute.
+bool is_dtest_absolute_path(const std::string& path);
+
 /// Parse command-line arguments into global options.
 /// @param argc Argument count from main()
 /// @param argv Argument vector from main()

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -3,15 +3,14 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
 #include <fstream>
 #include <string>
 #include <vector>
 
 #ifdef _WIN32
 #include <direct.h>
-#include <stdlib.h>
 #else
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -60,6 +59,55 @@ void make_dir(const std::string& path)
   mkdir(path.c_str(), 0755);
 #endif
 }
+
+void set_env_var(const char* name, const char* value)
+{
+#ifdef _WIN32
+  _putenv_s(name, value != nullptr ? value : "");
+#else
+  if (value == nullptr || value[0] == '\0')
+    unsetenv(name);
+  else
+    setenv(name, value, 1);
+#endif
+}
+
+/// Saves and restores one environment variable for the lifetime of the guard.
+class EnvVarGuard
+{
+ public:
+  explicit EnvVarGuard(const char* name)
+    : name_(name)
+  {
+    const char* prev = std::getenv(name_);
+    if (prev != nullptr)
+    {
+      had_value_ = true;
+      previous_ = prev;
+    }
+  }
+
+  ~EnvVarGuard()
+  {
+    if (had_value_)
+      set_env_var(name_, previous_.c_str());
+    else
+      set_env_var(name_, nullptr);
+  }
+
+  EnvVarGuard(const EnvVarGuard&) = delete;
+  auto operator=(const EnvVarGuard&) -> EnvVarGuard& = delete;
+
+  void set(const char* value) const
+  {
+    set_env_var(name_, value);
+  }
+
+ private:
+  const char* name_;
+  bool had_value_ = false;
+  std::string previous_;
+};
 
 std::string make_temp_input_file()
 {
@@ -186,21 +234,15 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
     std::string(::testing::TempDir()) + "dtest_hands_runfiles/";
   make_dir(runfiles);
   ASSERT_EQ(change_dir(runfiles.c_str()), 0);
-#ifdef _WIN32
-  _putenv_s("BUILD_WORKING_DIRECTORY", root_.c_str());
-  _putenv_s("BUILD_WORKSPACE_DIRECTORY", "");
-#else
-  ASSERT_EQ(setenv("BUILD_WORKING_DIRECTORY", root_.c_str(), 1), 0);
-  ASSERT_EQ(unsetenv("BUILD_WORKSPACE_DIRECTORY"), 0);
-#endif
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(root_.c_str());
+  workspace.set(nullptr);
+
   EXPECT_EQ(
     resolve_dtest_input_file("42", "dtest"),
     root_ + "hands/list42.txt");
-#ifdef _WIN32
-  _putenv_s("BUILD_WORKING_DIRECTORY", "");
-#else
-  unsetenv("BUILD_WORKING_DIRECTORY");
-#endif
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
@@ -209,21 +251,15 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
     std::string(::testing::TempDir()) + "dtest_hands_runfiles_ws/";
   make_dir(runfiles);
   ASSERT_EQ(change_dir(runfiles.c_str()), 0);
-#ifdef _WIN32
-  _putenv_s("BUILD_WORKING_DIRECTORY", "");
-  _putenv_s("BUILD_WORKSPACE_DIRECTORY", root_.c_str());
-#else
-  ASSERT_EQ(unsetenv("BUILD_WORKING_DIRECTORY"), 0);
-  ASSERT_EQ(setenv("BUILD_WORKSPACE_DIRECTORY", root_.c_str(), 1), 0);
-#endif
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(root_.c_str());
+
   EXPECT_EQ(
     resolve_dtest_input_file("42", "dtest"),
     root_ + "hands/list42.txt");
-#ifdef _WIN32
-  _putenv_s("BUILD_WORKSPACE_DIRECTORY", "");
-#else
-  unsetenv("BUILD_WORKSPACE_DIRECTORY");
-#endif
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -341,12 +341,16 @@ TEST(Args, AbsolutePathDetection)
   EXPECT_TRUE(is_dtest_absolute_path("C:\\bin\\dtest"));
   EXPECT_TRUE(is_dtest_absolute_path("C:/bin/dtest"));
   EXPECT_TRUE(is_dtest_absolute_path("c:\\"));
+  // Current-drive rooted (leading single separator) is absolute on Windows.
+  EXPECT_TRUE(is_dtest_absolute_path("\\repo\\bazel-bin\\dtest"));
+  EXPECT_TRUE(is_dtest_absolute_path("/repo/bazel-bin/dtest"));
+  EXPECT_TRUE(is_dtest_absolute_path("\\"));
+  EXPECT_TRUE(is_dtest_absolute_path("/"));
   EXPECT_TRUE(is_dtest_absolute_path("\\\\server\\share"));
   EXPECT_TRUE(is_dtest_absolute_path("\\\\server\\share\\bazel-bin\\dtest"));
   EXPECT_TRUE(is_dtest_absolute_path("//server/share/dtest"));
   EXPECT_FALSE(is_dtest_absolute_path("\\\\server"));
   EXPECT_FALSE(is_dtest_absolute_path("\\\\server\\"));
-  EXPECT_FALSE(is_dtest_absolute_path("/tmp/dtest"));
 #endif
 }
 
@@ -369,6 +373,31 @@ TEST_F(HandsLayoutFixture, ResolveNumericWithDriveRelativeArgv0)
   const std::string drive_rel = std::string(1, root_[0]) + ":dtest";
   EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", drive_rel),
+    root_ + "hands/list42.txt"));
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericWithCurrentDriveRootedArgv0)
+{
+  // "\path\..." is absolute on the current drive; do not prepend cwd.
+  ASSERT_GE(root_.size(), 2u);
+  ASSERT_EQ(root_[1], ':');
+  const std::string sibling =
+    std::string(::testing::TempDir()) + "dtest_hands_rootrel_cwd/";
+  ASSERT_TRUE(make_dir(sibling));
+  ASSERT_EQ(change_dir(sibling.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(nullptr);
+
+  // Drop the drive letter so argv0 is current-drive rooted.
+  const std::string root_rel_argv0 =
+    root_.substr(2) + "bazel-bin/library/tests/dtest";
+  ASSERT_TRUE(
+    root_rel_argv0[0] == '\\' || root_rel_argv0[0] == '/');
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("42", root_rel_argv0),
     root_ + "hands/list42.txt"));
 }
 #endif

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -9,7 +9,9 @@
 
 #ifdef _WIN32
 #include <direct.h>
+#include <stdlib.h>
 #else
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -174,6 +176,54 @@ TEST_F(HandsLayoutFixture, ResolveNumericFallsBackRelativeToBinary)
   EXPECT_EQ(
     resolve_dtest_input_file("42", binary_path_),
     root_ + "hands/list42.txt");
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
+{
+  // bazel run sets CWD to the runfiles tree (no hands/) and exports
+  // BUILD_WORKING_DIRECTORY as the invoke-time shell cwd.
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles/";
+  make_dir(runfiles);
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+#ifdef _WIN32
+  _putenv_s("BUILD_WORKING_DIRECTORY", root_.c_str());
+  _putenv_s("BUILD_WORKSPACE_DIRECTORY", "");
+#else
+  ASSERT_EQ(setenv("BUILD_WORKING_DIRECTORY", root_.c_str(), 1), 0);
+  ASSERT_EQ(unsetenv("BUILD_WORKSPACE_DIRECTORY"), 0);
+#endif
+  EXPECT_EQ(
+    resolve_dtest_input_file("42", "dtest"),
+    root_ + "hands/list42.txt");
+#ifdef _WIN32
+  _putenv_s("BUILD_WORKING_DIRECTORY", "");
+#else
+  unsetenv("BUILD_WORKING_DIRECTORY");
+#endif
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
+{
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles_ws/";
+  make_dir(runfiles);
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+#ifdef _WIN32
+  _putenv_s("BUILD_WORKING_DIRECTORY", "");
+  _putenv_s("BUILD_WORKSPACE_DIRECTORY", root_.c_str());
+#else
+  ASSERT_EQ(unsetenv("BUILD_WORKING_DIRECTORY"), 0);
+  ASSERT_EQ(setenv("BUILD_WORKSPACE_DIRECTORY", root_.c_str(), 1), 0);
+#endif
+  EXPECT_EQ(
+    resolve_dtest_input_file("42", "dtest"),
+    root_ + "hands/list42.txt");
+#ifdef _WIN32
+  _putenv_s("BUILD_WORKSPACE_DIRECTORY", "");
+#else
+  unsetenv("BUILD_WORKSPACE_DIRECTORY");
+#endif
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -59,7 +59,11 @@ bool path_is_directory(const std::string& path)
   struct stat st;
   if (stat(path.c_str(), &st) != 0)
     return false;
+#ifdef _WIN32
+  return (st.st_mode & S_IFMT) == S_IFDIR;
+#else
   return S_ISDIR(st.st_mode);
+#endif
 }
 
 /// Creates a directory. Succeeds if it already exists as a directory;

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -10,7 +10,9 @@
 
 #ifdef _WIN32
 #include <direct.h>
+#include <errno.h>
 #else
+#include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
@@ -51,13 +53,17 @@ std::string current_dir()
 }
 #endif
 
-void make_dir(const std::string& path)
+/// Creates a directory. Succeeds if it already exists; fails on other errors.
+bool make_dir(const std::string& path)
 {
 #ifdef _WIN32
-  _mkdir(path.c_str());
+  if (_mkdir(path.c_str()) == 0)
+    return true;
 #else
-  mkdir(path.c_str(), 0755);
+  if (mkdir(path.c_str(), 0755) == 0)
+    return true;
 #endif
+  return errno == EEXIST;
 }
 
 void set_env_var(const char* name, const char* value)
@@ -145,11 +151,11 @@ class HandsLayoutFixture : public ::testing::Test
     ASSERT_FALSE(original_cwd_.empty());
 
     root_ = std::string(::testing::TempDir()) + "dtest_hands_layout/";
-    make_dir(root_);
-    make_dir(root_ + "hands");
-    make_dir(root_ + "bazel-bin");
-    make_dir(root_ + "bazel-bin/library");
-    make_dir(root_ + "bazel-bin/library/tests");
+    ASSERT_TRUE(make_dir(root_));
+    ASSERT_TRUE(make_dir(root_ + "hands"));
+    ASSERT_TRUE(make_dir(root_ + "bazel-bin"));
+    ASSERT_TRUE(make_dir(root_ + "bazel-bin/library"));
+    ASSERT_TRUE(make_dir(root_ + "bazel-bin/library/tests"));
 
     {
       std::ofstream out(root_ + "hands/list42.txt");
@@ -248,7 +254,7 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
   // BUILD_WORKING_DIRECTORY as the invoke-time shell cwd.
   const std::string runfiles =
     std::string(::testing::TempDir()) + "dtest_hands_runfiles/";
-  make_dir(runfiles);
+  ASSERT_TRUE(make_dir(runfiles));
   ASSERT_EQ(change_dir(runfiles.c_str()), 0);
 
   const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
@@ -265,7 +271,7 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
 {
   const std::string runfiles =
     std::string(::testing::TempDir()) + "dtest_hands_runfiles_ws/";
-  make_dir(runfiles);
+  ASSERT_TRUE(make_dir(runfiles));
   ASSERT_EQ(change_dir(runfiles.c_str()), 0);
 
   const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
@@ -284,7 +290,7 @@ TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)
   // the repo root: argv0 is relative, CWD is not the repo root.
   const std::string sibling =
     std::string(::testing::TempDir()) + "dtest_hands_sibling/";
-  make_dir(sibling);
+  ASSERT_TRUE(make_dir(sibling));
   ASSERT_EQ(change_dir(sibling.c_str()), 0);
 
   // root_ and sibling share the same parent (TempDir), so this relative
@@ -302,8 +308,8 @@ TEST_F(HandsLayoutFixture, ResolveNumericPrefersCwdOverBinaryRelative)
   // also exists.
   const std::string other_root =
     std::string(::testing::TempDir()) + "dtest_hands_cwd_wins/";
-  make_dir(other_root);
-  make_dir(other_root + "hands");
+  ASSERT_TRUE(make_dir(other_root));
+  ASSERT_TRUE(make_dir(other_root + "hands"));
   const std::string cwd_file = other_root + "hands/list42.txt";
   {
     std::ofstream out(cwd_file);
@@ -318,3 +324,43 @@ TEST(Args, ResolveReturnsEmptyWhenMissing)
 {
   EXPECT_TRUE(resolve_dtest_input_file("no-such-list-999001", "dtest").empty());
 }
+
+TEST(Args, AbsolutePathDetection)
+{
+  EXPECT_FALSE(is_dtest_absolute_path("tmp/dtest"));
+  EXPECT_FALSE(is_dtest_absolute_path(""));
+#ifndef _WIN32
+  EXPECT_TRUE(is_dtest_absolute_path("/tmp/dtest"));
+  // On POSIX, leading backslash is not absolute.
+  EXPECT_FALSE(is_dtest_absolute_path("\\tmp\\dtest"));
+#else
+  // Drive-relative (no root separator after the colon) is not absolute.
+  EXPECT_FALSE(is_dtest_absolute_path("C:bin\\dtest"));
+  EXPECT_FALSE(is_dtest_absolute_path("C:bin/dtest"));
+  EXPECT_FALSE(is_dtest_absolute_path("C:"));
+  EXPECT_TRUE(is_dtest_absolute_path("C:\\bin\\dtest"));
+  EXPECT_TRUE(is_dtest_absolute_path("C:/bin/dtest"));
+  EXPECT_TRUE(is_dtest_absolute_path("c:\\"));
+  EXPECT_TRUE(is_dtest_absolute_path("\\\\server\\share"));
+  EXPECT_TRUE(is_dtest_absolute_path("\\\\server\\share\\bazel-bin\\dtest"));
+  EXPECT_TRUE(is_dtest_absolute_path("//server/share/dtest"));
+  EXPECT_FALSE(is_dtest_absolute_path("\\\\server"));
+  EXPECT_FALSE(is_dtest_absolute_path("\\\\server\\"));
+  EXPECT_FALSE(is_dtest_absolute_path("/tmp/dtest"));
+#endif
+}
+
+#ifdef _WIN32
+TEST_F(HandsLayoutFixture, ResolveNumericWithDriveRelativeArgv0)
+{
+  // "X:rel" is relative to the current directory on drive X, not rooted at X:\.
+  ASSERT_EQ(change_dir(root_.c_str()), 0);
+  ASSERT_GE(root_.size(), 2u);
+  ASSERT_EQ(root_[1], ':');
+  const std::string drive_rel =
+    std::string(1, root_[0]) + ":bazel-bin/library/tests/dtest";
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("42", drive_rel),
+    root_ + "hands/list42.txt"));
+}
+#endif

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -1,10 +1,18 @@
 /// @file args_test.cpp
-/// @brief Unit tests for dtest --max / --min option parsing.
+/// @brief Unit tests for dtest option parsing and `-f` path resolution.
 
 #include <gtest/gtest.h>
 
 #include <fstream>
 #include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 #include "args.hpp"
 #include "cst.hpp"
@@ -14,6 +22,43 @@ OptionsType options;
 namespace
 {
 
+#ifdef _WIN32
+int change_dir(const char* path)
+{
+  return _chdir(path);
+}
+
+std::string current_dir()
+{
+  std::vector<char> buf(4096);
+  if (_getcwd(buf.data(), static_cast<int>(buf.size())) == nullptr)
+    return {};
+  return buf.data();
+}
+#else
+int change_dir(const char* path)
+{
+  return chdir(path);
+}
+
+std::string current_dir()
+{
+  std::vector<char> buf(4096);
+  if (getcwd(buf.data(), buf.size()) == nullptr)
+    return {};
+  return buf.data();
+}
+#endif
+
+void make_dir(const std::string& path)
+{
+#ifdef _WIN32
+  _mkdir(path.c_str());
+#else
+  mkdir(path.c_str(), 0755);
+#endif
+}
+
 std::string make_temp_input_file()
 {
   const std::string path =
@@ -22,6 +67,42 @@ std::string make_temp_input_file()
   out << "placeholder\n";
   return path;
 }
+
+/// Temporary tree: `{root}/hands/list{N}.txt` and
+/// `{root}/bazel-bin/library/tests/` (binary path only; no real binary).
+class HandsLayoutFixture : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    original_cwd_ = current_dir();
+    ASSERT_FALSE(original_cwd_.empty());
+
+    root_ = std::string(::testing::TempDir()) + "dtest_hands_layout/";
+    make_dir(root_);
+    make_dir(root_ + "hands");
+    make_dir(root_ + "bazel-bin");
+    make_dir(root_ + "bazel-bin/library");
+    make_dir(root_ + "bazel-bin/library/tests");
+
+    {
+      std::ofstream out(root_ + "hands/list42.txt");
+      out << "placeholder\n";
+    }
+
+    binary_path_ = root_ + "bazel-bin/library/tests/dtest";
+  }
+
+  void TearDown() override
+  {
+    if (!original_cwd_.empty())
+      change_dir(original_cwd_.c_str());
+  }
+
+  std::string root_;
+  std::string binary_path_;
+  std::string original_cwd_;
+};
 
 }  // namespace
 
@@ -72,4 +153,66 @@ TEST(Args, MaxAndMinFlagsCanCombine)
   read_args(5, argv);
   EXPECT_TRUE(options.show_min_);
   EXPECT_TRUE(options.show_max_);
+}
+
+TEST(Args, ResolvePrefersLiteralExistingPath)
+{
+  const std::string path = make_temp_input_file();
+  EXPECT_EQ(resolve_dtest_input_file(path, "dtest"), path);
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericUsesHandsUnderCwd)
+{
+  ASSERT_EQ(change_dir(root_.c_str()), 0);
+  EXPECT_EQ(resolve_dtest_input_file("42", "dtest"), "hands/list42.txt");
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericFallsBackRelativeToBinary)
+{
+  // CWD has no hands/; argv0 points at the usual bazel-bin layout.
+  ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
+  EXPECT_EQ(
+    resolve_dtest_input_file("42", binary_path_),
+    root_ + "hands/list42.txt");
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)
+{
+  // Mimic running `../bazel-bin/library/tests/dtest -f 42` from a sibling of
+  // the repo root: argv0 is relative, CWD is not the repo root.
+  const std::string sibling =
+    std::string(::testing::TempDir()) + "dtest_hands_sibling/";
+  make_dir(sibling);
+  ASSERT_EQ(change_dir(sibling.c_str()), 0);
+
+  // root_ and sibling share the same parent (TempDir), so this relative
+  // argv0 reaches the fixture binary path.
+  const std::string rel_argv0 =
+    "../dtest_hands_layout/bazel-bin/library/tests/dtest";
+  EXPECT_EQ(
+    resolve_dtest_input_file("42", rel_argv0),
+    root_ + "hands/list42.txt");
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericPrefersCwdOverBinaryRelative)
+{
+  // A different list under cwd must win even when the binary-relative file
+  // also exists.
+  const std::string other_root =
+    std::string(::testing::TempDir()) + "dtest_hands_cwd_wins/";
+  make_dir(other_root);
+  make_dir(other_root + "hands");
+  const std::string cwd_file = other_root + "hands/list42.txt";
+  {
+    std::ofstream out(cwd_file);
+    out << "from-cwd\n";
+  }
+
+  ASSERT_EQ(change_dir(other_root.c_str()), 0);
+  EXPECT_EQ(resolve_dtest_input_file("42", binary_path_), "hands/list42.txt");
+}
+
+TEST(Args, ResolveReturnsEmptyWhenMissing)
+{
+  EXPECT_TRUE(resolve_dtest_input_file("no-such-list-999001", "dtest").empty());
 }

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -11,6 +11,7 @@
 #ifdef _WIN32
 #include <direct.h>
 #include <errno.h>
+#include <sys/stat.h>
 #else
 #include <errno.h>
 #include <sys/stat.h>
@@ -53,7 +54,16 @@ std::string current_dir()
 }
 #endif
 
-/// Creates a directory. Succeeds if it already exists; fails on other errors.
+bool path_is_directory(const std::string& path)
+{
+  struct stat st;
+  if (stat(path.c_str(), &st) != 0)
+    return false;
+  return S_ISDIR(st.st_mode);
+}
+
+/// Creates a directory. Succeeds if it already exists as a directory;
+/// fails if the path exists as a non-directory or on other errors.
 bool make_dir(const std::string& path)
 {
 #ifdef _WIN32
@@ -63,7 +73,7 @@ bool make_dir(const std::string& path)
   if (mkdir(path.c_str(), 0755) == 0)
     return true;
 #endif
-  return errno == EEXIST;
+  return path_is_directory(path);
 }
 
 void set_env_var(const char* name, const char* value)
@@ -187,6 +197,25 @@ TEST(Args, MaxAndMinFlagsDefaultOff)
   read_args(3, argv);
   EXPECT_FALSE(options.show_min_);
   EXPECT_FALSE(options.show_max_);
+}
+
+TEST(Args, MakeDirSucceedsWhenDirectoryAlreadyExists)
+{
+  const std::string dir =
+    std::string(::testing::TempDir()) + "args_make_dir_ok/";
+  ASSERT_TRUE(make_dir(dir));
+  EXPECT_TRUE(make_dir(dir));
+}
+
+TEST(Args, MakeDirFailsWhenPathIsExistingFile)
+{
+  const std::string path =
+    std::string(::testing::TempDir()) + "args_make_dir_file";
+  {
+    std::ofstream out(path);
+    out << "not-a-directory\n";
+  }
+  EXPECT_FALSE(make_dir(path));
 }
 
 TEST(Args, MaxFlagEnablesShowMax)

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -358,6 +358,15 @@ TEST(Args, ResolveReturnsEmptyWhenMissing)
   EXPECT_TRUE(resolve_dtest_input_file("no-such-list-999001", "dtest").empty());
 }
 
+TEST_F(HandsLayoutFixture, ResolveRejectsDirectoryAsLiteralPath)
+{
+  // -f is an input *file*; an existing directory must not short-circuit
+  // resolution (otherwise read_file later fails with a confusing parse error).
+  ASSERT_EQ(change_dir(root_.c_str()), 0);
+  EXPECT_TRUE(resolve_dtest_input_file("hands", "dtest").empty());
+  EXPECT_TRUE(resolve_dtest_input_file(root_ + "hands", "dtest").empty());
+}
+
 TEST(Args, AbsolutePathDetection)
 {
   EXPECT_FALSE(is_dtest_absolute_path("tmp/dtest"));

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -353,12 +353,20 @@ TEST(Args, AbsolutePathDetection)
 #ifdef _WIN32
 TEST_F(HandsLayoutFixture, ResolveNumericWithDriveRelativeArgv0)
 {
-  // "X:rel" is relative to the current directory on drive X, not rooted at X:\.
-  ASSERT_EQ(change_dir(root_.c_str()), 0);
+  // Sit in the fake binary dir so cwd has no hands/ (otherwise the numeric
+  // lookup would short-circuit before argv0). "X:dtest" is drive-relative to
+  // that directory — not rooted at X:\.
+  const std::string bin_dir = root_ + "bazel-bin/library/tests";
+  ASSERT_EQ(change_dir(bin_dir.c_str()), 0);
   ASSERT_GE(root_.size(), 2u);
   ASSERT_EQ(root_[1], ':');
-  const std::string drive_rel =
-    std::string(1, root_[0]) + ":bazel-bin/library/tests/dtest";
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(nullptr);
+
+  const std::string drive_rel = std::string(1, root_[0]) + ":dtest";
   EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", drive_rel),
     root_ + "hands/list42.txt"));

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -118,6 +118,22 @@ std::string make_temp_input_file()
   return path;
 }
 
+/// Compare paths ignoring '\\' vs '/' so Windows TempDir / resolver mixes match.
+bool same_path(std::string a, std::string b)
+{
+  for (char& c : a)
+  {
+    if (c == '\\')
+      c = '/';
+  }
+  for (char& c : b)
+  {
+    if (c == '\\')
+      c = '/';
+  }
+  return a == b;
+}
+
 /// Temporary tree: `{root}/hands/list{N}.txt` and
 /// `{root}/bazel-bin/library/tests/` (binary path only; no real binary).
 class HandsLayoutFixture : public ::testing::Test
@@ -221,9 +237,9 @@ TEST_F(HandsLayoutFixture, ResolveNumericFallsBackRelativeToBinary)
 {
   // CWD has no hands/; argv0 points at the usual bazel-bin layout.
   ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
-  EXPECT_EQ(
+  EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", binary_path_),
-    root_ + "hands/list42.txt");
+    root_ + "hands/list42.txt"));
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
@@ -240,9 +256,9 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
   working.set(root_.c_str());
   workspace.set(nullptr);
 
-  EXPECT_EQ(
+  EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", "dtest"),
-    root_ + "hands/list42.txt");
+    root_ + "hands/list42.txt"));
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
@@ -257,9 +273,9 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
   working.set(nullptr);
   workspace.set(root_.c_str());
 
-  EXPECT_EQ(
+  EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", "dtest"),
-    root_ + "hands/list42.txt");
+    root_ + "hands/list42.txt"));
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)
@@ -275,9 +291,9 @@ TEST_F(HandsLayoutFixture, ResolveNumericWithRelativeArgv0FromOtherCwd)
   // argv0 reaches the fixture binary path.
   const std::string rel_argv0 =
     "../dtest_hands_layout/bazel-bin/library/tests/dtest";
-  EXPECT_EQ(
+  EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", rel_argv0),
-    root_ + "hands/list42.txt");
+    root_ + "hands/list42.txt"));
 }
 
 TEST_F(HandsLayoutFixture, ResolveNumericPrefersCwdOverBinaryRelative)


### PR DESCRIPTION
## Summary
- Make `-f NNNN` find `hands/listNNNN.txt` under the current directory first
- Fall back to the repo `hands/` directory relative to `bazel-bin/library/tests/dtest`, without walking through the `bazel-bin` symlink into the execroot
- Cover cwd preference, binary-relative fallback, and relative `argv0` in `args_test`

## Test plan
- [x] `bazel test //library/tests:args_test`
- [x] `bazel build //library/tests:dtest && ./bazel-bin/library/tests/dtest -f 1 -s solve -n 1`
- [x] `(cd /tmp && \"$REPO/bazel-bin/library/tests/dtest\" -f 1 -s solve -n 1)` succeeds
- [x] `bazel run //library/tests:dtest -- -f 100`

Made with [Cursor](https://cursor.com)