### PR TITLE
Use bazelisk instead of bare bazel for CI and local commands

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 
 # Skip Playwright browser tests on `bazel test //...` (network, Chromium, no-sandbox).
 # Run e2e explicitly: bazel test --test_tag_filters=e2e //web:web_e2e_tests
-# Run every test: bazel test --test_tag_filters= /...
+# Run every test: bazelisk test --test_tag_filters= //...
 test --test_tag_filters=-e2e
 
 common --enable_platform_specific_config

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,25 +24,25 @@
 
 ```bash
 # Build everything (required before testing or running)
-bazel build //...
+bazelisk build //...
 
 # Run all tests
-bazel test //...
+bazelisk test //...
 
 # Build specific target
-bazel build //library/src:dds
+bazelisk build //library/src:dds
 
 # Run specific test
-bazel test //library/tests:dtest
+bazelisk test //library/tests:dtest
 
 # Build with optimization
-bazel build -c opt //...
+bazelisk build -c opt //...
 
 # Build with debug symbols
-bazel build -c dbg //...
+bazelisk build -c dbg //...
 
 # Build with AddressSanitizer (see .bazelrc build:asan and docs/BUILD_SYSTEM.md)
-bazel build --config=asan //...
+bazelisk build --config=asan //...
 ```
 
 ### Build Time Expectations
@@ -57,8 +57,8 @@ Note: Times may vary significantly based on hardware and network conditions.
 ### Before Making Changes
 ALWAYS run these commands first to establish baseline:
 ```bash
-bazel build //...
-bazel test //...
+bazelisk build //...
+bazelisk test //...
 ```
 This ensures any pre-existing issues are not attributed to your changes.
 
@@ -66,8 +66,8 @@ This ensures any pre-existing issues are not attributed to your changes.
 ALWAYS validate your changes:
 ```bash
 # Build and test
-bazel build //...
-bazel test //...
+bazelisk build //...
+bazelisk test //...
 ```
 
 ## Project Layout and Architecture
@@ -171,8 +171,8 @@ bazel test //...
 ### GitHub Actions Workflows
 
 **On Every PR** (must pass before merge):
-1. **Build** - `bazel build //...` on Linux and macOS
-2. **Test** - `bazel test //...` on both platforms
+1. **Build** - `bazelisk build //...` on Linux and macOS
+2. **Test** - `bazelisk test //...` on both platforms
 3. **Lint** - clang-tidy checks (configured in `.clang-tidy`)
 
 **Workflow Files**:
@@ -191,7 +191,7 @@ If CI fails:
 3. For clang-tidy issues, run:
    ```bash
    # Generate compile_commands.json
-   bazel build //... --config=clang-tidy
+   bazelisk build //... --config=clang-tidy
    # Run clang-tidy manually
    clang-tidy library/src/your_file.cpp
    ```
@@ -201,11 +201,11 @@ If CI fails:
 Before finalizing changes, optionally run:
 ```bash
 # Check for memory leaks (see docs/BUILD_SYSTEM.md for macOS/Linux notes)
-bazel build --config=asan //...
-bazel test --config=asan //...
+bazelisk build --config=asan //...
+bazelisk test --config=asan //...
 
 # Performance test with real hands
-bazel build //library/tests:dtest
+bazelisk build //library/tests:dtest
 ./bazel-bin/library/tests/dtest -f hands/list100.txt -s solve -n 4
 ```
 
@@ -266,7 +266,7 @@ bazel build //library/tests:dtest
 
 **Problem**: Bazel build hangs or is very slow
 - **Cause**: Large compilation unit or full rebuild
-- **Fix**: Use `bazel build --jobs=4` to limit parallelism, or be patient (initial builds are slow)
+- **Fix**: Use `bazelisk build --jobs=4` to limit parallelism, or be patient (initial builds are slow)
 
 **Problem**: Linker errors about multiple definitions
 - **Cause**: Inline functions in headers without `inline` keyword
@@ -276,7 +276,7 @@ bazel build //library/tests:dtest
 
 **Problem**: Tests fail with "Segmentation fault"
 - **Cause**: Usually memory management bug or uninitialized variable
-- **Fix**: Run with ASAN: `bazel test --config=asan //library/tests:failing_test`
+- **Fix**: Run with ASAN: `bazelisk test --config=asan //library/tests:failing_test`
 
 **Problem**: Tests fail with different results than expected
 - **Cause**: Possibly heuristic sorting or transposition table issues
@@ -286,7 +286,7 @@ bazel build //library/tests:dtest
 
 **Problem**: Performance much slower than expected
 - **Cause**: Debug build or single-threaded execution
-- **Fix**: Build with `bazel build -c opt //...` and ensure threading is enabled
+- **Fix**: Build with `bazelisk build -c opt //...` and ensure threading is enabled
 
 **Problem**: Out of memory errors
 - **Cause**: Transposition table too large
@@ -302,7 +302,7 @@ These instructions are comprehensive and tested. **Only search the codebase if**
 
 ### Making Changes
 1. **Minimal changes**: Modify only what's necessary
-2. **Test immediately**: Run `bazel test //...` after each logical change
+2. **Test immediately**: Run `bazelisk test //...` after each logical change
 3. **Follow patterns**: Match existing code style exactly
 4. **Update docs**: If changing public API, update corresponding documentation
 

--- a/.github/instructions/bazel.instructions.md
+++ b/.github/instructions/bazel.instructions.md
@@ -19,7 +19,7 @@ alwaysApply: false
 - Use `cc_library`, `cc_binary`, `cc_test` for C++ targets.
 - Keep test suites small & fast.
 - Restrict visibility (`visibility = ["//visibility:private"]`) when appropriate.
-- Run `bazel build //...` & `bazel test //...` locally before pushing.
+- Run `bazelisk build //...` & `bazelisk test //...` locally before pushing.
 - Document any non-trivial macros or build logic in comments.
 
 ## Working with bazel commands
