### PR TITLE
Add UndefinedBehaviorSanitizer build/test option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,7 +77,7 @@ build:asan_macos --copt=-Wno-macro-redefined
 # Usage: bazel test --config=tsan //path:target
 # macOS loads Xcode's compiler-rt via build:tsan_macos (rpath uses clang/N).
 # Keep N aligned with MODULE.bazel llvm_versions and installed Xcode; see
-# docs/BUILD_SYSTEM.md ("AddressSanitizer and ThreadSanitizer (macOS)").
+# docs/BUILD_SYSTEM.md (sanitizer macOS section).
 build:tsan --config=tsan_macos
 build:tsan --copt=-fsanitize=thread
 build:tsan --linkopt=-fsanitize=thread
@@ -87,3 +87,21 @@ build:tsan --compilation_mode=dbg
 test:tsan --test_timeout=120,300,900,3600
 # Hardcoded rpath: .../lib/clang/21/... must match MODULE.bazel llvm major and Xcode.
 build:tsan_macos --linkopt=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin
+
+# UndefinedBehaviorSanitizer configuration
+# Usage: bazel test --config=ubsan //path:target
+# Standalone (not combined with asan): keeps failure attribution clear and
+# avoids macOS ASAN's Xcode-toolchain coupling. Instrumentation uses hermetic
+# LLVM; macOS loads Xcode's UBSAN runtime via build:ubsan_macos (same clang/N
+# coupling as tsan_macos — see docs/BUILD_SYSTEM.md).
+build:ubsan --config=ubsan_macos
+build:ubsan --copt=-fsanitize=undefined
+build:ubsan --linkopt=-fsanitize=undefined
+# Fail the process on the first UB report (default is to continue).
+build:ubsan --copt=-fno-sanitize-recover=undefined
+build:ubsan --strip=never
+build:ubsan --features=dbg
+build:ubsan --compilation_mode=dbg
+test:ubsan --test_timeout=120,300,900,3600
+# Hardcoded rpath: .../lib/clang/21/... must match MODULE.bazel llvm major and Xcode.
+build:ubsan_macos --linkopt=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,9 @@ bazelisk build -c dbg //...
 
 # Build with AddressSanitizer (see .bazelrc build:asan and docs/BUILD_SYSTEM.md)
 bazelisk build --config=asan //...
+
+# Build with UndefinedBehaviorSanitizer (standalone; see docs/BUILD_SYSTEM.md)
+bazelisk build --config=ubsan //...
 ```
 
 ### Build Time Expectations
@@ -203,6 +206,9 @@ Before finalizing changes, optionally run:
 # Check for memory leaks (see docs/BUILD_SYSTEM.md for macOS/Linux notes)
 bazelisk build --config=asan //...
 bazelisk test --config=asan //...
+
+# Check for undefined behavior
+bazelisk test --config=ubsan //...
 
 # Performance test with real hands
 bazelisk build //library/tests:dtest

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -158,3 +158,49 @@ jobs:
           path: bazel-testlogs/
           if-no-files-found: ignore
           retention-days: 30
+
+  ubsan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Setup Bazelisk
+        uses: ./.github/actions/setup-bazelisk
+
+      - name: Prefetch external repos
+        run: |
+          max=3
+          for i in $(seq 1 "$max"); do
+            if bazelisk fetch --config=ubsan //library/tests/...; then
+              exit 0
+            fi
+            if [ "$i" -lt "$max" ]; then
+              echo "Fetch failed (attempt $i/$max). Retrying in 20s..."
+              sleep 20
+            fi
+          done
+          exit 1
+
+      - name: Run tests (UndefinedBehaviorSanitizer)
+        run: bazelisk test --config=ubsan --verbose_failures --test_output=errors //library/tests/...
+
+      - name: Upload UBSAN test logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-linux-ubsan
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -74,7 +74,8 @@ jobs:
           max=3
           for i in $(seq 1 "$max"); do
             if bazelisk fetch --config=asan //library/tests/system/... \
-              && bazelisk fetch --config=tsan //library/tests/system/...; then
+              && bazelisk fetch --config=tsan //library/tests/system/... \
+              && bazelisk fetch --config=ubsan //library/tests/system/...; then
               exit 0
             fi
             if [ "$i" -lt "$max" ]; then
@@ -89,6 +90,9 @@ jobs:
 
       - name: Run system tests (ThreadSanitizer)
         run: bazelisk test --config=tsan --verbose_failures --test_output=errors //library/tests/system/...
+
+      - name: Run system tests (UndefinedBehaviorSanitizer)
+        run: bazelisk test --config=ubsan --verbose_failures --test_output=errors //library/tests/system/...
 
       - name: Upload sanitizer test logs
         if: always()

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -64,21 +64,21 @@ If you see runtime loader failures after a toolchain or OS change:
 2. Re-resolve Bazel toolchains (`bazelisk shutdown`, then `bazelisk clean --expunge`).
 3. Re-run `bazelisk test //...` to confirm runtime compatibility.
 
-### AddressSanitizer and ThreadSanitizer (macOS)
+### AddressSanitizer, ThreadSanitizer, and UndefinedBehaviorSanitizer (macOS)
 
-Sanitizer builds use `--config=asan` or `--config=tsan` (see `.bazelrc`).
-Do not use `--define=asan=true`; that path is not supported.
+Sanitizer builds use `--config=asan`, `--config=tsan`, or `--config=ubsan`
+(see `.bazelrc`). Do not use `--define=asan=true`; that path is not supported.
 macOS-specific settings are chained automatically; you do not pass a separate
-`asan_macos` or `tsan_macos` flag.
+`asan_macos`, `tsan_macos`, or `ubsan_macos` flag.
 
 **Clang / Xcode version coupling.** Three places must stay on the same **clang
 major** version (currently **21**):
 
 | Location | Role |
 |----------|------|
-| `MODULE.bazel` → `llvm_versions` | Hermetic LLVM used for normal builds and for TSAN instrumentation |
-| Installed Xcode (`xcrun clang++ --version`) | ASAN compiler/runtime; TSAN `compiler-rt` dylib |
-| `.bazelrc` → `build:tsan_macos` rpath (`.../lib/clang/21/lib/darwin`) | Lets LLVM-instrumented TSAN binaries load Xcode's TSAN runtime |
+| `MODULE.bazel` → `llvm_versions` | Hermetic LLVM used for normal builds and for TSAN/UBSAN instrumentation |
+| Installed Xcode (`xcrun clang++ --version`) | ASAN compiler/runtime; TSAN/UBSAN `compiler-rt` dylibs |
+| `.bazelrc` → `build:tsan_macos` / `build:ubsan_macos` rpath (`.../lib/clang/21/lib/darwin`) | Lets LLVM-instrumented TSAN/UBSAN binaries load Xcode's runtimes |
 
 **ASAN (`--config=asan`).** macOS builds select the Xcode CC toolchain via
 `apple_support` (`build:asan_macos`). LLVM's bundled ASAN runtime hangs at
@@ -90,21 +90,29 @@ toolchain; only the **runtime** comes from Xcode's `compiler-rt`. LLVM's TSAN
 dylib segfaults on current macOS, but Xcode's dylib works with LLVM-instrumented
 binaries when the clang major matches.
 
+**UBSAN (`--config=ubsan`).** Standalone config (not combined with ASAN) so
+failure attribution stays clear and ASAN's Xcode-toolchain coupling is not
+shared. Like TSAN, instrumentation uses hermetic LLVM and the runtime is loaded
+from Xcode via `build:ubsan_macos`. `-fno-sanitize-recover=undefined` makes the
+first UB report abort the process (required for CI).
+
 **When upgrading LLVM or Xcode**, update all coupled paths together:
 
 1. Bump `llvm_versions` in `MODULE.bazel` (and run
    `bazelisk mod deps --lockfile_mode=update` to refresh `MODULE.bazel.lock`).