@@ -31,6 +31,6 @@ bazel validate //path/to:BUILD
 bazel deps //my:target
 
 # Generate a build command for a target
-bazel build //my:target
+bazelisk build //my:target
 ```
 

--- a/.github/pull_request_templates/refactor_dynamic_environment.md
+++ b/.github/pull_request_templates/refactor_dynamic_environment.md
@@ -11,7 +11,7 @@ Details
 - Build: `library/src/BUILD.bazel` excludes legacy `SolverContext.cpp`; route context through `system/SolverContext.*` and `SolverContextAdapter`.
 
 Validation
-- `bazel test //...` passes with and without `--define=tt_context_ownership=true`.
+- `bazelisk test //...` passes with and without `--define=tt_context_ownership=true`.
 - `dtest` builds and runs with both default and constrained TT sizes, no segfaults.
 
 Next steps (separate PR)

--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(glob(["*.yml"]))
+
+filegroup(
+    name = "all_workflows",
+    srcs = glob(["*.yml"]),
+    visibility = ["//visibility:public"],
+)

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           max=3
           for i in $(seq 1 "$max"); do
-            if bazel fetch //...; then
+            if bazelisk fetch //...; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
@@ -51,11 +51,11 @@ jobs:
 
       # 6️⃣ Build all targets
       - name: Build all targets
-        run: bazel build --verbose_failures //...
+        run: bazelisk build --verbose_failures //...
 
       # 7️⃣ Run all tests (including Python)
       - name: Run all tests
-        run: bazel test --verbose_failures //...
+        run: bazelisk test --verbose_failures //...
 
       # 8️⃣ Upload test logs
       - name: Upload test logs - Linux
@@ -91,7 +91,7 @@ jobs:
         run: |
           max=3
           for i in $(seq 1 "$max"); do
-            if bazel fetch --config=asan //library/tests/...; then
+            if bazelisk fetch --config=asan //library/tests/...; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Run tests (AddressSanitizer)
-        run: bazel test --config=asan --verbose_failures --test_output=errors //library/tests/...
+        run: bazelisk test --config=asan --verbose_failures --test_output=errors //library/tests/...
 
       - name: Upload ASAN test logs
         if: always()
@@ -137,7 +137,7 @@ jobs:
         run: |
           max=3
           for i in $(seq 1 "$max"); do
-            if bazel fetch --config=tsan //library/tests/system/...; then
+            if bazelisk fetch --config=tsan //library/tests/system/...; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
@@ -148,7 +148,7 @@ jobs:
           exit 1
 
       - name: Run system tests (ThreadSanitizer)
-        run: bazel test --config=tsan --verbose_failures --test_output=errors //library/tests/system/...
+        run: bazelisk test --config=tsan --verbose_failures --test_output=errors //library/tests/system/...
 
       - name: Upload TSAN test logs
         if: always()

--- a/.github/workflows/ci_wasm.yml
+++ b/.github/workflows/ci_wasm.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           max=3
           for i in $(seq 1 "$max"); do
-            if bazel fetch //web/... //wasm/...; then
+            if bazelisk fetch //web/... //wasm/...; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
@@ -49,20 +49,20 @@ jobs:
 
       # 5️⃣ Unit tests and WASM builds (hermetic emsdk toolchain downloaded by Bazel)
       - name: Test web helpers, system tests, e2e, and CalcDDtablePBN
-        run: bazel test --verbose_failures //web:web_tests //web:web_system_tests //wasm:all
+        run: bazelisk test --verbose_failures //web:web_tests //web:web_system_tests //wasm:all
 
       - name: Build WASM targets
         run: |
           max=3
           for i in $(seq 1 "$max"); do
-            if bazel build --verbose_failures //wasm:all_examples_wasm; then
+            if bazelisk build --verbose_failures //wasm:all_examples_wasm; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
               echo "Build failed (attempt $i/$max). Retrying in 20s..."
               sleep 20
               # Restart server only — keep downloaded external repos / disk cache.
-              bazel shutdown || true
+              bazelisk shutdown || true
             fi
           done
           exit 1

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           $max = 3
           for ($i = 1; $i -le $max; $i++) {
-            bazel fetch //...
+            bazelisk fetch //...
             if ($LASTEXITCODE -eq 0) { exit 0 }
             if ($i -lt $max) {
               Write-Host "Fetch failed (attempt $i/$max). Retrying in 20s..."
@@ -39,20 +39,20 @@ jobs:
         run: |
           $max = 3
           for ($i = 1; $i -le $max; $i++) {
-            bazel build --verbose_failures //...
+            bazelisk build --verbose_failures //...
             if ($LASTEXITCODE -eq 0) { exit 0 }
             if ($i -lt $max) {
               Write-Host "Build failed (attempt $i/$max). Retrying in 20s..."
               Start-Sleep -Seconds 20
               # Restart server only — keep downloaded external repos / disk cache.
-              bazel shutdown || $true
+              bazelisk shutdown || $true
             }
           }
           exit 1
 
       # Run all tests (including Python) — no retry so real test failures surface quickly
       - name: Run all tests
-        run: bazel test --verbose_failures //...
+        run: bazelisk test --verbose_failures //...
 
       # Upload test logs
       - name: Upload test logs - Windows

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -100,8 +100,8 @@ binaries when the clang major matches.
    `xcrun clang++ --version`  
    `xcrun clang -print-file-name=libclang_rt.tsan_osx_dynamic.dylib`
 4. Re-run sanitizer smoke tests, e.g.  
-   `bazel test --config=asan //library/tests/system:context_tt_facade_test`  
-   `bazel test --config=tsan //library/tests/system:thread_safety_stress_test`
+   `bazelisk test --config=asan //library/tests/system:context_tt_facade_test`  
+   `bazelisk test --config=tsan //library/tests/system:thread_safety_stress_test`
 
 If TSAN fails to start after an Xcode upgrade (dyld cannot load the runtime),
 the rpath major is likely out of sync with the installed toolchain.
@@ -111,8 +111,8 @@ the rpath major is likely out of sync with the installed toolchain.
 
 | Workflow | Job | Command |
 |----------|-----|---------|
-| `ci_linux.yml` | `asan` | `bazel test --config=asan //library/tests/...` |
-| `ci_linux.yml` | `tsan` | `bazel test --config=tsan //library/tests/system/...` |
+| `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
+| `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_macos.yml` | `sanitizers` | ASAN and TSAN on `//library/tests/system/...` (validates macOS toolchain/rpath wiring) |
 
 

--- a/docs/c++_interface.md
+++ b/docs/c++_interface.md
@@ -147,17 +147,17 @@ int main()
 Build all targets:
 
 ```bash
-bazel build //...
+bazelisk build //...
 ```
 
 Run tests:
 
 ```bash
-bazel test //...
+bazelisk test //...
 ```
 
 Build docs package:
 
 ```bash
-bazel build //:doxygen_docs
+bazelisk build //:doxygen_docs
 ```

--- a/docs/jni_interface.md
+++ b/docs/jni_interface.md
@@ -41,7 +41,7 @@ No `jextract` install is required — the bindings are hand-written (see
 ## Building the shared library
 
 ```bash
-bazel build //jni:dds_shared
+bazelisk build //jni:dds_shared
 ```
 
 This produces one self-contained native library rolling up the entire solver
@@ -174,8 +174,8 @@ command line) to grant access and silence the runtime warning.
 The end-to-end smoke tests wire all of this together:
 
 ```bash
-bazel test //jni:dds_ffm_smoke_test           # explicit-path loading
-bazel test //jni:dds_ffm_embedded_smoke_test  # loadEmbedded() from the jar
+bazelisk test //jni:dds_ffm_smoke_test           # explicit-path loading
+bazelisk test //jni:dds_ffm_embedded_smoke_test  # loadEmbedded() from the jar
 ```
 
 ## Packaging & local install
@@ -188,7 +188,7 @@ bazel test //jni:dds_ffm_embedded_smoke_test  # loadEmbedded() from the jar
 Install it into your local Maven repository (`~/.m2`):
 
 ```bash
-bazel run //jni:dds_ffm_dist.publish \
+bazelisk run //jni:dds_ffm_dist.publish \
     --define maven_repo="file://$HOME/.m2/repository" \
     --define gpg_sign=false
 ```

--- a/docs/python_interface.md
+++ b/docs/python_interface.md
@@ -17,16 +17,16 @@ The DDS (Double Dummy Solver) library provides a Python interface for analyzing 
 
 ```bash
 # Build the Python extension and Python package wrapper
-bazel build //python:dds3_lib
+bazelisk build //python:dds3_lib
 
 # Build wheel artifact
-bazel build //python:dds3_wheel_dist
+bazelisk build //python:dds3_wheel_dist
 
 # Build with optimizations
-bazel build -c opt //python:_dds3
+bazelisk build -c opt //python:_dds3
 
 # Build with debug symbols
-bazel build -c dbg //python:_dds3
+bazelisk build -c dbg //python:_dds3
 ```
 
 The compiled extension will be located at `bazel-bin/python/_dds3.so`.
@@ -50,7 +50,7 @@ pip install pytest
 export PYTHONPATH=python:bazel-bin/python
 
 # Run Bazel smoke test for Python bindings
-bazel test //python:python_interface_smoke_test
+bazelisk test //python:python_interface_smoke_test
 
 # Or use pytest directly
 pytest python/tests/ -v
@@ -383,7 +383,7 @@ except RuntimeError as e:
 - The extension is thread-safe for most operations
 - Use `thread_index` parameter for multi-threaded solving (0-based index)
 - For batch processing, prefer `calc_all_tables_pbn` over multiple `solve_board_pbn` calls
-- Consider using optimized builds (`bazel build -c opt`) for performance-critical code
+- Consider using optimized builds (`bazelisk build -c opt`) for performance-critical code
 
 ## Building from Source
 
@@ -406,7 +406,7 @@ required.
 sudo apt-get install build-essential python3-dev
 
 # Build
-bazel build -c opt //python:_dds3
+bazelisk build -c opt //python:_dds3
 ```
 
 On Linux hosts where a pinned LLVM toolchain is configured (for example,

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -28,7 +28,7 @@ WASM targets use `wasm_cc_binary`, which applies an Emscripten **platform transi
 ### Build all WASM examples
 
 ```bash
-bazel build //wasm:all_examples_wasm
+bazelisk build //wasm:all_examples_wasm
 ```
 
 The alias `//examples:all_examples_wasm` points at the same filegroup.
@@ -36,7 +36,7 @@ The alias `//examples:all_examples_wasm` points at the same filegroup.
 ### Build a specific example
 
 ```bash
-bazel build //wasm:solve_board_wasm
+bazelisk build //wasm:solve_board_wasm
 ```
 
 ### Output files
@@ -62,11 +62,11 @@ Rules in `wasm/BUILD.bazel` wrap native binaries:
 use `-n N` for N workers (or omit / `0` for auto).
 
 ```bash
-bazel build //wasm:dtest_wasm
+bazelisk build //wasm:dtest_wasm
 node bazel-bin/wasm/dtest.js -f hands/list2.txt -s solve -n 2
 
 # Or via Bazel (forwards args after -- to dtest; cwd is your shell's directory):
-bazel run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2
+bazelisk run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2
 ```
 ## How it works
 
@@ -74,7 +74,7 @@ bazel run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2
 2. **`//:build_wasm`** in the root `BUILD.bazel` matches `@platforms//cpu:wasm32` for `select()` in `CPPVARIABLES.bzl` and example link flags.
 3. **`wasm_compat.bzl`** — shared Emscripten link flags (`WASM_LINKOPTS`) on the WASM-capable `cc_binary` targets.
 
-Native builds (`bazel build //...`, `bazel test //library/tests/...`, Python bindings) are unchanged and use the host LLVM toolchain.
+Native builds (`bazelisk build //...`, `bazelisk test //library/tests/...`, Python bindings) are unchanged and use the host LLVM toolchain.
 
 ## Running WASM examples
 
@@ -106,10 +106,10 @@ The MVP loads wasm from `dds_mvp_wasm_bin.js` (base64, no network fetch). Run
 small post-process step for Emscripten `isFileURI`; see **Emscripten / emsdk
 version** above).
 
-`bazel clean` does not delete those copied files under `web/` (they live outside `bazel-out`). Use either:
+`bazelisk clean` does not delete those copied files under `web/` (they live outside `bazel-out`). Use either:
 
 ```bash
-./clean.sh              # bazel clean + remove web/dds_mvp_wasm.*
+./clean.sh              # bazelisk clean + remove web/dds_mvp_wasm.*
 ./clean.sh --expunge
 ./web/clean_wasm.sh     # web artifacts only
 ```
@@ -158,11 +158,11 @@ There is no separate `build:wasm` profile in `.bazelrc`; WASM builds are selecte
 Unit and system tests (Node.js required for system tests; skipped if `node` is not on `PATH`):
 
 ```bash
-bazel test //web:web_tests //web:web_system_tests //web:web_e2e_tests
-bazel test //wasm:all
+bazelisk test //web:web_tests //web:web_system_tests //web:web_e2e_tests
+bazelisk test //wasm:all
 ```
 
-`bazel test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazel test //web:web_e2e_tests` or `bazel test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazel test --test_tag_filters= /...`
+`bazelisk test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazelisk test //web:web_e2e_tests` or `bazelisk test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazelisk test --test_tag_filters= /...`
 
 - **`//web:dds_mvp_wasm_system_test`** — builds `//web:dds_mvp_wasm`, runs `patch_mvp_wasm` / `gen_wasm_bin_js` / `verify_wasm_js`, then calls `dds_mvp_calc_table` via Node (`web/tests/dds_mvp_wasm_node.mjs`).
 - **`//web:dds_mvp_e2e_test`** — Playwright tests for `dds_mvp.html` over `file://` (UI) and isolated HTTP (part-score solve, COOP/COEP). Requires Node, network (Chromium download on first run), and `tags = ["no-sandbox"]`.

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -162,7 +162,7 @@ bazelisk test //web:web_tests //web:web_system_tests //web:web_e2e_tests
 bazelisk test //wasm:all
 ```
 
-`bazelisk test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazelisk test //web:web_e2e_tests` or `bazelisk test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazelisk test --test_tag_filters= /...`
+`bazelisk test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazelisk test //web:web_e2e_tests` or `bazelisk test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazelisk test --test_tag_filters= //...`
 
 - **`//web:dds_mvp_wasm_system_test`** — builds `//web:dds_mvp_wasm`, runs `patch_mvp_wasm` / `gen_wasm_bin_js` / `verify_wasm_js`, then calls `dds_mvp_calc_table` via Node (`web/tests/dds_mvp_wasm_node.mjs`).
 - **`//web:dds_mvp_e2e_test`** — Playwright tests for `dds_mvp.html` over `file://` (UI) and isolated HTTP (part-score solve, COOP/COEP). Requires Node, network (Chromium download on first run), and `tags = ["no-sandbox"]`.

--- a/examples/README
+++ b/examples/README
@@ -3,16 +3,16 @@ There are a number of simple examples for individual DDS functions.
 ## Building with Bazel (Recommended)
 
 Build all examples:
-    bazel build //examples:all_examples
+    bazelisk build //examples:all_examples
 
 Build a specific example:
-    bazel build //examples:calc_dd_table
+    bazelisk build //examples:calc_dd_table
 
 Run an example:
-    bazel run //examples:calc_dd_table
+    bazelisk run //examples:calc_dd_table
 
 Python `dd_table_for_deal` (see `python/examples/`):
-    bazel run //python/examples:dd_table_for_deal -- hands/example.pbn
+    bazelisk run //python/examples:dd_table_for_deal -- hands/example.pbn
 
 Available examples:
 - analyse_all_plays_bin, analyse_all_plays_pbn

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -87,7 +87,7 @@ auto read_pbn_file_workspace_relative(std::string_view path)
     return text;
   }
 