-2. Update the `clang/N` segment in `build:tsan_macos` in `.bazelrc` to match the
-   new major version.
+2. Update the `clang/N` segment in `build:tsan_macos` and `build:ubsan_macos` in
+   `.bazelrc` to match the new major version.
 3. Confirm Xcode ships that major:  
    `xcrun clang++ --version`  
-   `xcrun clang -print-file-name=libclang_rt.tsan_osx_dynamic.dylib`
+   `xcrun clang -print-file-name=libclang_rt.tsan_osx_dynamic.dylib`  
+   `xcrun clang -print-file-name=libclang_rt.ubsan_osx_dynamic.dylib`
 4. Re-run sanitizer smoke tests, e.g.  
    `bazelisk test --config=asan //library/tests/system:context_tt_facade_test`  
-   `bazelisk test --config=tsan //library/tests/system:thread_safety_stress_test`
+   `bazelisk test --config=tsan //library/tests/system:thread_safety_stress_test`  
+   `bazelisk test --config=ubsan //library/tests/system:context_tt_facade_test`
 
-If TSAN fails to start after an Xcode upgrade (dyld cannot load the runtime),
-the rpath major is likely out of sync with the installed toolchain.
+If TSAN or UBSAN fails to start after an Xcode upgrade (dyld cannot load the
+runtime), the rpath major is likely out of sync with the installed toolchain.
 
 **CI.** GitHub Actions runs sanitizer jobs on pull requests to `main` and
 `develop`:
@@ -113,7 +121,8 @@ the rpath major is likely out of sync with the installed toolchain.
 |----------|-----|---------|
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
-| `ci_macos.yml` | `sanitizers` | ASAN and TSAN on `//library/tests/system/...` (validates macOS toolchain/rpath wiring) |
+| `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |
+| `ci_macos.yml` | `sanitizers` | ASAN, TSAN, and UBSAN on `//library/tests/system/...` (validates macOS toolchain/rpath wiring) |
 
 
 ## Visual Studio and Rider Build

--- a/library/src/heuristic_sorting/heuristic_sorting.cpp
+++ b/library/src/heuristic_sorting/heuristic_sorting.cpp
@@ -864,6 +864,13 @@ void get_top_number(const HeuristicContext& ctx, const int ris, const int prank,
   int removed = static_cast<int>(ctx.removed_ranks[ctx.lead_suit] |
                                  bit_map_rank[prank]);
 
+  // Empty suit: last_group_ == -1; no sequence to measure.
+  if (g < 0)
+  {
+    top_number = -1;
+    return;
+  }
+
   int fullseq = mp.fullseq_[g];
 
   while (g >= 1 && ((mp.gap_[g] & removed) == mp.gap_[g]))

--- a/library/src/lookup_tables/lookup_tables.cpp
+++ b/library/src/lookup_tables/lookup_tables.cpp
@@ -182,11 +182,15 @@ static auto init_lookup_tables_impl() -> void
       group_data_storage[ris].rank_[g] = topBitNo;
       group_data_storage[ris].sequence_[g] = 0;
       group_data_storage[ris].fullseq_[g] = topBitRank;
-      // gap_[g] is the gap between the current group g and the previous group (g-1).
-      // Since g was just incremented and g >= 1 here, rank_[g-1] is always valid.
-      // The first group (g == 0) is handled separately via explicit initialization above.
-      group_data_storage[ris].gap_[g] =
-        topside[topBitNo] & botside[ group_data_storage[ris].rank_[g - 1] ];
+      // gap_[g] is the gap between group g and the previous group (g-1).
+      // When opening the first group from an empty suit (last_group_ was -1),
+      // g == 0 and there is no previous group; gap_[0] is unused (see
+      // MoveGroupType) and stays 0, matching the explicit ris==1 seed above.
+      if (g == 0)
+        group_data_storage[ris].gap_[g] = 0;
+      else
+        group_data_storage[ris].gap_[g] =
+          topside[topBitNo] & botside[ group_data_storage[ris].rank_[g - 1] ];
     }
   }
 }