-  // bazel run uses a runfiles cwd; BUILD_WORKSPACE_DIRECTORY is the repo root.
+  // bazelisk run uses a runfiles cwd; BUILD_WORKSPACE_DIRECTORY is the repo root.
   if (const char* workspace = std::getenv("BUILD_WORKSPACE_DIRECTORY"))
   {
     return read_pbn_file(std::filesystem::path(workspace) / path);

--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -41,7 +41,7 @@ cc_binary(
     visibility = ["//visibility:public"],
 )
 
-# Test target for Bazel test execution (`bazel test //library/tests:all`)
+# Test target for Bazel test execution (`bazelisk test //library/tests:all`)
 # Uses testable_dds to expose internal symbols for unit testing
 cc_test(
     name = "unit_tests",

--- a/library/tests/heuristic_sorting/README.md
+++ b/library/tests/heuristic_sorting/README.md
@@ -10,7 +10,7 @@ Prerequisites
 Build
 
 ```bash
-bazel build //...
+bazelisk build //...
 ```
 
 Run tests (no cached results)
@@ -18,7 +18,7 @@ Run tests (no cached results)
 Run the whole heuristic-sorting test suite with the new heuristic and force tests to re-run:
 
 ```bash
-bazel test //library/tests/heuristic_sorting:all \
+bazelisk test //library/tests/heuristic_sorting:all \
   --nocache_test_results \
   --test_output=errors
 ```
@@ -26,14 +26,14 @@ bazel test //library/tests/heuristic_sorting:all \
 Run a single test target (faster iteration):
 
 ```bash
-bazel test //library/tests/heuristic_sorting:targeted_unit_tests \
+bazelisk test //library/tests/heuristic_sorting:targeted_unit_tests \
   --nocache_test_results \
   --test_output=errors
 ```
 
 Coverage notes
 
-I attempted a `bazel coverage` run; Bazel invoked `gcov` with flags that do not match the macOS-provided toolchain, producing no coverage data (errors like "gcov: Unknown command line argument '-output'" in the test logs).
+I attempted a `bazelisk coverage` run; Bazel invoked `gcov` with flags that do not match the macOS-provided toolchain, producing no coverage data (errors like "gcov: Unknown command line argument '-output'" in the test logs).
 
 Quick fixes:
 
@@ -49,7 +49,7 @@ brew install gcc
 - Re-run coverage once gcov is GNU-compatible:
 
 ```bash
-bazel coverage //library/tests/heuristic_sorting:all \
+bazelisk coverage //library/tests/heuristic_sorting:all \
   --nocache_test_results \
   --test_output=errors
 ```

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -81,6 +81,15 @@ py_test(
     }),
 )
 