--- a/library/src/solver_if.cpp
+++ b/library/src/solver_if.cpp
@@ -153,7 +153,6 @@ auto solve_board_internal(
   ctx.search().trick_nodes() = 0;
 
   thrp->lookAheadPos.hand_rel_first = hand_rel_first;
-  thrp->lookAheadPos.first[ini_depth] = dl.first;
   thrp->lookAheadPos.tricks_max = 0;
 
   MoveType mv = {0, 0, 0, 0};
@@ -190,6 +189,9 @@ auto solve_board_internal(
 
     goto SOLVER_DONE;
   }
+
+  // Validated cardCount > 4 ⇒ ini_depth >= 1; safe to index first[].
+  thrp->lookAheadPos.first[ini_depth] = dl.first;
 
 
   // ----------------------------------------------------------

--- a/library/tests/heuristic_sorting/targeted_unit_tests.cpp
+++ b/library/tests/heuristic_sorting/targeted_unit_tests.cpp
@@ -71,11 +71,9 @@ TEST(TargetedUnitTests, GetTopNumberEdgeCases) {
   TrackType track_dummy = {};
   HeuristicContext ctx = { tpos, bm, bmtt, thrp_rel_dummy, mply_dummy, 0, 0, DDS_NOTRUMP, 0, &track_dummy, 0, 0, 0, 0 };
 
-  // Call the free helper get_top_number from internal.hpp
+  // Empty suit (ris == 0): no groups; must not index fullseq_[-1].
   get_top_number(ctx, 0, 14, topNumber, mno);
-  // topNumber may be -1 if no candidate found; ensure values are in expected ranges
-  EXPECT_GE(topNumber, -1);
-  EXPECT_LE(topNumber, 14);
+  EXPECT_EQ(topNumber, -1);
   EXPECT_GE(mno, 0);
   EXPECT_LE(mno, 13);
 

--- a/library/tests/utility/lookup_tables_test.cpp
+++ b/library/tests/utility/lookup_tables_test.cpp
@@ -133,6 +133,19 @@ TEST_F(LookupTablesTest, EmptySetHandling) {
     // Other values for i=0 depend on implementation but should be well-defined
     EXPECT_NO_THROW((void)highest_rank[0]);
     EXPECT_NO_THROW((void)lowest_rank[0]);
+    EXPECT_EQ(group_data[0].last_group_, -1);
+}
+
+TEST_F(LookupTablesTest, SingleCardSuitsOpenGroupZeroWithoutPriorGap) {
+    // Power-of-two bitmasks are single-card suits: copied from the empty suit
+    // (last_group_ == -1), then opened as group 0. gap_[0] is unused and must
+    // stay 0 — never computed via rank_[g-1] (which would be rank_[-1]).
+    for (int bit = 0; bit < 13; ++bit) {
+        const int ris = 1 << bit;
+        EXPECT_EQ(group_data[ris].last_group_, 0) << "ris=" << ris;
+        EXPECT_EQ(group_data[ris].gap_[0], 0) << "ris=" << ris;
+        EXPECT_EQ(group_data[ris].rank_[0], bit + 2) << "ris=" << ris;
+    }
 }
 
 TEST_F(LookupTablesTest, FullSetHandling) {


### PR DESCRIPTION
## Summary
- Add standalone `--config=ubsan` (not combined with ASan) with macOS Xcode `compiler-rt` rpath, matching the TSan pattern
- Wire UBSan into Linux CI (`ubsan` job on `//library/tests/...`) and macOS `sanitizers` job
- Fix UBSan-found undefined behavior: `rank_[-1]` in lookup-table init, `first[-4]` on empty deals in `solve_board`, and `fullseq_[-1]` in `get_top_number` for empty suits

## Test plan
- [x] `bazelisk test --config=ubsan //library/tests/...` (41/41 pass locally on macOS)
- [x] Linux CI `ubsan` job green
- [x] macOS CI `sanitizers` job includes UBSan step and stays green
- [x] Spot-check docs: `docs/BUILD_SYSTEM.md` UBSan section matches `.bazelrc`


Made with [Cursor](https://cursor.com)