+# Guard: CI workflows must invoke bazelisk rather than bare bazel.
+py_test(
+    name = "ci_bazelisk_test",
+    size = "small",
+    main = "tests/ci_bazelisk_test.py",
+    srcs = ["tests/ci_bazelisk_test.py"],
+    data = ["//.github/workflows:all_workflows"],
+)
+
 py_test(
     name = "python_interface_smoke_test",
     size = "small",

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -5,13 +5,13 @@ See also `python/tests/README.md` and `docs/python_interface.md`
 *Run via Bazel*
 
 ```bash
-bazel run //python/examples:dd_table_for_deal "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 5.A95432.7632.K6 AKJ9842.K.T8.J93"
+bazelisk run //python/examples:dd_table_for_deal "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 5.A95432.7632.K6 AKJ9842.K.T8.J93"
 ```
 
 or
 
 ```bash
-bazel run //python/examples:dd_table_for_deal hands/example.pbn
+bazelisk run //python/examples:dd_table_for_deal hands/example.pbn
 ```
 
 
@@ -19,7 +19,7 @@ bazel run //python/examples:dd_table_for_deal hands/example.pbn
 
 To run the examples directly, without Bazel, first build the native module and set `PYTHONPATH`:
 
-    bazel build //python:_dds3
+    bazelisk build //python:_dds3
     export PYTHONPATH=python:bazel-bin/python
 
 Direct commands:

--- a/python/tests/README.md
+++ b/python/tests/README.md
@@ -114,8 +114,8 @@ The PYTHONPATH should include both the source package directory and the Bazel ex
 
 Example CI command:
 ```bash
-bazel build //python:dds3_lib
-bazel test //python:python_interface_smoke_test
+bazelisk build //python:dds3_lib
+bazelisk test //python:python_interface_smoke_test
 export PYTHONPATH=$PWD/python:$PWD/bazel-bin/python
 pytest python/tests/ -v --tb=short
 ```

--- a/python/tests/benchmark.py
+++ b/python/tests/benchmark.py
@@ -41,7 +41,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Mapping, Sequence, TextIO
+from typing import Callable, Mapping, Sequence, TextIO
 
 SOLVERS = ("solve", "calc")
 ALT_ENTER = "\033[?1049h\033[H\033[2J"
@@ -55,6 +55,14 @@ def dtest_rel(*, os_name: str = os.name) -> Path:
 
 
 DTEST_REL = dtest_rel()
+
+
+def resolve_bazel_command(*, which: Callable[[str], str | None] | None = None) -> str:
+    """Prefer bazelisk; fall back to bazel for older local installs."""
+    finder = which or shutil.which
+    if finder("bazelisk"):
+        return "bazelisk"
+    return "bazel"
 
 
 class BenchmarkError(Exception):
@@ -478,7 +486,7 @@ Options:
   --repeats N         Runs per combination per binary (default: 1; env: REPEATS)
   --max-deals N       Include list10^n.txt files with 10^n <= N (default: 100; env: MAX_DEALS)
                       (alias: --max_deals)
-  --build             Build dtest for the current checkout (bazel build //library/tests:dtest)
+  --build             Build dtest for the current checkout (bazelisk build //library/tests:dtest)
   --branch NAME       Git branch to build and benchmark ("." means the current branch).
                       Repeatable. Each named branch is checked out, dtest is built and
                       its binary saved, then the original branch is restored. A clean
@@ -700,7 +708,10 @@ class BenchmarkRunner:
             raise subprocess.CalledProcessError(proc.returncode, cmd)
 
     def bazel_dtest(self) -> None:
-        self.run_build(["bazel", "build", "//library/tests:dtest"], cwd=self.root)
+        self.run_build(
+            [resolve_bazel_command(), "build", "//library/tests:dtest"],
+            cwd=self.root,
+        )
 
     def checkout_and_build(self, name: str) -> None:
         self.run_build(["git", "-C", str(self.root), "checkout", name])
@@ -708,9 +719,10 @@ class BenchmarkRunner:
 
     def build_branch_binary(self, name: str, dest: Path) -> None:
         if self.cfg.dry_run:
+            bazel = resolve_bazel_command()
             print(f"DRY_RUN: git -C {self.root} checkout {name}", file=self.err)
             print(
-                f"DRY_RUN: (cd {self.root} && bazel build //library/tests:dtest)",
+                f"DRY_RUN: (cd {self.root} && {bazel} build //library/tests:dtest)",
                 file=self.err,
             )
             print(f"DRY_RUN: cp -L {self.root / DTEST_REL} {dest}", file=self.err)
@@ -733,8 +745,9 @@ class BenchmarkRunner:
         if self.cfg.dry_run:
             print(f"DRY_RUN: git -C {self.root} checkout {self.orig_branch}", file=self.err)
             if rebuild:
+                bazel = resolve_bazel_command()
                 print(
-                    f"DRY_RUN: (cd {self.root} && bazel build //library/tests:dtest)",
+                    f"DRY_RUN: (cd {self.root} && {bazel} build //library/tests:dtest)",
                     file=self.err,
                 )
             return
@@ -860,8 +873,9 @@ def main(argv: Sequence[str] | None = None, env: Mapping[str, str] | None = None
 
     if cfg.build:
         if cfg.dry_run:
+            bazel = resolve_bazel_command()
             print(
-                f"DRY_RUN: (cd {root} && bazel build //library/tests:dtest)",
+                f"DRY_RUN: (cd {root} && {bazel} build //library/tests:dtest)",
                 file=sys.stderr,
             )
         else:
@@ -879,7 +893,10 @@ def main(argv: Sequence[str] | None = None, env: Mapping[str, str] | None = None
                     file=sys.stderr,
                 )
                 if i == 0:
-                    print("hint: bazel build //library/tests:dtest", file=sys.stderr)
+                    print(
+                        f"hint: {resolve_bazel_command()} build //library/tests:dtest",
+                        file=sys.stderr,
+                    )
                 return 1
 
     order = run_order(num_bins, reverse=cfg.reverse)

--- a/python/tests/benchmark_test.py
+++ b/python/tests/benchmark_test.py
@@ -187,6 +187,55 @@ class TestRunBuild(unittest.TestCase):
             self.assertEqual(fake_stderr.getvalue(), "")
 
 
+class TestResolveBazelCommand(unittest.TestCase):
+    def test_prefers_bazelisk_when_available(self) -> None:
+        def fake_which(name: str) -> str | None:
+            return "/usr/bin/bazelisk" if name == "bazelisk" else None
+
+        self.assertEqual(benchmark.resolve_bazel_command(which=fake_which), "bazelisk")
+
+    def test_falls_back_to_bazel_when_bazelisk_missing(self) -> None:
+        def fake_which(name: str) -> str | None:
+            return "/usr/bin/bazel" if name == "bazel" else None
+
+        self.assertEqual(benchmark.resolve_bazel_command(which=fake_which), "bazel")
+
+    def test_falls_back_to_bazel_when_neither_on_path(self) -> None:
+        self.assertEqual(benchmark.resolve_bazel_command(which=lambda _name: None), "bazel")
+
+
+class TestBazelDtestCommand(unittest.TestCase):
+    def test_bazel_dtest_invokes_resolved_launcher(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = benchmark.BenchmarkRunner(Path(tmp), benchmark.Config())
+            seen: list[list[str]] = []
+
+            def capture(cmd, **_kwargs):  # type: ignore[no-untyped-def]
+                seen.append(list(cmd))
+
+            with mock.patch.object(runner, "run_build", side_effect=capture):
+                with mock.patch.object(
+                    benchmark, "resolve_bazel_command", return_value="bazelisk"
+                ):
+                    runner.bazel_dtest()
+            self.assertEqual(seen, [["bazelisk", "build", "//library/tests:dtest"]])
+
+    def test_dry_run_build_message_uses_resolved_launcher(self) -> None:
+        err = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = benchmark.BenchmarkRunner(
+                Path(tmp),
+                benchmark.Config(dry_run=True),
+                err=err,
+            )
+            with mock.patch.object(
+                benchmark, "resolve_bazel_command", return_value="bazelisk"
+            ):
+                runner.build_branch_binary("develop", Path(tmp) / "out")
+            self.assertIn("bazelisk build //library/tests:dtest", err.getvalue())
+            self.assertNotIn("bazel build //library/tests:dtest", err.getvalue())
+
+
 class TestRunOrder(unittest.TestCase):
     def test_default(self) -> None:
         self.assertEqual(benchmark.run_order(3, reverse=False), [0, 1, 2])

--- a/python/tests/ci_bazelisk_test.py
+++ b/python/tests/ci_bazelisk_test.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 
 # Matches a bare `bazel` launcher token followed by a Bazel subcommand.
-# Intentionally does not match paths (bazel-bin), artifact names, or
-# bazelisk / bazelisk-version / bazel-contrib.
+# Lookbehind excludes word chars / `.` / `-` so `bazelisk`, `bazel-bin`, and
+# `bazel-contrib` do not match. Absolute or drive-qualified paths such as
+# `/usr/bin/bazel build` still match — CI should use bazelisk, not bare bazel.
 _BARE_BAZEL_CMD = re.compile(
     r"(?<![\w.-])bazel\s+(build|test|fetch|run|clean|shutdown|coverage|info|mod|query)\b"
 )
@@ -27,6 +28,23 @@ def _repo_root(start: Path | None = None) -> Path:
         if workflows.is_dir() and any(workflows.glob("ci_*.yml")):
             return parent
     raise AssertionError("could not locate repository root from test file path")
+
+
+class TestBareBazelCmd(unittest.TestCase):
+    def test_matches_bare_bazel_subcommand(self) -> None:
+        self.assertIsNotNone(_BARE_BAZEL_CMD.search("bazel build //..."))
+        self.assertIsNotNone(_BARE_BAZEL_CMD.search("  bazel test --verbose_failures //..."))
+
+    def test_matches_path_qualified_bare_bazel(self) -> None:
+        """CI must not sneak past the guard via an absolute bazel path."""
+        self.assertIsNotNone(_BARE_BAZEL_CMD.search("/usr/bin/bazel build //..."))
+        self.assertIsNotNone(_BARE_BAZEL_CMD.search(r"C:\tools\bazel test //..."))
+
+    def test_does_not_match_bazelisk_or_artifact_names(self) -> None:
+        self.assertIsNone(_BARE_BAZEL_CMD.search("bazelisk build //..."))
+        self.assertIsNone(_BARE_BAZEL_CMD.search("bazelisk-version: 1.0"))
+        self.assertIsNone(_BARE_BAZEL_CMD.search("path: bazel-bin/library/tests/dtest"))
+        self.assertIsNone(_BARE_BAZEL_CMD.search("https://github.com/bazel-contrib/rules_python"))
 
 
 class TestRepoRoot(unittest.TestCase):

--- a/python/tests/ci_bazelisk_test.py
+++ b/python/tests/ci_bazelisk_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Guard that CI invokes bazelisk, not bare bazel, for Bazel CLI commands."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+# Matches a bare `bazel` launcher token followed by a Bazel subcommand.
+# Intentionally does not match paths (bazel-bin), artifact names, or
+# bazelisk / bazelisk-version / bazel-contrib.
+_BARE_BAZEL_CMD = re.compile(
+    r"(?<![\w.-])bazel\s+(build|test|fetch|run|clean|shutdown|coverage|info|mod|query)\b"
+)
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        workflows = parent / ".github" / "workflows"
+        if workflows.is_dir() and any(workflows.glob("ci_*.yml")):
+            return parent
+    raise AssertionError("could not locate repository root from test file path")
+
+
+class TestCiUsesBazelisk(unittest.TestCase):
+    def test_workflow_run_steps_use_bazelisk_launcher(self) -> None:
+        workflows = sorted((_repo_root() / ".github" / "workflows").glob("ci_*.yml"))
+        self.assertTrue(workflows, "expected CI workflow YAML files")
+        offenders: list[str] = []
+        for path in workflows:
+            text = path.read_text(encoding="utf-8")
+            for i, line in enumerate(text.splitlines(), start=1):
+                if line.lstrip().startswith("#"):
+                    continue
+                if _BARE_BAZEL_CMD.search(line):
+                    offenders.append(f"{path.name}:{i}: {line.strip()}")
+        self.assertEqual(
+            offenders,
+            [],
+            "CI should invoke bazelisk (not bare bazel) for Bazel commands:\n"
+            + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/ci_bazelisk_test.py
+++ b/python/tests/ci_bazelisk_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -16,13 +17,40 @@ _BARE_BAZEL_CMD = re.compile(
 )
 
 
-def _repo_root() -> Path:
-    here = Path(__file__).resolve()
+def _repo_root(start: Path | None = None) -> Path:
+    # Do not Path.resolve() — under `bazel test` this file is often a runfiles
+    # symlink into the execroot/source tree, and resolving leaves the runfiles
+    # tree where //.github/workflows data deps live.
+    here = (start or Path(__file__)).absolute()
     for parent in here.parents:
         workflows = parent / ".github" / "workflows"
         if workflows.is_dir() and any(workflows.glob("ci_*.yml")):
             return parent
     raise AssertionError("could not locate repository root from test file path")
+
+
+class TestRepoRoot(unittest.TestCase):
+    def test_does_not_follow_symlink_out_of_runfiles_tree(self) -> None:
+        """Runfiles often symlink sources; resolve() would miss sibling data deps."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            source = tmp_path / "source" / "python" / "tests"
+            source.mkdir(parents=True)
+            (source / "ci_bazelisk_test.py").write_text("# source copy\n", encoding="utf-8")
+
+            runfiles = tmp_path / "runfiles" / "_main"
+            tests_dir = runfiles / "python" / "tests"
+            tests_dir.mkdir(parents=True)
+            workflows = runfiles / ".github" / "workflows"
+            workflows.mkdir(parents=True)
+            (workflows / "ci_linux.yml").write_text("name: ci\n", encoding="utf-8")
+
+            link = tests_dir / "ci_bazelisk_test.py"
+            link.symlink_to(source / "ci_bazelisk_test.py")
+
+            root = _repo_root(start=link)
+            self.assertEqual(root, runfiles)
+            self.assertTrue((root / ".github" / "workflows" / "ci_linux.yml").is_file())
 
 
 class TestCiUsesBazelisk(unittest.TestCase):

--- a/specs/wasm-emscripten.md
+++ b/specs/wasm-emscripten.md
@@ -30,7 +30,7 @@ core solver builds and runs correctly under Emscripten.
   `dtest_wasm` (← `//library/tests:dtest`) ports the hand-list test harness for
   Node (host file access via `NODERAWFS`); it is not part of `all_examples_wasm`.
   `//wasm:run_dtest_wasm` is a `py_binary` that runs that module under Node
-  (`bazel run //wasm:run_dtest_wasm -- …`).
+  (`bazelisk run //wasm:run_dtest_wasm -- …`).
 - **The toolchain is hermetic and transition-driven.** `wasm_cc_binary` applies an
   Emscripten **platform transition** to the underlying `cc_binary` — no
   `--config=wasm` or `.bazelrc` profile is needed. The emsdk toolchain is
@@ -64,7 +64,7 @@ core solver builds and runs correctly under Emscripten.
 - `wasm/BUILD.bazel` — the example `wasm_cc_binary` targets, `dtest_wasm`,
   `run_dtest_wasm`, `all_examples_wasm`, `calc_dd_table_pbn_test`,
   `wasm_examples_system_test`, and the test suites.
-- `wasm/run_dtest_wasm.py` — `bazel run` entry that invokes `dtest.js` via Node.
+- `wasm/run_dtest_wasm.py` — `bazelisk run` entry that invokes `dtest.js` via Node.
 - `wasm/tests/test_wasm_examples_system.py` — the end-to-end runner.
 - Consumer guide: `docs/wasm_build.md`. Shared link flags: `WASM_LINKOPTS` in
   `wasm_compat.bzl`.

--- a/wasm/BUILD.bazel
+++ b/wasm/BUILD.bazel
@@ -44,7 +44,7 @@ wasm_cc_binary(
     ],
 )
 
-# `bazel run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2`
+# `bazelisk run //wasm:run_dtest_wasm -- -f hands/list2.txt -s solve -n 2`
 py_binary(
     name = "run_dtest_wasm",
     srcs = ["run_dtest_wasm.py"],

--- a/wasm/run_dtest_wasm.py
+++ b/wasm/run_dtest_wasm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run //wasm:dtest_wasm under Node.js (for `bazel run //wasm:run_dtest_wasm`)."""
+"""Run //wasm:dtest_wasm under Node.js (for `bazelisk run //wasm:run_dtest_wasm`)."""
 from __future__ import annotations
 
 import os
@@ -52,7 +52,7 @@ def rlocation(relpath: str) -> Path:
     name = Path(relpath).name
     candidates: list[Path] = []
 
-    # Same Bazel package: data deps land beside this script under bazel run.
+    # Same Bazel package: data deps land beside this script under bazelisk run.
     # Do not Path.resolve() — that follows the runfiles symlink into the
     # source tree and loses the sibling .js/.wasm data deps.
     candidates.append(Path(__file__).absolute().parent / name)
@@ -97,7 +97,7 @@ def build_node_command(*, js_path: str, argv: list[str]) -> list[str]:
 
 
 def resolve_cwd(env: dict[str, str]) -> str | None:
-    # `bazel run` sets this to the directory where the user invoked Bazel, so
+    # `bazelisk run` sets this to the directory where the user invoked Bazel, so
     # relative -f paths like hands/list1.txt resolve under NODERAWFS.
     return env.get("BUILD_WORKING_DIRECTORY") or None
 

--- a/web/dds_mvp.js
+++ b/web/dds_mvp.js
@@ -5,7 +5,7 @@
 //   https://opensource.org/licenses/MIT
 
 // Unit tests: web/tests/dds_mvp_test.mjs
-// Run with: bazel test //web:dds_mvp_js_test
+// Run with: bazelisk test //web:dds_mvp_js_test
 // or: python -m unittest web.tests.test_dds_mvp_js
 // or: node --test web/tests/dds_mvp_test.mjs
 

--- a/web/requirements.in
+++ b/web/requirements.in
@@ -8,12 +8,12 @@
 # Normal Bazel builds consume requirements_lock.txt; they do not regenerate it.
 # To update requirements_lock.txt after editing this file:
 #
-#   bazel run @python_3_14//:python3 -- -m pip install pip-tools
-#   bazel run @python_3_14//:python3 -- -m piptools compile --generate-hashes \
+#   bazelisk run @python_3_14//:python3 -- -m pip install pip-tools
+#   bazelisk run @python_3_14//:python3 -- -m piptools compile --generate-hashes \
 #     --output-file=web/requirements_lock.txt web/requirements.in
 #
 # Todo: Consider adding a 'compile_pip_requirements' rules_python target that
-# would be invoked by 'bazel run … --update'. If done, though, requirements_lock.txt
+# would be invoked by 'bazelisk run … --update'. If done, though, requirements_lock.txt
 # should remain in the repo so that it stays versioned.
 
 playwright==1.52.0

--- a/web/tests/dds_mvp_test.mjs
+++ b/web/tests/dds_mvp_test.mjs
@@ -2,7 +2,7 @@
  * Unit tests for web/dds_mvp.js (Node built-in test runner).
  *
  * Run with:
- *    bazel test //web:dds_mvp_js_test
+ *    bazelisk test //web:dds_mvp_js_test
  * or: python -m unittest web.tests.test_dds_mvp_js
  * or: node --test web/tests/dds_mvp_test.mjs
  */

--- a/web/tests/test_dds_mvp_js.py
+++ b/web/tests/test_dds_mvp_js.py
@@ -1,6 +1,6 @@
 """Unit tests for web/dds_mvp.js via Node's built-in test runner.
 
-Run with: bazel test //web:dds_mvp_js_test
+Run with: bazelisk test //web:dds_mvp_js_test
 or: python -m unittest web.tests.test_dds_mvp_js
 or: node --test web/tests/dds_mvp_test.mjs
 """

--- a/web/update_wasm.sh
+++ b/web/update_wasm.sh
@@ -2,8 +2,13 @@
 # Copy Bazel WASM artifacts next to dds_mvp.html for local static serving.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-bazel build //web:dds_mvp_wasm
-bin="$(bazel info bazel-bin)/web"
+if command -v bazelisk >/dev/null 2>&1; then
+  BAZEL=bazelisk
+else
+  BAZEL=bazel
+fi
+"$BAZEL" build //web:dds_mvp_wasm
+bin="$("$BAZEL" info bazel-bin)/web"
 cp -f "${bin}/dds_mvp_wasm.js" web/
 cp -f "${bin}/dds_mvp_wasm.wasm" web/
 chmod u+w web/dds_mvp_wasm.js


### PR DESCRIPTION
## Summary
- Switch Bazel CLI invocations from bare `bazel` to `bazelisk` so Linux/Windows/WASM CI match macOS, and so local scripts/docs follow the same launcher CI already installs.
- Prefer `bazelisk` in scripts (`web/update_wasm.sh`, `python/tests/benchmark.py`) with a `bazel` fallback when it is missing from `PATH`.
- Add `//python:ci_bazelisk_test` so bare `bazel` launchers do not regress in CI workflows; keep root discovery inside the runfiles tree (avoid `Path.resolve()`).

## Test plan
- [x] `python3 -m unittest` for benchmark + CI guard tests
- [x] `bazelisk test //python:benchmark_test //python:ci_bazelisk_test`
- [ ] CI green on this PR (Linux / macOS / Windows / WASM)


Made with [Cursor](https://cursor.com)