### PR TITLE
Add par output to dd_table_for_deal

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//:CPPVARIABLES.bzl", "DDS_CPPOPTS", "DDS_LINKOPTS", "DDS_LOCAL_DEFINES")
 load("//:wasm_compat.bzl", "WASM_LINKOPTS")
 
@@ -150,6 +150,31 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "dd_table_for_deal_lib",
+    srcs = ["dd_table_for_deal_lib.cpp"],
+    hdrs = ["dd_table_for_deal.hpp"],
+    includes = ["."],
+    copts = EXAMPLES_CPPOPTS,
+    local_defines = EXAMPLES_LOCAL_DEFINES,
+    deps = [
+        "//library/src/api:api_definitions",
+    ],
+)
+
+cc_test(
+    name = "dd_table_for_deal_test",
+    size = "small",
+    srcs = ["tests/dd_table_for_deal_test.cpp"],
+    copts = EXAMPLES_CPPOPTS,
+    local_defines = EXAMPLES_LOCAL_DEFINES,
+    deps = [
+        ":dd_table_for_deal_lib",
+        "//library/src/api:api_definitions",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_binary(
     name = "dd_table_for_deal",
     srcs = ["dd_table_for_deal.cpp"],
@@ -157,6 +182,7 @@ cc_binary(
     linkopts = DDS_LINKOPTS,
     local_defines = EXAMPLES_LOCAL_DEFINES,
     deps = [
+        ":dd_table_for_deal_lib",
         ":hands",
         "//library/src:dds",
         "//library/src/api:api_definitions",

--- a/examples/README
+++ b/examples/README
@@ -13,6 +13,7 @@ Run an example:
 
 Python `dd_table_for_deal` (see `python/examples/`):
     bazelisk run //python/examples:dd_table_for_deal -- hands/example.pbn
+    bazelisk run //python/examples:dd_table_for_deal -- --vul ns hands/example.pbn
 
 Available examples:
 - analyse_all_plays_bin, analyse_all_plays_pbn

--- a/examples/README
+++ b/examples/README
@@ -14,6 +14,7 @@ Run an example:
 Python `dd_table_for_deal` (see `python/examples/`):
     bazelisk run //python/examples:dd_table_for_deal -- hands/example.pbn
     bazelisk run //python/examples:dd_table_for_deal -- --vul ns hands/example.pbn
+    bazelisk run //python/examples:dd_table_for_deal -- --limit 3 hands/multi_board.pbn
 
 Available examples:
 - analyse_all_plays_bin, analyse_all_plays_pbn

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -156,7 +156,7 @@ auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
 
 auto print_par_or_verbose(
     DdTableResults const * table,
-    int vulnerable) -> void
+    int vulnerable) -> bool
 {
   ParResultsMaster sidesRes[2];
   const int res = SidesParBin(table, sidesRes, vulnerable);
@@ -165,13 +165,13 @@ auto print_par_or_verbose(
     char line[80];
     ErrorMessage(res, line);
     fprintf(stderr, "DDS error: %s\n", line);
-    return;
+    return false;
   }
 
   if (const auto line = format_par_line(sidesRes))
   {
     printf("%s\n", line->c_str());
-    return;
+    return true;
   }
 
   ParResults par;
@@ -181,10 +181,11 @@ auto print_par_or_verbose(
   {
     ErrorMessage(par_res, err);
     fprintf(stderr, "DDS error: %s\n", err);
-    return;
+    return false;
   }
 
   print_par(&par);
+  return true;
 }
 
 
@@ -224,7 +225,8 @@ auto process_deal(
 
   print_pbn_hand(line, tableDealPBN.cards);
   print_table(&table);
-  print_par_or_verbose(&table, vulnerable);
+  if (!print_par_or_verbose(&table, vulnerable))
+    return false;
   if (deal_count > 1)
     printf("\n");
   return true;

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -13,7 +13,6 @@
 // Coded by Cursor, based on calc_dd_table.cpp
 
 #include <algorithm>
-#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -21,7 +20,6 @@
 #include <fstream>
 #include <iostream>
 #include <optional>
-#include <regex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -31,17 +29,18 @@
 #include <unistd.h>
 #endif
 #include <api/dll.h>
+#include "dd_table_for_deal.hpp"
 #include "hands.hpp"
 
 
 namespace {
 
-constexpr std::size_t PBN_FILE_MAX = 16 * 1024 * 1024;
-constexpr std::size_t PBN_DEAL_MAX = sizeof(DdTableDealPBN::cards);
-
-const std::regex DEAL_TAG_RE{
-    R"re(\[Deal\s*"([^"]*)")re",
-    std::regex::icase};
+using dd_table_for_deal::PBN_DEAL_MAX;
+using dd_table_for_deal::PBN_FILE_MAX;
+using dd_table_for_deal::extract_deal_tags;
+using dd_table_for_deal::format_par_line;
+using dd_table_for_deal::looks_like_path;
+using dd_table_for_deal::parse_vulnerable;
 
 
 static auto stdin_is_tty() -> bool
@@ -107,61 +106,6 @@ auto read_pbn_file_workspace_relative(std::string_view path)
 }
 
 
-auto extract_deal_tags(std::string_view text) -> std::vector<std::string>
-{
-  std::vector<std::string> deals;
-  auto begin = text.cbegin();
-  const auto end = text.cend();
-  std::match_results<std::string_view::const_iterator> match;
-  while (std::regex_search(begin, end, match, DEAL_TAG_RE) && match.size() > 1)
-  {
-    deals.emplace_back(match[1].first, match[1].second);
-    begin = match[0].second;
-  }
-  return deals;
-}
-
-
-auto parse_vulnerable(std::string_view text) -> std::optional<int>
-{
-  std::string lower(text);
-  std::transform(lower.begin(), lower.end(), lower.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-
-  if (lower == "none" || lower == "0")
-    return 0;
-  if (lower == "both" || lower == "1")
-    return 1;
-  if (lower == "ns" || lower == "2")
-    return 2;
-  if (lower == "ew" || lower == "3")
-    return 3;
-  return std::nullopt;
-}
-
-
-auto looks_like_path(std::string_view arg) -> bool
-{
-  if (arg.find('/') != std::string_view::npos
-      || arg.find('\\') != std::string_view::npos)
-  {
-    return true;
-  }
-
-  if (arg.size() >= 4)
-  {
-    std::string lower(arg.substr(arg.size() - 4));
-    std::transform(lower.begin(), lower.end(), lower.begin(),
-                   [](unsigned char c) {
-                     return static_cast<char>(std::tolower(c));
-                   });
-    if (lower == ".pbn" || lower == ".txt")
-      return true;
-  }
-  return false;
-}
-
-
 auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
 {
   if (arg == "-")
@@ -212,116 +156,6 @@ auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
 }
 
 
-auto denom_char(int denom) -> char
-{
-  static constexpr char kDenomChars[] = "NSHDC";
-  if (denom < 0 || denom > 4)
-    return '?';
-  return kDenomChars[denom];
-}
-
-
-auto seat_name(int seats) -> const char *
-{
-  static const char * kSeatNames[] = {"N", "E", "S", "W", "NS", "EW"};
-  if (seats < 0 || seats > 5)
-    return "?";
-  return kSeatNames[seats];
-}
-
-
-auto format_contract(const ContractType& contract, char * out, std::size_t out_size)
-    -> bool
-{
-  if (out_size < 8)
-    return false;
-
-  if (contract.under_tricks > 0)
-  {
-    std::snprintf(
-        out,
-        out_size,
-        "%s %d%cx",
-        seat_name(contract.seats),
-        contract.level,
-        denom_char(contract.denom));
-  }
-  else
-  {
-    std::snprintf(
-        out,
-        out_size,
-        "%s %d%c",
-        seat_name(contract.seats),
-        contract.level,
-        denom_char(contract.denom));
-  }
-  return true;
-}
-
-
-auto format_par_line(
-    ParResultsMaster const sidesRes[2],
-    int /*vulnerable*/,
-    char * line,
-    std::size_t line_size) -> bool
-{
-  if (line_size < 32)
-    return false;
-
-  if (sidesRes[0].score == 0 && sidesRes[1].score == 0)
-  {
-    std::snprintf(line, line_size, "Par: 0");
-    return true;
-  }
-
-  // Prefer the side whose score matches the declaring side's viewpoint.
-  const ContractType& first = sidesRes[0].number > 0
-      ? sidesRes[0].contracts[0]
-      : sidesRes[1].contracts[0];
-  const int side =
-      (first.seats == 4 || first.seats == 0 || first.seats == 2) ? 0 : 1;
-  const ParResultsMaster& chosen = sidesRes[side];
-  if (chosen.number <= 0)
-    return false;
-
-  std::string body;
-  for (int i = 0; i < chosen.number; ++i)
-  {
-    char piece[16];
-    if (!format_contract(chosen.contracts[i], piece, sizeof(piece)))
-      return false;
-    if (i > 0)
-      body += ',';
-    body += piece;
-  }
-
-  const ContractType& contract = chosen.contracts[0];
-  char result[8];
-  if (contract.under_tricks > 0)
-  {
-    std::snprintf(result, sizeof(result), "-%d", contract.under_tricks);
-  }
-  else if (contract.over_tricks > 0)
-  {
-    std::snprintf(result, sizeof(result), "+%d", contract.over_tricks);
-  }
-  else
-  {
-    std::snprintf(result, sizeof(result), "=");
-  }
-
-  const int written = std::snprintf(
-      line,
-      line_size,
-      "Par: %s %s %d",
-      body.c_str(),
-      result,
-      chosen.score);
-  return written > 0 && static_cast<std::size_t>(written) < line_size;
-}
-
-
 auto print_par_or_verbose(
     DdTableResults const * table,
     int vulnerable) -> void
@@ -336,19 +170,19 @@ auto print_par_or_verbose(
     return;
   }
 
-  char line[256];
-  if (format_par_line(sidesRes, vulnerable, line, sizeof(line)))
+  if (const auto line = format_par_line(sidesRes))
   {
-    printf("%s\n", line);
+    printf("%s\n", line->c_str());
     return;
   }
 
   ParResults par;
+  char err[80];
   const int par_res = Par(table, &par, vulnerable);
   if (par_res != RETURN_NO_FAULT)
   {
-    ErrorMessage(par_res, line);
-    fprintf(stderr, "DDS error: %s\n", line);
+    ErrorMessage(par_res, err);
+    fprintf(stderr, "DDS error: %s\n", err);
     return;
   }
 

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -114,7 +114,7 @@ auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
     const auto text = read_pbn_stream(std::cin);
     if (!text)
     {
-      std::cerr << "No PBN input on stdin\n";
+      std::cerr << "Cannot read PBN from stdin\n";
       return std::nullopt;
     }
 
@@ -239,14 +239,15 @@ auto process_deal(
 static auto print_usage(const char * prog) -> void
 {
   fprintf(stderr,
-          "Usage: %s [--vul none|both|ns|ew] <pbn_deal_or_file>\n"
+          "Usage: %s [--vul none|both|ns|ew|0|1|2|3] <pbn_deal_or_file>\n"
           "       %s -h | --help\n"
           "\n"
           "Calculate double-dummy tricks and par for all strains and leads.\n"
           "\n"
           "Arguments:\n"
           "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
-          "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
+          "  --vul              Vulnerability: none|both|ns|ew or 0|1|2|3"
+          " (default: none)\n"
           "\n"
           "If stdin is not a terminal, PBN is read from stdin (all [Deal \"...\"] tags).\n"
           "\n"

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -37,9 +37,11 @@ namespace {
 
 using dd_table_for_deal::PBN_DEAL_MAX;
 using dd_table_for_deal::PBN_FILE_MAX;
+using dd_table_for_deal::apply_deal_limit;
 using dd_table_for_deal::extract_deal_tags;
 using dd_table_for_deal::format_par_line;
 using dd_table_for_deal::looks_like_path;
+using dd_table_for_deal::parse_limit;
 using dd_table_for_deal::parse_vulnerable;
 using dd_table_for_deal::should_report_failed_stream_read;
 using dd_table_for_deal::unique_deals;
@@ -242,7 +244,8 @@ auto process_deal(
 static auto print_usage(const char * prog) -> void
 {
   fprintf(stderr,
-          "Usage: %s [--vul none|both|ns|ew|0|1|2|3] <pbn_deal_or_file>\n"
+          "Usage: %s [--vul none|both|ns|ew|0|1|2|3] [--limit N] "
+          "<pbn_deal_or_file>\n"
           "       %s -h | --help\n"
           "\n"
           "Calculate double-dummy tricks and par for all strains and leads.\n"
@@ -251,6 +254,7 @@ static auto print_usage(const char * prog) -> void
           "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
           "  --vul              Vulnerability: none|both|ns|ew or 0|1|2|3"
           " (default: none)\n"
+          "  --limit            Solve only the first N unique deals\n"
           "\n"
           "If stdin is not a terminal, PBN is read from stdin (all [Deal \"...\"] tags).\n"
           "\n"
@@ -258,7 +262,9 @@ static auto print_usage(const char * prog) -> void
           "  %s \"N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
           "5.A95432.7632.K6 AKJ9842.K.T8.J93\"\n"
           "  %s --vul ns hands/example.pbn\n"
+          "  %s --limit 3 hands/multi_board.pbn\n"
           "  %s < hands/example.pbn\n",
+          prog,
           prog,
           prog,
           prog,
@@ -271,6 +277,7 @@ auto main(int argc, char * argv[]) -> int
 {
   const char * input = nullptr;
   int vulnerable = 0;
+  std::optional<std::size_t> limit;
 
   for (int i = 1; i < argc; ++i)
   {
@@ -295,6 +302,24 @@ auto main(int argc, char * argv[]) -> int
         return 1;
       }
       vulnerable = *vul;
+      continue;
+    }
+    if (strcmp(argv[i], "--limit") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "--limit requires a positive integer\n");
+        print_usage(argv[0]);
+        return 1;
+      }
+      const auto parsed_limit = parse_limit(argv[++i]);
+      if (!parsed_limit)
+      {
+        fprintf(stderr, "Invalid --limit value (use a positive integer)\n");
+        print_usage(argv[0]);
+        return 1;
+      }
+      limit = parsed_limit;
       continue;
     }
     if (argv[i][0] == '-' && strcmp(argv[i], "-") != 0)
@@ -328,7 +353,7 @@ auto main(int argc, char * argv[]) -> int
     return 1;
   }
 
-  const auto deals = unique_deals(*loaded);
+  const auto deals = apply_deal_limit(unique_deals(*loaded), limit);
 
   for (std::size_t i = 0; i < deals.size(); ++i)
   {

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -43,6 +43,8 @@ using dd_table_for_deal::format_par_line;
 using dd_table_for_deal::looks_like_path;
 using dd_table_for_deal::parse_limit;
 using dd_table_for_deal::parse_vulnerable;
+using dd_table_for_deal::path_is_openable;
+using dd_table_for_deal::read_pbn_stream;
 using dd_table_for_deal::should_report_failed_stream_read;
 using dd_table_for_deal::unique_deals;
 
@@ -54,29 +56,6 @@ static auto stdin_is_tty() -> bool
 #else
   return isatty(STDIN_FILENO) != 0;
 #endif
-}
-
-
-auto read_pbn_stream(std::istream& in) -> std::optional<std::string>
-{
-  std::string text;
-  text.reserve(64 * 1024);
-  char buffer[4096];
-  while (in)
-  {
-    in.read(buffer, static_cast<std::streamsize>(sizeof(buffer)));
-    const auto n = in.gcount();
-    if (n > 0)
-      text.append(buffer, static_cast<std::size_t>(n));
-    if (text.size() > PBN_FILE_MAX)
-    {
-      std::cerr << "PBN input too large (max " << PBN_FILE_MAX << " characters)\n";
-      return std::nullopt;
-    }
-  }
-  if (text.empty())
-    return std::nullopt;
-  return text;
 }
 
 
@@ -107,6 +86,18 @@ auto read_pbn_file_workspace_relative(std::string_view path)
   }
 
   return std::nullopt;
+}
+
+
+auto path_openable_workspace_relative(std::string_view path) -> bool
+{
+  if (path_is_openable(path))
+    return true;
+  if (const char* workspace = std::getenv("BUILD_WORKSPACE_DIRECTORY"))
+  {
+    return path_is_openable((std::filesystem::path(workspace) / path).string());
+  }
+  return false;
 }
 
 
@@ -147,7 +138,9 @@ auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
 
   if (looks_like_path(arg))
   {
-    std::cerr << "Cannot read file: " << arg << "\n";
+    // Missing file vs openable-but-failed (e.g. oversize already reported).
+    if (!path_openable_workspace_relative(arg))
+      std::cerr << "Cannot read file: " << arg << "\n";
     return std::nullopt;
   }
 
@@ -330,6 +323,7 @@ auto main(int argc, char * argv[]) -> int
     }
     if (input != nullptr)
     {
+      fprintf(stderr, "Only one deal argument is allowed\n");
       print_usage(argv[0]);
       return 1;
     }

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -230,9 +230,39 @@ auto seat_name(int seats) -> const char *
 }
 
 
+auto format_contract(const ContractType& contract, char * out, std::size_t out_size)
+    -> bool
+{
+  if (out_size < 8)
+    return false;
+
+  if (contract.under_tricks > 0)
+  {
+    std::snprintf(
+        out,
+        out_size,
+        "%s %d%cx",
+        seat_name(contract.seats),
+        contract.level,
+        denom_char(contract.denom));
+  }
+  else
+  {
+    std::snprintf(
+        out,
+        out_size,
+        "%s %d%c",
+        seat_name(contract.seats),
+        contract.level,
+        denom_char(contract.denom));
+  }
+  return true;
+}
+
+
 auto format_par_line(
     ParResultsMaster const sidesRes[2],
-    int vulnerable,
+    int /*vulnerable*/,
     char * line,
     std::size_t line_size) -> bool
 {
@@ -245,44 +275,50 @@ auto format_par_line(
     return true;
   }
 
-  if (sidesRes[0].number != 1 || sidesRes[1].number != 1)
+  // Prefer the side whose score matches the declaring side's viewpoint.
+  const ContractType& first = sidesRes[0].number > 0
+      ? sidesRes[0].contracts[0]
+      : sidesRes[1].contracts[0];
+  const int side =
+      (first.seats == 4 || first.seats == 0 || first.seats == 2) ? 0 : 1;
+  const ParResultsMaster& chosen = sidesRes[side];
+  if (chosen.number <= 0)
     return false;
 
-  const ContractType& contract = sidesRes[0].contracts[0];
-  const char * seats = seat_name(contract.seats);
-  const char result_sign = contract.under_tricks > 0 ? '-' : '+';
-  const int result_value =
-      contract.under_tricks > 0 ? contract.under_tricks : contract.over_tricks;
+  std::string body;
+  for (int i = 0; i < chosen.number; ++i)
+  {
+    char piece[16];
+    if (!format_contract(chosen.contracts[i], piece, sizeof(piece)))
+      return false;
+    if (i > 0)
+      body += ',';
+    body += piece;
+  }
 
+  const ContractType& contract = chosen.contracts[0];
+  char result[8];
   if (contract.under_tricks > 0)
   {
-    std::snprintf(
-        line,
-        line_size,
-        "Par: %s %d%c%c %c%d %d",
-        seats,
-        contract.level,
-        denom_char(contract.denom),
-        'x',
-        result_sign,
-        result_value,
-        sidesRes[0].score);
+    std::snprintf(result, sizeof(result), "-%d", contract.under_tricks);
+  }
+  else if (contract.over_tricks > 0)
+  {
+    std::snprintf(result, sizeof(result), "+%d", contract.over_tricks);
   }
   else
   {
-    std::snprintf(
-        line,
-        line_size,
-        "Par: %s %d%c %c%d %d",
-        seats,
-        contract.level,
-        denom_char(contract.denom),
-        result_sign,
-        result_value,
-        sidesRes[0].score);
+    std::snprintf(result, sizeof(result), "=");
   }
 
-  return true;
+  const int written = std::snprintf(
+      line,
+      line_size,
+      "Par: %s %s %d",
+      body.c_str(),
+      result,
+      chosen.score);
+  return written > 0 && static_cast<std::size_t>(written) < line_size;
 }
 
 
@@ -300,7 +336,7 @@ auto print_par_or_verbose(
     return;
   }
 
-  char line[80];
+  char line[256];
   if (format_par_line(sidesRes, vulnerable, line, sizeof(line)))
   {
     printf("%s\n", line);

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -41,6 +41,7 @@ using dd_table_for_deal::extract_deal_tags;
 using dd_table_for_deal::format_par_line;
 using dd_table_for_deal::looks_like_path;
 using dd_table_for_deal::parse_vulnerable;
+using dd_table_for_deal::unique_deals;
 
 
 static auto stdin_is_tty() -> bool
@@ -317,15 +318,17 @@ auto main(int argc, char * argv[]) -> int
     }
   }
 
-  const auto deals = load_deals(input);
-  if (!deals)
+  const auto loaded = load_deals(input);
+  if (!loaded)
   {
     return 1;
   }
 
-  for (std::size_t i = 0; i < deals->size(); ++i)
+  const auto deals = unique_deals(*loaded);
+
+  for (std::size_t i = 0; i < deals.size(); ++i)
   {
-    if (!process_deal((*deals)[i], i + 1, deals->size(), vulnerable))
+    if (!process_deal(deals[i], i + 1, deals.size(), vulnerable))
       return 1;
   }
 

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -24,6 +24,7 @@
 #include <regex>
 #include <string>
 #include <string_view>
+#include <vector>
 #if defined(_WIN32)
 #include <io.h>
 #else
@@ -35,7 +36,7 @@
 
 namespace {
 
-constexpr std::size_t PBN_FILE_MAX = 8192;
+constexpr std::size_t PBN_FILE_MAX = 16 * 1024 * 1024;
 constexpr std::size_t PBN_DEAL_MAX = sizeof(DdTableDealPBN::cards);
 
 const std::regex DEAL_TAG_RE{
@@ -55,15 +56,23 @@ static auto stdin_is_tty() -> bool
 
 auto read_pbn_stream(std::istream& in) -> std::optional<std::string>
 {
-  std::string text(PBN_FILE_MAX - 1, '\0');
-  in.read(text.data(), static_cast<std::streamsize>(PBN_FILE_MAX - 1));
-  const auto n = in.gcount();
-  if (n <= 0)
+  std::string text;
+  text.reserve(64 * 1024);
+  char buffer[4096];
+  while (in)
   {
-    return std::nullopt;
+    in.read(buffer, static_cast<std::streamsize>(sizeof(buffer)));
+    const auto n = in.gcount();
+    if (n > 0)
+      text.append(buffer, static_cast<std::size_t>(n));
+    if (text.size() > PBN_FILE_MAX)
+    {
+      std::cerr << "PBN input too large (max " << PBN_FILE_MAX << " characters)\n";
+      return std::nullopt;
+    }
   }
-
-  text.resize(static_cast<std::size_t>(n));
+  if (text.empty())
+    return std::nullopt;
   return text;
 }
 
@@ -98,16 +107,18 @@ auto read_pbn_file_workspace_relative(std::string_view path)
 }
 
 
-auto extract_deal_tag(std::string_view text) -> std::optional<std::string>
+auto extract_deal_tags(std::string_view text) -> std::vector<std::string>
 {
+  std::vector<std::string> deals;
+  auto begin = text.cbegin();
+  const auto end = text.cend();
   std::match_results<std::string_view::const_iterator> match;
-  if (std::regex_search(text.cbegin(), text.cend(), match, DEAL_TAG_RE)
-      && match.size() > 1)
+  while (std::regex_search(begin, end, match, DEAL_TAG_RE) && match.size() > 1)
   {
-    return std::string(match[1].first, match[1].second);
+    deals.emplace_back(match[1].first, match[1].second);
+    begin = match[0].second;
   }
-
-  return std::nullopt;
+  return deals;
 }
 
 
@@ -129,7 +140,29 @@ auto parse_vulnerable(std::string_view text) -> std::optional<int>
 }
 
 
-auto load_deal(std::string_view arg) -> std::optional<std::string>
+auto looks_like_path(std::string_view arg) -> bool
+{
+  if (arg.find('/') != std::string_view::npos
+      || arg.find('\\') != std::string_view::npos)
+  {
+    return true;
+  }
+
+  if (arg.size() >= 4)
+  {
+    std::string lower(arg.substr(arg.size() - 4));
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) {
+                     return static_cast<char>(std::tolower(c));
+                   });
+    if (lower == ".pbn" || lower == ".txt")
+      return true;
+  }
+  return false;
+}
+
+
+auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
 {
   if (arg == "-")
   {
@@ -140,26 +173,32 @@ auto load_deal(std::string_view arg) -> std::optional<std::string>
       return std::nullopt;
     }
 
-    const auto deal = extract_deal_tag(*text);
-    if (!deal)
+    const auto deals = extract_deal_tags(*text);
+    if (deals.empty())
     {
       std::cerr << "No [Deal \"...\"] tag found in stdin\n";
       return std::nullopt;
     }
 
-    return deal;
+    return deals;
   }
 
   if (const auto text = read_pbn_file_workspace_relative(arg))
   {
-    const auto deal = extract_deal_tag(*text);
-    if (!deal)
+    const auto deals = extract_deal_tags(*text);
+    if (deals.empty())
     {
       std::cerr << "No [Deal \"...\"] tag found in " << arg << "\n";
       return std::nullopt;
     }
 
-    return deal;
+    return deals;
+  }
+
+  if (looks_like_path(arg))
+  {
+    std::cerr << "Cannot read file: " << arg << "\n";
+    return std::nullopt;
   }
 
   if (arg.size() >= PBN_DEAL_MAX)
@@ -169,7 +208,7 @@ auto load_deal(std::string_view arg) -> std::optional<std::string>
     return std::nullopt;
   }
 
-  return std::string(arg);
+  return std::vector<std::string>{std::string(arg)};
 }
 
 
@@ -280,6 +319,49 @@ auto print_par_or_verbose(
   print_par(&par);
 }
 
+
+auto process_deal(
+    std::string const& deal,
+    std::size_t deal_no,
+    std::size_t deal_count,
+    int vulnerable) -> bool
+{
+  DdTableDealPBN tableDealPBN{};
+  if (deal.size() >= sizeof(tableDealPBN.cards))
+  {
+    fprintf(stderr,
+            "PBN deal too long (max %zu characters)\n",
+            sizeof(tableDealPBN.cards) - 1);
+    return false;
+  }
+
+  std::copy_n(deal.begin(), deal.size(), tableDealPBN.cards);
+  tableDealPBN.cards[deal.size()] = '\0';
+
+  DdTableResults table;
+  char line[80];
+
+  const int res = CalcDDtablePBN(tableDealPBN, &table);
+  if (res != RETURN_NO_FAULT)
+  {
+    ErrorMessage(res, line);
+    fprintf(stderr, "DDS error: %s\n", line);
+    return false;
+  }
+
+  if (deal_count == 1)
+    sprintf(line, "dd_table_for_deal:\n");
+  else
+    sprintf(line, "Deal %zu:\n", deal_no);
+
+  print_pbn_hand(line, tableDealPBN.cards);
+  print_table(&table);
+  print_par_or_verbose(&table, vulnerable);
+  if (deal_count > 1)
+    printf("\n");
+  return true;
+}
+
 }  // namespace
 
 
@@ -295,7 +377,7 @@ static auto print_usage(const char * prog) -> void
           "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
           "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
           "\n"
-          "If stdin is not a terminal, PBN is read from stdin (uses [Deal \"...\"]).\n"
+          "If stdin is not a terminal, PBN is read from stdin (all [Deal \"...\"] tags).\n"
           "\n"
           "Examples:\n"
           "  %s \"N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
@@ -365,39 +447,17 @@ auto main(int argc, char * argv[]) -> int
     }
   }
 
-  const auto deal = load_deal(input);
-  if (!deal)
+  const auto deals = load_deals(input);
+  if (!deals)
   {
     return 1;
   }
 
-  DdTableDealPBN tableDealPBN{};
-  if (deal->size() >= sizeof(tableDealPBN.cards))
+  for (std::size_t i = 0; i < deals->size(); ++i)
   {
-    fprintf(stderr,
-            "PBN deal too long (max %zu characters)\n",
-            sizeof(tableDealPBN.cards) - 1);
-    return 1;
+    if (!process_deal((*deals)[i], i + 1, deals->size(), vulnerable))
+      return 1;
   }
-
-  std::copy_n(deal->begin(), deal->size(), tableDealPBN.cards);
-  tableDealPBN.cards[deal->size()] = '\0';
-
-  DdTableResults table;
-  char line[80];
-
-  const int res = CalcDDtablePBN(tableDealPBN, &table);
-  if (res != RETURN_NO_FAULT)
-  {
-    ErrorMessage(res, line);
-    fprintf(stderr, "DDS error: %s\n", line);
-    return 1;
-  }
-
-  sprintf(line, "dd_table_for_deal:\n");
-  print_pbn_hand(line, tableDealPBN.cards);
-  print_table(&table);
-  print_par_or_verbose(&table, vulnerable);
 
   return 0;
 }

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -8,11 +8,12 @@
 */
 
 
-// Print the double-dummy table for a deal from the command line or a PBN file.
+// Print the double-dummy table and par for a deal from the command line or a PBN file.
 
 // Coded by Cursor, based on calc_dd_table.cpp
 
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -110,6 +111,24 @@ auto extract_deal_tag(std::string_view text) -> std::optional<std::string>
 }
 
 
+auto parse_vulnerable(std::string_view text) -> std::optional<int>
+{
+  std::string lower(text);
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+  if (lower == "none" || lower == "0")
+    return 0;
+  if (lower == "both" || lower == "1")
+    return 1;
+  if (lower == "ns" || lower == "2")
+    return 2;
+  if (lower == "ew" || lower == "3")
+    return 3;
+  return std::nullopt;
+}
+
+
 auto load_deal(std::string_view arg) -> std::optional<std::string>
 {
   if (arg == "-")
@@ -153,26 +172,135 @@ auto load_deal(std::string_view arg) -> std::optional<std::string>
   return std::string(arg);
 }
 
+
+auto denom_char(int denom) -> char
+{
+  static constexpr char kDenomChars[] = "NSHDC";
+  if (denom < 0 || denom > 4)
+    return '?';
+  return kDenomChars[denom];
+}
+
+
+auto seat_name(int seats) -> const char *
+{
+  static const char * kSeatNames[] = {"N", "E", "S", "W", "NS", "EW"};
+  if (seats < 0 || seats > 5)
+    return "?";
+  return kSeatNames[seats];
+}
+
+
+auto format_par_line(
+    ParResultsMaster const sidesRes[2],
+    int vulnerable,
+    char * line,
+    std::size_t line_size) -> bool
+{
+  if (line_size < 32)
+    return false;
+
+  if (sidesRes[0].score == 0 && sidesRes[1].score == 0)
+  {
+    std::snprintf(line, line_size, "Par: 0");
+    return true;
+  }
+
+  if (sidesRes[0].number != 1 || sidesRes[1].number != 1)
+    return false;
+
+  const ContractType& contract = sidesRes[0].contracts[0];
+  const char * seats = seat_name(contract.seats);
+  const char result_sign = contract.under_tricks > 0 ? '-' : '+';
+  const int result_value =
+      contract.under_tricks > 0 ? contract.under_tricks : contract.over_tricks;
+
+  if (contract.under_tricks > 0)
+  {
+    std::snprintf(
+        line,
+        line_size,
+        "Par: %s %d%c%c %c%d %d",
+        seats,
+        contract.level,
+        denom_char(contract.denom),
+        'x',
+        result_sign,
+        result_value,
+        sidesRes[0].score);
+  }
+  else
+  {
+    std::snprintf(
+        line,
+        line_size,
+        "Par: %s %d%c %c%d %d",
+        seats,
+        contract.level,
+        denom_char(contract.denom),
+        result_sign,
+        result_value,
+        sidesRes[0].score);
+  }
+
+  return true;
+}
+
+
+auto print_par_or_verbose(
+    DdTableResults const * table,
+    int vulnerable) -> void
+{
+  ParResultsMaster sidesRes[2];
+  const int res = SidesParBin(table, sidesRes, vulnerable);
+  if (res != RETURN_NO_FAULT)
+  {
+    char line[80];
+    ErrorMessage(res, line);
+    fprintf(stderr, "DDS error: %s\n", line);
+    return;
+  }
+
+  char line[80];
+  if (format_par_line(sidesRes, vulnerable, line, sizeof(line)))
+  {
+    printf("%s\n", line);
+    return;
+  }
+
+  ParResults par;
+  const int par_res = Par(table, &par, vulnerable);
+  if (par_res != RETURN_NO_FAULT)
+  {
+    ErrorMessage(par_res, line);
+    fprintf(stderr, "DDS error: %s\n", line);
+    return;
+  }
+
+  print_par(&par);
+}
+
 }  // namespace
 
 
 static auto print_usage(const char * prog) -> void
 {
   fprintf(stderr,
-          "Usage: %s <pbn_deal_or_file>\n"
+          "Usage: %s [--vul none|both|ns|ew] <pbn_deal_or_file>\n"
           "       %s -h | --help\n"
           "\n"
-          "Calculate double-dummy tricks for all strains and leads.\n"
+          "Calculate double-dummy tricks and par for all strains and leads.\n"
           "\n"
           "Arguments:\n"
           "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
+          "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
           "\n"
           "If stdin is not a terminal, PBN is read from stdin (uses [Deal \"...\"]).\n"
           "\n"
           "Examples:\n"
           "  %s \"N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
           "5.A95432.7632.K6 AKJ9842.K.T8.J93\"\n"
-          "  %s hands/example.pbn\n"
+          "  %s --vul ns hands/example.pbn\n"
           "  %s < hands/example.pbn\n",
           prog,
           prog,
@@ -184,25 +312,57 @@ static auto print_usage(const char * prog) -> void
 
 auto main(int argc, char * argv[]) -> int
 {
-  const char * input;
+  const char * input = nullptr;
+  int vulnerable = 0;
 
-  if (argc == 2)
+  for (int i = 1; i < argc; ++i)
   {
-    if (strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
+    if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
     {
       print_usage(argv[0]);
       return 0;
     }
-    input = argv[1];
+    if (strcmp(argv[i], "--vul") == 0)
+    {
+      if (i + 1 >= argc)
+      {
+        fprintf(stderr, "--vul requires a value (none|both|ns|ew or 0|1|2|3)\n");
+        print_usage(argv[0]);
+        return 1;
+      }
+      const auto vul = parse_vulnerable(argv[++i]);
+      if (!vul)
+      {
+        fprintf(stderr, "Invalid --vul value (use none|both|ns|ew or 0|1|2|3)\n");
+        print_usage(argv[0]);
+        return 1;
+      }
+      vulnerable = *vul;
+      continue;
+    }
+    if (argv[i][0] == '-' && strcmp(argv[i], "-") != 0)
+    {
+      fprintf(stderr, "Unknown option: %s\n", argv[i]);
+      print_usage(argv[0]);
+      return 1;
+    }
+    if (input != nullptr)
+    {
+      print_usage(argv[0]);
+      return 1;
+    }
+    input = argv[i];
   }
-  else if (argc == 1 && !stdin_is_tty())
+
+  if (input == nullptr)
   {
-    input = "-";
-  }
-  else
-  {
-    print_usage(argv[0]);
-    return 1;
+    if (!stdin_is_tty())
+      input = "-";
+    else
+    {
+      print_usage(argv[0]);
+      return 1;
+    }
   }
 
   const auto deal = load_deal(input);
@@ -237,6 +397,7 @@ auto main(int argc, char * argv[]) -> int
   sprintf(line, "dd_table_for_deal:\n");
   print_pbn_hand(line, tableDealPBN.cards);
   print_table(&table);
+  print_par_or_verbose(&table, vulnerable);
 
   return 0;
 }

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -41,6 +41,7 @@ using dd_table_for_deal::extract_deal_tags;
 using dd_table_for_deal::format_par_line;
 using dd_table_for_deal::looks_like_path;
 using dd_table_for_deal::parse_vulnerable;
+using dd_table_for_deal::should_report_failed_stream_read;
 using dd_table_for_deal::unique_deals;
 
 
@@ -114,7 +115,9 @@ auto load_deals(std::string_view arg) -> std::optional<std::vector<std::string>>
     const auto text = read_pbn_stream(std::cin);
     if (!text)
     {
-      std::cerr << "Cannot read PBN from stdin\n";
+      // Oversized input is already reported by read_pbn_stream.
+      if (should_report_failed_stream_read(std::cin))
+        std::cerr << "Cannot read PBN from stdin\n";
       return std::nullopt;
     }
 

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -36,7 +36,6 @@
 namespace {
 
 using dd_table_for_deal::PBN_DEAL_MAX;
-using dd_table_for_deal::PBN_FILE_MAX;
 using dd_table_for_deal::apply_deal_limit;
 using dd_table_for_deal::extract_deal_tags;
 using dd_table_for_deal::format_par_line;

--- a/examples/dd_table_for_deal.cpp
+++ b/examples/dd_table_for_deal.cpp
@@ -221,9 +221,9 @@ auto process_deal(
   }
 
   if (deal_count == 1)
-    sprintf(line, "dd_table_for_deal:\n");
+    std::snprintf(line, sizeof(line), "dd_table_for_deal:\n");
   else
-    sprintf(line, "Deal %zu:\n", deal_no);
+    std::snprintf(line, sizeof(line), "Deal %zu:\n", deal_no);
 
   print_pbn_hand(line, tableDealPBN.cards);
   print_table(&table);

--- a/examples/dd_table_for_deal.hpp
+++ b/examples/dd_table_for_deal.hpp
@@ -1,0 +1,33 @@
+/*
+   DDS, a bridge double dummy solver.
+
+   Copyright (C) 2006-2014 by Bo Haglund /
+   2014-2016 by Bo Haglund & Soren Hein.
+
+   See LICENSE and README.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <api/dll.h>
+
+namespace dd_table_for_deal {
+
+constexpr std::size_t PBN_FILE_MAX = 16 * 1024 * 1024;
+constexpr std::size_t PBN_DEAL_MAX = sizeof(DdTableDealPBN::cards);
+
+auto parse_vulnerable(std::string_view text) -> std::optional<int>;
+
+auto extract_deal_tags(std::string_view text) -> std::vector<std::string>;
+
+auto looks_like_path(std::string_view arg) -> bool;
+
+auto format_par_line(ParResultsMaster const sidesRes[2])
+    -> std::optional<std::string>;
+
+}  // namespace dd_table_for_deal

--- a/examples/dd_table_for_deal.hpp
+++ b/examples/dd_table_for_deal.hpp
@@ -24,6 +24,14 @@ constexpr std::size_t PBN_DEAL_MAX = sizeof(DdTableDealPBN::cards);
 
 auto parse_vulnerable(std::string_view text) -> std::optional<int>;
 
+// Positive deal count, or nullopt if the text is not a valid positive integer.
+auto parse_limit(std::string_view text) -> std::optional<std::size_t>;
+
+// Keep the first `limit` deals when set; otherwise return deals unchanged.
+auto apply_deal_limit(
+    std::vector<std::string> deals,
+    std::optional<std::size_t> limit) -> std::vector<std::string>;
+
 auto extract_deal_tags(std::string_view text) -> std::vector<std::string>;
 
 auto unique_deals(std::vector<std::string> const& deals)

--- a/examples/dd_table_for_deal.hpp
+++ b/examples/dd_table_for_deal.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -29,6 +30,10 @@ auto unique_deals(std::vector<std::string> const& deals)
     -> std::vector<std::string>;
 
 auto looks_like_path(std::string_view arg) -> bool;
+
+// True when a failed stream read should report empty/IO failure to the user.
+// False when the stream is still readable (e.g. oversize already reported).
+auto should_report_failed_stream_read(std::istream const& in) -> bool;
 
 auto format_par_line(ParResultsMaster const sidesRes[2])
     -> std::optional<std::string>;

--- a/examples/dd_table_for_deal.hpp
+++ b/examples/dd_table_for_deal.hpp
@@ -39,6 +39,12 @@ auto unique_deals(std::vector<std::string> const& deals)
 
 auto looks_like_path(std::string_view arg) -> bool;
 
+// Read until EOF. Empty input yields an empty string. Oversized input prints an
+// error and returns nullopt.
+auto read_pbn_stream(std::istream& in) -> std::optional<std::string>;
+
+auto path_is_openable(std::string_view path) -> bool;
+
 // True when a failed stream read should report empty/IO failure to the user.
 // False when the stream is still readable (e.g. oversize already reported).
 auto should_report_failed_stream_read(std::istream const& in) -> bool;

--- a/examples/dd_table_for_deal.hpp
+++ b/examples/dd_table_for_deal.hpp
@@ -25,6 +25,9 @@ auto parse_vulnerable(std::string_view text) -> std::optional<int>;
 
 auto extract_deal_tags(std::string_view text) -> std::vector<std::string>;
 
+auto unique_deals(std::vector<std::string> const& deals)
+    -> std::vector<std::string>;
+
 auto looks_like_path(std::string_view arg) -> bool;
 
 auto format_par_line(ParResultsMaster const sidesRes[2])

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <regex>
 #include <string>
+#include <unordered_set>
 
 namespace dd_table_for_deal {
 namespace {
@@ -100,6 +101,21 @@ auto extract_deal_tags(std::string_view text) -> std::vector<std::string>
     begin = match[0].second;
   }
   return deals;
+}
+
+
+auto unique_deals(std::vector<std::string> const& deals)
+    -> std::vector<std::string>
+{
+  std::vector<std::string> unique;
+  std::unordered_set<std::string> seen;
+  unique.reserve(deals.size());
+  for (const auto& deal : deals)
+  {
+    if (seen.insert(deal).second)
+      unique.push_back(deal);
+  }
+  return unique;
 }
 
 

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -242,6 +242,9 @@ auto format_par_line(ParResultsMaster const sidesRes[2])
   if (sidesRes[0].score == 0 && sidesRes[1].score == 0)
     return std::string("Par: 0");
 
+  if (sidesRes[0].number <= 0 && sidesRes[1].number <= 0)
+    return std::nullopt;
+
   const ContractType& first = sidesRes[0].number > 0
       ? sidesRes[0].contracts[0]
       : sidesRes[1].contracts[0];

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -1,0 +1,176 @@
+/*
+   DDS, a bridge double dummy solver.
+
+   Copyright (C) 2006-2014 by Bo Haglund /
+   2014-2016 by Bo Haglund & Soren Hein.
+
+   See LICENSE and README.
+*/
+
+#include "dd_table_for_deal.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <regex>
+#include <string>
+
+namespace dd_table_for_deal {
+namespace {
+
+const std::regex DEAL_TAG_RE{
+    R"re(\[Deal\s*"([^"]*)")re",
+    std::regex::icase};
+
+
+auto denom_char(int denom) -> char
+{
+  static constexpr char kDenomChars[] = "NSHDC";
+  if (denom < 0 || denom > 4)
+    return '?';
+  return kDenomChars[denom];
+}
+
+
+auto seat_name(int seats) -> const char *
+{
+  static const char * kSeatNames[] = {"N", "E", "S", "W", "NS", "EW"};
+  if (seats < 0 || seats > 5)
+    return "?";
+  return kSeatNames[seats];
+}
+
+
+auto format_contract(const ContractType& contract) -> std::optional<std::string>
+{
+  char out[16];
+  if (contract.under_tricks > 0)
+  {
+    std::snprintf(
+        out,
+        sizeof(out),
+        "%s %d%cx",
+        seat_name(contract.seats),
+        contract.level,
+        denom_char(contract.denom));
+  }
+  else
+  {
+    std::snprintf(
+        out,
+        sizeof(out),
+        "%s %d%c",
+        seat_name(contract.seats),
+        contract.level,
+        denom_char(contract.denom));
+  }
+  return std::string(out);
+}
+
+}  // namespace
+
+
+auto parse_vulnerable(std::string_view text) -> std::optional<int>
+{
+  std::string lower(text);
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+  if (lower == "none" || lower == "0")
+    return 0;
+  if (lower == "both" || lower == "1")
+    return 1;
+  if (lower == "ns" || lower == "2")
+    return 2;
+  if (lower == "ew" || lower == "3")
+    return 3;
+  return std::nullopt;
+}
+
+
+auto extract_deal_tags(std::string_view text) -> std::vector<std::string>
+{
+  std::vector<std::string> deals;
+  auto begin = text.cbegin();
+  const auto end = text.cend();
+  std::match_results<std::string_view::const_iterator> match;
+  while (std::regex_search(begin, end, match, DEAL_TAG_RE) && match.size() > 1)
+  {
+    deals.emplace_back(match[1].first, match[1].second);
+    begin = match[0].second;
+  }
+  return deals;
+}
+
+
+auto looks_like_path(std::string_view arg) -> bool
+{
+  if (arg.find('/') != std::string_view::npos
+      || arg.find('\\') != std::string_view::npos)
+  {
+    return true;
+  }
+
+  if (arg.size() >= 4)
+  {
+    std::string lower(arg.substr(arg.size() - 4));
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) {
+                     return static_cast<char>(std::tolower(c));
+                   });
+    if (lower == ".pbn" || lower == ".txt")
+      return true;
+  }
+  return false;
+}
+
+
+auto format_par_line(ParResultsMaster const sidesRes[2])
+    -> std::optional<std::string>
+{
+  if (sidesRes[0].score == 0 && sidesRes[1].score == 0)
+    return std::string("Par: 0");
+
+  const ContractType& first = sidesRes[0].number > 0
+      ? sidesRes[0].contracts[0]
+      : sidesRes[1].contracts[0];
+  const int side =
+      (first.seats == 4 || first.seats == 0 || first.seats == 2) ? 0 : 1;
+  const ParResultsMaster& chosen = sidesRes[side];
+  if (chosen.number <= 0)
+    return std::nullopt;
+
+  std::string body;
+  for (int i = 0; i < chosen.number; ++i)
+  {
+    const auto piece = format_contract(chosen.contracts[i]);
+    if (!piece)
+      return std::nullopt;
+    if (i > 0)
+      body += ',';
+    body += *piece;
+  }
+
+  const ContractType& contract = chosen.contracts[0];
+  char result[8];
+  if (contract.under_tricks > 0)
+    std::snprintf(result, sizeof(result), "-%d", contract.under_tricks);
+  else if (contract.over_tricks > 0)
+    std::snprintf(result, sizeof(result), "+%d", contract.over_tricks);
+  else
+    std::snprintf(result, sizeof(result), "=");
+
+  char line[256];
+  const int written = std::snprintf(
+      line,
+      sizeof(line),
+      "Par: %s %s %d",
+      body.c_str(),
+      result,
+      chosen.score);
+  if (written <= 0 || static_cast<std::size_t>(written) >= sizeof(line))
+    return std::nullopt;
+  return std::string(line);
+}
+
+}  // namespace dd_table_for_deal

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -12,6 +12,9 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <istream>
 #include <limits>
 #include <regex>
@@ -196,6 +199,34 @@ auto looks_like_path(std::string_view arg) -> bool
       return true;
   }
   return false;
+}
+
+
+auto read_pbn_stream(std::istream& in) -> std::optional<std::string>
+{
+  std::string text;
+  text.reserve(64 * 1024);
+  char buffer[4096];
+  while (in)
+  {
+    in.read(buffer, static_cast<std::streamsize>(sizeof(buffer)));
+    const auto n = in.gcount();
+    if (n > 0)
+      text.append(buffer, static_cast<std::size_t>(n));
+    if (text.size() > PBN_FILE_MAX)
+    {
+      std::cerr << "PBN input too large (max " << PBN_FILE_MAX << " characters)\n";
+      return std::nullopt;
+    }
+  }
+  return text;
+}
+
+
+auto path_is_openable(std::string_view path) -> bool
+{
+  std::ifstream file(std::filesystem::path(path), std::ios::binary);
+  return static_cast<bool>(file);
 }
 
 

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#include <istream>
 #include <regex>
 #include <string>
 #include <unordered_set>
@@ -138,6 +139,12 @@ auto looks_like_path(std::string_view arg) -> bool
       return true;
   }
   return false;
+}
+
+
+auto should_report_failed_stream_read(std::istream const& in) -> bool
+{
+  return in.eof() || in.bad();
 }
 
 

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -43,16 +43,41 @@ auto seat_name(int seats) -> const char *
 }
 
 
-auto format_contract(const ContractType& contract) -> std::optional<std::string>
+auto format_contract(
+    const ContractType& contract,
+    bool include_seats) -> std::optional<std::string>
 {
   char out[16];
-  if (contract.under_tricks > 0)
+  const char doubled = contract.under_tricks > 0 ? 'x' : '\0';
+  if (include_seats)
+  {
+    if (doubled)
+    {
+      std::snprintf(
+          out,
+          sizeof(out),
+          "%s %d%cx",
+          seat_name(contract.seats),
+          contract.level,
+          denom_char(contract.denom));
+    }
+    else
+    {
+      std::snprintf(
+          out,
+          sizeof(out),
+          "%s %d%c",
+          seat_name(contract.seats),
+          contract.level,
+          denom_char(contract.denom));
+    }
+  }
+  else if (doubled)
   {
     std::snprintf(
         out,
         sizeof(out),
-        "%s %d%cx",
-        seat_name(contract.seats),
+        "%d%cx",
         contract.level,
         denom_char(contract.denom));
   }
@@ -61,8 +86,7 @@ auto format_contract(const ContractType& contract) -> std::optional<std::string>
     std::snprintf(
         out,
         sizeof(out),
-        "%s %d%c",
-        seat_name(contract.seats),
+        "%d%c",
         contract.level,
         denom_char(contract.denom));
   }
@@ -166,11 +190,11 @@ auto format_par_line(ParResultsMaster const sidesRes[2])
   std::string body;
   for (int i = 0; i < chosen.number; ++i)
   {
-    const auto piece = format_contract(chosen.contracts[i]);
+    const auto piece = format_contract(chosen.contracts[i], /*include_seats=*/i == 0);
     if (!piece)
       return std::nullopt;
     if (i > 0)
-      body += ',';
+      body += ", ";
     body += *piece;
   }
 

--- a/examples/dd_table_for_deal_lib.cpp
+++ b/examples/dd_table_for_deal_lib.cpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <cstdio>
 #include <istream>
+#include <limits>
 #include <regex>
 #include <string>
 #include <unordered_set>
@@ -111,6 +112,38 @@ auto parse_vulnerable(std::string_view text) -> std::optional<int>
   if (lower == "ew" || lower == "3")
     return 3;
   return std::nullopt;
+}
+
+
+auto parse_limit(std::string_view text) -> std::optional<std::size_t>
+{
+  if (text.empty())
+    return std::nullopt;
+
+  std::size_t value = 0;
+  for (char ch : text)
+  {
+    if (ch < '0' || ch > '9')
+      return std::nullopt;
+    const std::size_t digit = static_cast<std::size_t>(ch - '0');
+    if (value > (std::numeric_limits<std::size_t>::max() - digit) / 10)
+      return std::nullopt;
+    value = value * 10 + digit;
+  }
+  if (value == 0)
+    return std::nullopt;
+  return value;
+}
+
+
+auto apply_deal_limit(
+    std::vector<std::string> deals,
+    std::optional<std::size_t> limit) -> std::vector<std::string>
+{
+  if (!limit.has_value() || *limit >= deals.size())
+    return deals;
+  deals.resize(*limit);
+  return deals;
 }
 
 

--- a/examples/hands.cpp
+++ b/examples/hands.cpp
@@ -551,7 +551,7 @@ auto print_hand(char title[],
   printf("%s\n", dashes);
   for (int i = 0; i < DDS_HAND_LINES; i++)
     printf("%s\n", text[i]);
-  printf("\n\n");
+  printf("\n");
 }
 
 

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -86,6 +86,24 @@ TEST(ExtractDealTags, EmptyWhenNoTags)
 }
 
 
+TEST(UniqueDeals, PreservesFirstSeenOrderAndDropsDuplicates)
+{
+  const std::vector<std::string> deals = {
+      "deal-a",
+      "deal-b",
+      "deal-a",
+      "deal-c",
+      "deal-b",
+      "deal-a",
+  };
+  const auto unique = dd_table_for_deal::unique_deals(deals);
+  ASSERT_EQ(unique.size(), 3u);
+  EXPECT_EQ(unique[0], "deal-a");
+  EXPECT_EQ(unique[1], "deal-b");
+  EXPECT_EQ(unique[2], "deal-c");
+}
+
+
 TEST(LooksLikePath, DetectsPathsAndExtensions)
 {
   EXPECT_TRUE(dd_table_for_deal::looks_like_path("boards.pbn"));

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -290,3 +290,15 @@ TEST(FormatParLine, PassedOut)
   ASSERT_TRUE(line.has_value());
   EXPECT_EQ(*line, "Par: 0");
 }
+
+
+TEST(FormatParLine, ReturnsNulloptWhenNoContractsDespiteScores)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = -100;
+  sides[0].number = 0;
+  sides[1].score = 100;
+  sides[1].number = 0;
+
+  EXPECT_FALSE(dd_table_for_deal::format_par_line(sides).has_value());
+}

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -9,6 +9,8 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <fstream>
 #include <sstream>
 
 #include <api/dll.h>
@@ -87,6 +89,44 @@ TEST(ApplyDealLimit, KeepsPrefixWhenLimited)
   EXPECT_EQ(
       dd_table_for_deal::apply_deal_limit(deals, 10),
       deals);
+}
+
+
+TEST(ReadPbnStream, EmptyInputReturnsEmptyString)
+{
+  std::istringstream in("");
+  const auto text = dd_table_for_deal::read_pbn_stream(in);
+  ASSERT_TRUE(text.has_value());
+  EXPECT_TRUE(text->empty());
+}
+
+
+TEST(ReadPbnStream, ReturnsContents)
+{
+  std::istringstream in("[Deal \"N:..\"]\n");
+  const auto text = dd_table_for_deal::read_pbn_stream(in);
+  ASSERT_TRUE(text.has_value());
+  EXPECT_EQ(*text, "[Deal \"N:..\"]\n");
+}
+
+
+TEST(PathIsOpenable, TrueForExistingFile)
+{
+  const auto path =
+      std::filesystem::temp_directory_path() / "dds_dd_table_for_deal_openable.pbn";
+  {
+    std::ofstream out(path);
+    out << "[Deal \"x\"]\n";
+  }
+  EXPECT_TRUE(dd_table_for_deal::path_is_openable(path.string()));
+  std::filesystem::remove(path);
+}
+
+
+TEST(PathIsOpenable, FalseForMissingFile)
+{
+  EXPECT_FALSE(dd_table_for_deal::path_is_openable(
+      "/definitely/missing/dds_dd_table_for_deal_no_such.pbn"));
 }
 
 

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -58,6 +58,38 @@ TEST(ParseVulnerable, RejectsUnknown)
 }
 
 
+TEST(ParseLimit, AcceptsPositiveIntegers)
+{
+  EXPECT_EQ(dd_table_for_deal::parse_limit("1"), 1u);
+  EXPECT_EQ(dd_table_for_deal::parse_limit("25"), 25u);
+}
+
+
+TEST(ParseLimit, RejectsNonPositiveAndNonNumeric)
+{
+  EXPECT_FALSE(dd_table_for_deal::parse_limit("").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_limit("0").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_limit("-1").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_limit("3x").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_limit("1.5").has_value());
+}
+
+
+TEST(ApplyDealLimit, KeepsPrefixWhenLimited)
+{
+  const std::vector<std::string> deals{"a", "b", "c"};
+  EXPECT_EQ(
+      dd_table_for_deal::apply_deal_limit(deals, 2),
+      (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(
+      dd_table_for_deal::apply_deal_limit(deals, std::nullopt),
+      deals);
+  EXPECT_EQ(
+      dd_table_for_deal::apply_deal_limit(deals, 10),
+      deals);
+}
+
+
 TEST(ShouldReportFailedStreamRead, TrueOnEofOrBad)
 {
   std::istringstream empty("");

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -9,6 +9,8 @@
 
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 #include <api/dll.h>
 #include "dd_table_for_deal.hpp"
 
@@ -53,6 +55,27 @@ TEST(ParseVulnerable, RejectsUnknown)
   EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("").has_value());
   EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("maybe").has_value());
   EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("4").has_value());
+}
+
+
+TEST(ShouldReportFailedStreamRead, TrueOnEofOrBad)
+{
+  std::istringstream empty("");
+  empty.get();
+  EXPECT_TRUE(empty.eof());
+  EXPECT_TRUE(dd_table_for_deal::should_report_failed_stream_read(empty));
+
+  std::istringstream bad_stream("x");
+  bad_stream.setstate(std::ios::badbit);
+  EXPECT_TRUE(dd_table_for_deal::should_report_failed_stream_read(bad_stream));
+}
+
+
+TEST(ShouldReportFailedStreamRead, FalseWhenStreamStillReadable)
+{
+  // Oversized reads stop early without setting eof/bad; do not re-report.
+  std::istringstream mid("still-readable");
+  EXPECT_FALSE(dd_table_for_deal::should_report_failed_stream_read(mid));
 }
 
 

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -1,0 +1,161 @@
+/*
+   DDS, a bridge double dummy solver.
+
+   Copyright (C) 2006-2014 by Bo Haglund /
+   2014-2016 by Bo Haglund & Soren Hein.
+
+   See LICENSE and README.
+*/
+
+#include <gtest/gtest.h>
+
+#include <api/dll.h>
+#include "dd_table_for_deal.hpp"
+
+namespace {
+
+auto make_contract(
+    int seats,
+    int level,
+    int denom,
+    int under_tricks,
+    int over_tricks) -> ContractType
+{
+  ContractType c{};
+  c.seats = seats;
+  c.level = level;
+  c.denom = denom;
+  c.under_tricks = under_tricks;
+  c.over_tricks = over_tricks;
+  return c;
+}
+
+}  // namespace
+
+
+TEST(ParseVulnerable, AcceptsAliasesAndCodes)
+{
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("none"), 0);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("None"), 0);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("0"), 0);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("both"), 1);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("1"), 1);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("ns"), 2);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("NS"), 2);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("2"), 2);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("ew"), 3);
+  EXPECT_EQ(dd_table_for_deal::parse_vulnerable("3"), 3);
+}
+
+
+TEST(ParseVulnerable, RejectsUnknown)
+{
+  EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("maybe").has_value());
+  EXPECT_FALSE(dd_table_for_deal::parse_vulnerable("4").has_value());
+}
+
+
+TEST(ExtractDealTags, FindsAllTags)
+{
+  const char* text =
+      "{Board 1}\n"
+      "[Deal \"N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
+      "5.A95432.7632.K6 AKJ9842.K.T8.J93\"]\n"
+      "\n"
+      "{Board 2}\n"
+      "[Deal \"N:QJ6.K652.J85.T98 873.J97.AT764.Q4 "
+      "K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3\"]\n";
+
+  const auto deals = dd_table_for_deal::extract_deal_tags(text);
+  ASSERT_EQ(deals.size(), 2u);
+  EXPECT_EQ(
+      deals[0],
+      "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
+      "5.A95432.7632.K6 AKJ9842.K.T8.J93");
+  EXPECT_EQ(
+      deals[1],
+      "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 "
+      "K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3");
+}
+
+
+TEST(ExtractDealTags, EmptyWhenNoTags)
+{
+  EXPECT_TRUE(dd_table_for_deal::extract_deal_tags("{comment only}").empty());
+}
+
+
+TEST(LooksLikePath, DetectsPathsAndExtensions)
+{
+  EXPECT_TRUE(dd_table_for_deal::looks_like_path("boards.pbn"));
+  EXPECT_TRUE(dd_table_for_deal::looks_like_path("hands/x.pbn"));
+  EXPECT_TRUE(dd_table_for_deal::looks_like_path("notes.txt"));
+  EXPECT_FALSE(dd_table_for_deal::looks_like_path(
+      "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
+      "5.A95432.7632.K6 AKJ9842.K.T8.J93"));
+}
+
+
+TEST(FormatParLine, SingleSacrifice)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = -300;
+  sides[0].number = 1;
+  sides[0].contracts[0] = make_contract(/*NS*/ 4, 5, /*H*/ 2, 2, 0);
+  sides[1].score = 300;
+  sides[1].number = 1;
+  sides[1].contracts[0] = make_contract(/*NS*/ 4, 5, /*H*/ 2, 2, 0);
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: NS 5Hx -2 -300");
+}
+
+
+TEST(FormatParLine, SingleMakingUsesEqualsAndDeclaringScore)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = -110;
+  sides[0].number = 1;
+  sides[0].contracts[0] = make_contract(/*EW*/ 5, 2, /*S*/ 1, 0, 0);
+  sides[1].score = 110;
+  sides[1].number = 1;
+  sides[1].contracts[0] = make_contract(/*EW*/ 5, 2, /*S*/ 1, 0, 0);
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: EW 2S = 110");
+}
+
+
+TEST(FormatParLine, MultipleSacrificesOnOneLine)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = 100;
+  sides[0].number = 2;
+  sides[0].contracts[0] = make_contract(/*EW*/ 5, 3, /*D*/ 3, 1, 0);
+  sides[0].contracts[1] = make_contract(/*EW*/ 5, 3, /*C*/ 4, 1, 0);
+  sides[1].score = -100;
+  sides[1].number = 2;
+  sides[1].contracts[0] = make_contract(/*EW*/ 5, 3, /*D*/ 3, 1, 0);
+  sides[1].contracts[1] = make_contract(/*EW*/ 5, 3, /*C*/ 4, 1, 0);
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: EW 3Dx,EW 3Cx -1 -100");
+}
+
+
+TEST(FormatParLine, PassedOut)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = 0;
+  sides[0].number = 1;
+  sides[1].score = 0;
+  sides[1].number = 1;
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: 0");
+}

--- a/examples/tests/dd_table_for_deal_test.cpp
+++ b/examples/tests/dd_table_for_deal_test.cpp
@@ -184,7 +184,25 @@ TEST(FormatParLine, MultipleSacrificesOnOneLine)
 
   const auto line = dd_table_for_deal::format_par_line(sides);
   ASSERT_TRUE(line.has_value());
-  EXPECT_EQ(*line, "Par: EW 3Dx,EW 3Cx -1 -100");
+  EXPECT_EQ(*line, "Par: EW 3Dx, 3Cx -1 -100");
+}
+
+
+TEST(FormatParLine, OmitsRepeatedDeclaringSideWhenSeatsDiffer)
+{
+  ParResultsMaster sides[2]{};
+  sides[0].score = 100;
+  sides[0].number = 2;
+  sides[0].contracts[0] = make_contract(/*EW*/ 5, 4, /*H*/ 2, 1, 0);
+  sides[0].contracts[1] = make_contract(/*E*/ 1, 5, /*C*/ 4, 1, 0);
+  sides[1].score = -100;
+  sides[1].number = 2;
+  sides[1].contracts[0] = make_contract(/*EW*/ 5, 4, /*H*/ 2, 1, 0);
+  sides[1].contracts[1] = make_contract(/*E*/ 1, 5, /*C*/ 4, 1, 0);
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: EW 4Hx, 5Cx -1 -100");
 }
 
 

--- a/hands/multi_board.pbn
+++ b/hands/multi_board.pbn
@@ -1,0 +1,377 @@
+% PBN 2.1
+% Anonymized multi-board example for dd_table_for_deal
+
+[Board "1"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:QJ4.AK7.543.Q965 A3.T985.KT86.AT4 KT765.62.AJ92.72 982.QJ43.Q7.KJ83"]
+
+[Board "1"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:QJ4.AK7.543.Q965 A3.T985.KT86.AT4 KT765.62.AJ92.72 982.QJ43.Q7.KJ83"]
+
+[Board "1"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:QJ4.AK7.543.Q965 A3.T985.KT86.AT4 KT765.62.AJ92.72 982.QJ43.Q7.KJ83"]
+
+[Board "2"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:42.K8.T8653.8653 AQ9765.432.K2.A4 T3.AQ9765.9.KT97 KJ8.JT.AQJ74.QJ2"]
+
+[Board "2"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:42.K8.T8653.8653 AQ9765.432.K2.A4 T3.AQ9765.9.KT97 KJ8.JT.AQJ74.QJ2"]
+
+[Board "2"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:42.K8.T8653.8653 AQ9765.432.K2.A4 T3.AQ9765.9.KT97 KJ8.JT.AQJ74.QJ2"]
+
+[Board "3"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:KQT97.6.AT.KT975 J86.KQJ943.K963. A54.AT52.Q85.J84 32.87.J742.AQ632"]
+
+[Board "3"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:KQT97.6.AT.KT975 J86.KQJ943.K963. A54.AT52.Q85.J84 32.87.J742.AQ632"]
+
+[Board "3"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:KQT97.6.AT.KT975 J86.KQJ943.K963. A54.AT52.Q85.J84 32.87.J742.AQ632"]
+
+[Board "4"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:KJ82.T5.K76432.7 Q7.J8763.QT9.T94 954.A42.A8.AKJ63 AT63.KQ9.J5.Q852"]
+
+[Board "4"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:KJ82.T5.K76432.7 Q7.J8763.QT9.T94 954.A42.A8.AKJ63 AT63.KQ9.J5.Q852"]
+
+[Board "4"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:KJ82.T5.K76432.7 Q7.J8763.QT9.T94 954.A42.A8.AKJ63 AT63.KQ9.J5.Q852"]
+
+[Board "5"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:AT973.863.KT65.K K6542.KQT9.983.5 QJ.J74.A4.AQT943 8.A52.QJ72.J8762"]
+
+[Board "5"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:AT973.863.KT65.K K6542.KQT9.983.5 QJ.J74.A4.AQT943 8.A52.QJ72.J8762"]
+
+[Board "5"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:AT973.863.KT65.K K6542.KQT9.983.5 QJ.J74.A4.AQT943 8.A52.QJ72.J8762"]
+
+[Board "6"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:Q54.QJ65.75.AK54 KJT3.A84.QJT82.T 96.KT9.K6.QJ7632 A872.732.A943.98"]
+
+[Board "6"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:Q54.QJ65.75.AK54 KJT3.A84.QJT82.T 96.KT9.K6.QJ7632 A872.732.A943.98"]
+
+[Board "6"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:Q54.QJ65.75.AK54 KJT3.A84.QJT82.T 96.KT9.K6.QJ7632 A872.732.A943.98"]
+
+[Board "7"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:K2.K87.A8632.AKQ AJ876.A93.KJT7.4 T94.QJT52.Q9.963 Q53.64.54.JT8752"]
+
+[Board "7"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:K2.K87.A8632.AKQ AJ876.A93.KJT7.4 T94.QJT52.Q9.963 Q53.64.54.JT8752"]
+
+[Board "7"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:K2.K87.A8632.AKQ AJ876.A93.KJT7.4 T94.QJT52.Q9.963 Q53.64.54.JT8752"]
+
+[Board "8"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:AT73.K7.T.QT9643 QJ862.A9.8763.K7 K9.QJ542.KQ94.85 54.T863.AJ52.AJ2"]
+
+[Board "8"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:AT73.K7.T.QT9643 QJ862.A9.8763.K7 K9.QJ542.KQ94.85 54.T863.AJ52.AJ2"]
+
+[Board "8"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:AT73.K7.T.QT9643 QJ862.A9.8763.K7 K9.QJ542.KQ94.85 54.T863.AJ52.AJ2"]
+
+[Board "9"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:AT6542.K843.Q.85 3.AT97.KJ965.QT7 J87.QJ.A84.K9643 KQ9.652.T732.AJ2"]
+
+[Board "9"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:AT6542.K843.Q.85 3.AT97.KJ965.QT7 J87.QJ.A84.K9643 KQ9.652.T732.AJ2"]
+
+[Board "9"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:AT6542.K843.Q.85 3.AT97.KJ965.QT7 J87.QJ.A84.K9643 KQ9.652.T732.AJ2"]
+
+[Board "10"]
+[Dealer "E"]
+[Vulnerable "All"]
+[Deal "N:AJ7.6.KQ98.T9742 Q652.T94.T4.K853 .KQ853.A7652.QJ6 KT9843.AJ72.J3.A"]
+
+[Board "10"]
+[Dealer "E"]
+[Vulnerable "All"]
+[Deal "N:AJ7.6.KQ98.T9742 Q652.T94.T4.K853 .KQ853.A7652.QJ6 KT9843.AJ72.J3.A"]
+
+[Board "10"]
+[Dealer "E"]
+[Vulnerable "All"]
+[Deal "N:AJ7.6.KQ98.T9742 Q652.T94.T4.K853 .KQ853.A7652.QJ6 KT9843.AJ72.J3.A"]
+
+[Board "11"]
+[Dealer "S"]
+[Vulnerable "-"]
+[Deal "N:AT9542.QJ8.T2.AT 87.T753.K63.9852 J6.A642.J85.J764 KQ3.K9.AQ974.KQ3"]
+
+[Board "11"]
+[Dealer "S"]
+[Vulnerable "-"]
+[Deal "N:AT9542.QJ8.T2.AT 87.T753.K63.9852 J6.A642.J85.J764 KQ3.K9.AQ974.KQ3"]
+
+[Board "11"]
+[Dealer "S"]
+[Vulnerable "-"]
+[Deal "N:AT9542.QJ8.T2.AT 87.T753.K63.9852 J6.A642.J85.J764 KQ3.K9.AQ974.KQ3"]
+
+[Board "12"]
+[Dealer "W"]
+[Vulnerable "NS"]
+[Deal "N:T4.J73.532.KQ543 A73.A4.AK97.A876 QJ.KQT852.64.JT2 K98652.96.QJT8.9"]
+
+[Board "12"]
+[Dealer "W"]
+[Vulnerable "NS"]
+[Deal "N:T4.J73.532.KQ543 A73.A4.AK97.A876 QJ.KQT852.64.JT2 K98652.96.QJT8.9"]
+
+[Board "12"]
+[Dealer "W"]
+[Vulnerable "NS"]
+[Deal "N:T4.J73.532.KQ543 A73.A4.AK97.A876 QJ.KQT852.64.JT2 K98652.96.QJT8.9"]
+
+[Board "13"]
+[Dealer "N"]
+[Vulnerable "All"]
+[Deal "N:3.QT543.K732.Q97 JT7652.KJ8.T4.54 AQ84.A9.985.JT63 K9.762.AQJ6.AK82"]
+
+[Board "13"]
+[Dealer "N"]
+[Vulnerable "All"]
+[Deal "N:3.QT543.K732.Q97 JT7652.KJ8.T4.54 AQ84.A9.985.JT63 K9.762.AQJ6.AK82"]
+
+[Board "13"]
+[Dealer "N"]
+[Vulnerable "All"]
+[Deal "N:3.QT543.K732.Q97 JT7652.KJ8.T4.54 AQ84.A9.985.JT63 K9.762.AQJ6.AK82"]
+
+[Board "14"]
+[Dealer "E"]
+[Vulnerable "-"]
+[Deal "N:A85.Q4.753.QJ965 K76.JT9.KQJ4.A87 J94.A653.AT62.KT QT32.K872.98.432"]
+
+[Board "14"]
+[Dealer "E"]
+[Vulnerable "-"]
+[Deal "N:A85.Q4.753.QJ965 K76.JT9.KQJ4.A87 J94.A653.AT62.KT QT32.K872.98.432"]
+
+[Board "14"]
+[Dealer "E"]
+[Vulnerable "-"]
+[Deal "N:A85.Q4.753.QJ965 K76.JT9.KQJ4.A87 J94.A653.AT62.KT QT32.K872.98.432"]
+
+[Board "15"]
+[Dealer "S"]
+[Vulnerable "NS"]
+[Deal "N:T9.KQT6.AQ32.AQ9 AK6.52.T98.T7654 QJ42.A43.KJ65.J2 8753.J987.74.K83"]
+
+[Board "15"]
+[Dealer "S"]
+[Vulnerable "NS"]
+[Deal "N:T9.KQT6.AQ32.AQ9 AK6.52.T98.T7654 QJ42.A43.KJ65.J2 8753.J987.74.K83"]
+
+[Board "15"]
+[Dealer "S"]
+[Vulnerable "NS"]
+[Deal "N:T9.KQT6.AQ32.AQ9 AK6.52.T98.T7654 QJ42.A43.KJ65.J2 8753.J987.74.K83"]
+
+[Board "16"]
+[Dealer "W"]
+[Vulnerable "EW"]
+[Deal "N:JT6.A3.QJT53.863 743.T764.6.K7542 A95.J8.A972.QJT9 KQ82.KQ952.K84.A"]
+
+[Board "16"]
+[Dealer "W"]
+[Vulnerable "EW"]
+[Deal "N:JT6.A3.QJT53.863 743.T764.6.K7542 A95.J8.A972.QJT9 KQ82.KQ952.K84.A"]
+
+[Board "16"]
+[Dealer "W"]
+[Vulnerable "EW"]
+[Deal "N:JT6.A3.QJT53.863 743.T764.6.K7542 A95.J8.A972.QJT9 KQ82.KQ952.K84.A"]
+
+[Board "17"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:Q4.K2.KQ8743.KJ9 T73.3.AJ965.Q543 K96.QJT9865..AT2 AJ852.A74.T2.876"]
+
+[Board "17"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:Q4.K2.KQ8743.KJ9 T73.3.AJ965.Q543 K96.QJT9865..AT2 AJ852.A74.T2.876"]
+
+[Board "17"]
+[Dealer "N"]
+[Vulnerable "-"]
+[Deal "N:Q4.K2.KQ8743.KJ9 T73.3.AJ965.Q543 K96.QJT9865..AT2 AJ852.A74.T2.876"]
+
+[Board "18"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:T976.JT7654.K.Q9 K43.K.AT6543.AT2 A852.92.Q72.7643 QJ.AQ83.J98.KJ85"]
+
+[Board "18"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:T976.JT7654.K.Q9 K43.K.AT6543.AT2 A852.92.Q72.7643 QJ.AQ83.J98.KJ85"]
+
+[Board "18"]
+[Dealer "E"]
+[Vulnerable "NS"]
+[Deal "N:T976.JT7654.K.Q9 K43.K.AT6543.AT2 A852.92.Q72.7643 QJ.AQ83.J98.KJ85"]
+
+[Board "19"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:T642.AK7.AQ4.K52 K75.95.KT72.AQ64 J983.T6.J83.JT97 AQ.QJ8432.965.83"]
+
+[Board "19"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:T642.AK7.AQ4.K52 K75.95.KT72.AQ64 J983.T6.J83.JT97 AQ.QJ8432.965.83"]
+
+[Board "19"]
+[Dealer "S"]
+[Vulnerable "EW"]
+[Deal "N:T642.AK7.AQ4.K52 K75.95.KT72.AQ64 J983.T6.J83.JT97 AQ.QJ8432.965.83"]
+
+[Board "20"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:632.KJ84.Q73.985 KT.T75.AK96.KQJT A85.Q63.J854.A43 QJ974.A92.T2.762"]
+
+[Board "20"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:632.KJ84.Q73.985 KT.T75.AK96.KQJT A85.Q63.J854.A43 QJ974.A92.T2.762"]
+
+[Board "20"]
+[Dealer "W"]
+[Vulnerable "All"]
+[Deal "N:632.KJ84.Q73.985 KT.T75.AK96.KQJT A85.Q63.J854.A43 QJ974.A92.T2.762"]
+
+[Board "21"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:64.Q83.K9.AK8732 Q.JT9.T86532.T65 T53.K754.AQJ4.J9 AKJ9872.A62.7.Q4"]
+
+[Board "21"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:64.Q83.K9.AK8732 Q.JT9.T86532.T65 T53.K754.AQJ4.J9 AKJ9872.A62.7.Q4"]
+
+[Board "21"]
+[Dealer "N"]
+[Vulnerable "NS"]
+[Deal "N:64.Q83.K9.AK8732 Q.JT9.T86532.T65 T53.K754.AQJ4.J9 AKJ9872.A62.7.Q4"]
+
+[Board "22"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:K9.KT97654.T5.98 T62.A2.J98743.Q6 QJ3.QJ.K62.T7543 A8754.83.AQ.AKJ2"]
+
+[Board "22"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:K9.KT97654.T5.98 T62.A2.J98743.Q6 QJ3.QJ.K62.T7543 A8754.83.AQ.AKJ2"]
+
+[Board "22"]
+[Dealer "E"]
+[Vulnerable "EW"]
+[Deal "N:K9.KT97654.T5.98 T62.A2.J98743.Q6 QJ3.QJ.K62.T7543 A8754.83.AQ.AKJ2"]
+
+[Board "23"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:KT8.QT8.K2.98654 AQ4.974.975.K732 J7652.632.Q643.A 93.AKJ5.AJT8.QJT"]
+
+[Board "23"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:KT8.QT8.K2.98654 AQ4.974.975.K732 J7652.632.Q643.A 93.AKJ5.AJT8.QJT"]
+
+[Board "23"]
+[Dealer "S"]
+[Vulnerable "All"]
+[Deal "N:KT8.QT8.K2.98654 AQ4.974.975.K732 J7652.632.Q643.A 93.AKJ5.AJT8.QJT"]
+
+[Board "24"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:Q.KQT.J98754.432 864.AJ763.62.AT6 KT952.985.AQT.KQ AJ73.42.K3.J9875"]
+
+[Board "24"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:Q.KQT.J98754.432 864.AJ763.62.AT6 KT952.985.AQT.KQ AJ73.42.K3.J9875"]
+
+[Board "24"]
+[Dealer "W"]
+[Vulnerable "-"]
+[Deal "N:Q.KQT.J98754.432 864.AJ763.62.AT6 KT952.985.AQT.KQ AJ73.42.K3.J9875"]
+
+[Board "25"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:T9863.5.J85.Q764 K.T732.T64.JT853 AJ752.AK96.AQ7.K Q4.QJ84.K932.A92"]
+
+[Board "25"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:T9863.5.J85.Q764 K.T732.T64.JT853 AJ752.AK96.AQ7.K Q4.QJ84.K932.A92"]
+
+[Board "25"]
+[Dealer "N"]
+[Vulnerable "EW"]
+[Deal "N:T9863.5.J85.Q764 K.T732.T64.JT853 AJ752.AK96.AQ7.K Q4.QJ84.K932.A92"]

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -201,6 +201,14 @@ py_test(
     deps = ["//python/examples:dd_table_for_deal_lib"],
 )
 
+py_test(
+    name = "dd_table_for_deal_par_test",
+    size = "small",
+    main = "tests/test_dd_table_for_deal_par.py",
+    srcs = ["tests/test_dd_table_for_deal_par.py"],
+    deps = ["//python/examples:dd_table_for_deal_lib"],
+)
+
 py_wheel(
     name = "dds3_wheel",
     distribution = "dds3",

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -13,6 +13,7 @@ or
 ```bash
 bazelisk run //python/examples:dd_table_for_deal -- hands/example.pbn
 bazelisk run //python/examples:dd_table_for_deal -- --vul ns hands/example.pbn
+bazelisk run //python/examples:dd_table_for_deal -- --limit 3 hands/multi_board.pbn
 ```
 
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -11,7 +11,8 @@ bazelisk run //python/examples:dd_table_for_deal "N:73.QJT.AQ54.T752 QT6.876.KJ9
 or
 
 ```bash
-bazelisk run //python/examples:dd_table_for_deal hands/example.pbn
+bazelisk run //python/examples:dd_table_for_deal -- hands/example.pbn
+bazelisk run //python/examples:dd_table_for_deal -- --vul ns hands/example.pbn
 ```
 
 

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -222,6 +222,46 @@ def _contract_body(side_contracts: str) -> str | None:
     return body or None
 
 
+def _normalize_contract_piece(piece: str) -> tuple[str, str] | None:
+    """Expand DDS multi-level encodings like 'EW 45S' into ('EW 4S', '+1')."""
+    match = _CONTRACT_RE.match(piece.strip())
+    if match is None:
+        return None
+
+    seats, levels, denom, doubled = match.groups()
+    seats = seats.upper()
+    denom = denom.upper()
+    digits = [int(ch) for ch in levels]
+    level = digits[0]
+    over = digits[-1] - digits[0]
+
+    if doubled:
+        return f"{seats} {level}{denom}x", "="
+
+    contract = f"{seats} {level}{denom}"
+    result = f"+{over}" if over > 0 else "="
+    return contract, result
+
+
+def _normalize_par_body(body: str) -> tuple[str, str] | None:
+    """Normalize comma-separated contracts; result comes from the first make."""
+    pieces = [p.strip() for p in body.split(",") if p.strip()]
+    if not pieces:
+        return None
+
+    normalized: list[str] = []
+    result = "="
+    for i, piece in enumerate(pieces):
+        parsed = _normalize_contract_piece(piece)
+        if parsed is None:
+            return None
+        contract, piece_result = parsed
+        normalized.append(contract)
+        if i == 0:
+            result = piece_result
+    return ",".join(normalized), result
+
+
 def _first_seats(body: str) -> str | None:
     match = _CONTRACT_RE.match(body.split(",", 1)[0].strip())
     if match is None:
@@ -256,12 +296,17 @@ def _format_par_line(par_results: dict, *, vulnerable: int) -> str | None:
     if seats is None:
         return None
 
+    normalized = _normalize_par_body(body)
+    if normalized is None:
+        return None
+    body, make_result = normalized
+
     score = _declaring_score(par_results, seats)
     is_sacrifice = "x" in body.lower()
     if is_sacrifice:
         result = f"-{_sacrifice_undertricks(score, vulnerable, seats)}"
     else:
-        result = "="
+        result = make_result
 
     return f"Par: {body} {result} {score}"
 
@@ -365,7 +410,7 @@ def _print_pbn_hand(title: str, pbn_deal: str) -> None:
     print("-" * dash_len)
     for i in range(_DDS_HAND_LINES):
         print("".join(text[i][: row_ends[i]]))
-    print("\n")
+    print()
 
 
 def _print_table(res_table: list[list[int]]) -> None:

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -50,11 +50,11 @@ _DEAL_TAG_RE = re.compile(r'\[Deal\s*"([^"]*)"', re.IGNORECASE)
 
 
 def _read_pbn_stream(stream) -> str | None:
-    data = stream.read(PBN_FILE_MAX)
+    data = stream.read(PBN_FILE_MAX + 1)
     if not data:
         return None
     text = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
-    if len(text) >= PBN_FILE_MAX:
+    if len(text) > PBN_FILE_MAX:
         raise ValueError(f"PBN input too large (max {PBN_FILE_MAX} characters)")
     return text
 

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -166,14 +166,15 @@ def _parse_cli(argv: list[str]) -> tuple[str, int] | None:
 
 def _print_usage(prog: str) -> None:
     print(
-        f"Usage: {prog} [--vul none|both|ns|ew] <pbn_deal_or_file>\n"
+        f"Usage: {prog} [--vul none|both|ns|ew|0|1|2|3] <pbn_deal_or_file>\n"
         f"       {prog} -h | --help\n"
         "\n"
         "Calculate double-dummy tricks and par for all strains and leads.\n"
         "\n"
         "Arguments:\n"
         "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
-        "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
+        "  --vul              Vulnerability: none|both|ns|ew or 0|1|2|3"
+        " (default: none)\n"
         "\n"
         'If stdin is not a terminal, PBN is read from stdin (all [Deal "..."] tags).\n'
         "\n"

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Print the double-dummy table for a deal from PBN on the command line or a file.
+"""Print the double-dummy table and par for a deal from PBN on the CLI or a file.
 
 Python counterpart to examples/dd_table_for_deal.cpp.
 """
@@ -11,9 +11,25 @@ import re
 import sys
 from pathlib import Path
 
-from dds3 import calc_all_tables_pbn
+from dds3 import calc_all_tables_pbn, calc_par_from_table
 
 PBN_FILE_MAX = 8192
+
+_CONTRACT_RE = re.compile(
+    r"^(N|E|S|W|NS|EW)\s+(\d+)([SHDCN])(x)?$",
+    re.IGNORECASE,
+)
+
+_VULNERABLE_ALIASES = {
+    "none": 0,
+    "0": 0,
+    "both": 1,
+    "1": 1,
+    "ns": 2,
+    "2": 2,
+    "ew": 3,
+    "3": 3,
+}
 
 # res_table[strain][hand]: strain 0-3 = S,H,D,C; 4 = NT. Columns match C++ print_table.
 _STRAIN_ROWS = (("NT", 4), ("S", 0), ("H", 1), ("D", 2), ("C", 3))
@@ -80,25 +96,158 @@ def _load_deal(arg: str) -> str:
     return arg
 
 
+def _parse_vulnerable(text: str) -> int:
+    try:
+        return _VULNERABLE_ALIASES[text.lower()]
+    except KeyError as exc:
+        raise ValueError(
+            "Invalid --vul value (use none|both|ns|ew or 0|1|2|3)"
+        ) from exc
+
+
+def _parse_cli(argv: list[str]) -> tuple[str, int] | None:
+    """Return (deal_arg, vulnerable) or None for help. Raises ValueError on bad args."""
+    if len(argv) >= 2 and argv[1] in ("-h", "--help"):
+        return None
+
+    deal: str | None = None
+    vulnerable = 0
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--vul":
+            if i + 1 >= len(argv):
+                raise ValueError("--vul requires a value (none|both|ns|ew or 0|1|2|3)")
+            vulnerable = _parse_vulnerable(argv[i + 1])
+            i += 2
+            continue
+        if arg.startswith("-") and arg != "-":
+            raise ValueError(f"Unknown option: {arg}")
+        if deal is not None:
+            raise ValueError("Only one deal argument is allowed")
+        deal = arg
+        i += 1
+
+    if deal is None:
+        if not sys.stdin.isatty():
+            deal = "-"
+        else:
+            raise ValueError("missing deal argument")
+
+    return deal, vulnerable
+
+
 def _print_usage(prog: str) -> None:
     print(
-        f"Usage: {prog} <pbn_deal_or_file>\n"
+        f"Usage: {prog} [--vul none|both|ns|ew] <pbn_deal_or_file>\n"
         f"       {prog} -h | --help\n"
         "\n"
-        "Calculate double-dummy tricks for all strains and leads.\n"
+        "Calculate double-dummy tricks and par for all strains and leads.\n"
         "\n"
         "Arguments:\n"
         "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
+        "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
         "\n"
         'If stdin is not a terminal, PBN is read from stdin (uses [Deal "..."]).\n'
         "\n"
         "Examples:\n"
         f'  {prog} "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 '
         f'5.A95432.7632.K6 AKJ9842.K.T8.J93"\n'
-        f"  {prog} hands/example.pbn\n"
+        f"  {prog} --vul ns hands/example.pbn\n"
         f"  {prog} < hands/example.pbn\n",
         file=sys.stderr,
     )
+
+
+def _rawscore_undertricks(tricks: int, is_vul: bool) -> int:
+    """Match library/src/par.cpp rawscore(-1, tricks, is_vul)."""
+    if is_vul:
+        return -300 * tricks + 100
+    if tricks <= 3:
+        return -200 * tricks + 100
+    return -300 * tricks + 400
+
+
+def _side_vulnerable(seats: str, vulnerable: int) -> bool:
+    if vulnerable == 1:
+        return True
+    if seats in ("NS", "N", "S"):
+        return vulnerable == 2
+    if seats in ("EW", "E", "W"):
+        return vulnerable == 3
+    return False
+
+
+def _sacrifice_undertricks(score: int, vulnerable: int, seats: str) -> int:
+    """Infer sacrifice undertricks from the NS-view par score."""
+    is_vul = _side_vulnerable(seats, vulnerable)
+    for tricks in range(1, 14):
+        sacrifice_score = _rawscore_undertricks(tricks, is_vul)
+        if sacrifice_score == score or -sacrifice_score == score:
+            return tricks
+    raise ValueError(f"cannot infer undertricks for par score {score}")
+
+
+def _contract_body(side_contracts: str) -> str | None:
+    if ":" not in side_contracts:
+        return None
+    body = side_contracts.split(":", 1)[1].strip()
+    if not body or "," in body:
+        return None
+    return body
+
+
+def _format_par_line(par_results: dict, *, vulnerable: int) -> str | None:
+    """Return a one-line par summary, or None when verbose output is needed."""
+    scores = par_results["par_score"]
+    contracts = par_results["par_contracts_string"]
+
+    ns_score = int(scores[0].split()[1])
+    if ns_score == 0 and int(scores[1].split()[1]) == 0:
+        body = _contract_body(contracts[0])
+        if body is None:
+            return "Par: 0"
+        return "Par: 0"
+
+    body = _contract_body(contracts[0])
+    if body is None:
+        return None
+
+    match = _CONTRACT_RE.match(body)
+    if match is None:
+        return None
+
+    seats, level, denom, doubled = match.groups()
+    seats = seats.upper()
+    contract = f"{level}{denom.upper()}"
+    if doubled:
+        contract += "x"
+
+    if doubled:
+        result = f"-{_sacrifice_undertricks(ns_score, vulnerable, seats)}"
+    else:
+        result = "+0"
+
+    return f"Par: {seats} {contract} {result} {ns_score}"
+
+
+def _print_par_verbose(par_results: dict) -> None:
+    """Match examples/hands.cpp print_par."""
+    scores = par_results["par_score"]
+    contracts = par_results["par_contracts_string"]
+    print(f"NS score: {scores[0]}")
+    print(f"EW score: {scores[1]}")
+    print(f"NS list : {contracts[0]}")
+    print(f"EW list : {contracts[1]}")
+    print()
+
+
+def _print_par(par_results: dict, *, vulnerable: int = 0) -> None:
+    line = _format_par_line(par_results, vulnerable=vulnerable)
+    if line is None:
+        _print_par_verbose(par_results)
+    else:
+        print(line)
 
 
 def _is_card(ch: str) -> int:
@@ -212,16 +361,18 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv if argv is None else argv)
     prog = Path(argv[0]).name
 
-    if len(argv) == 2:
-        if argv[1] in ("-h", "--help"):
-            _print_usage(prog)
-            return 0
-        input_arg = argv[1]
-    elif len(argv) == 1 and not sys.stdin.isatty():
-        input_arg = "-"
-    else:
+    try:
+        parsed = _parse_cli(argv)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
         _print_usage(prog)
         return 1
+
+    if parsed is None:
+        _print_usage(prog)
+        return 0
+
+    input_arg, vulnerable = parsed
 
     try:
         pbn_deal = _load_deal(input_arg)
@@ -240,9 +391,16 @@ def main(argv: list[str] | None = None) -> int:
         print("DDS error: no table returned", file=sys.stderr)
         return 1
 
-    res_table = tables[0]["res_table"]
+    table = tables[0]
+    try:
+        par_results = calc_par_from_table(table, vulnerable=vulnerable)
+    except (ValueError, RuntimeError) as exc:
+        print(f"DDS error: {exc}", file=sys.stderr)
+        return 1
+
     _print_pbn_hand("dd_table_for_deal:\n", pbn_deal)
-    _print_table(res_table)
+    _print_table(table["res_table"])
+    _print_par(par_results, vulnerable=vulnerable)
     return 0
 
 

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -132,13 +132,23 @@ def _parse_vulnerable(text: str) -> int:
         ) from exc
 
 
-def _parse_cli(argv: list[str]) -> tuple[str, int] | None:
-    """Return (deal_arg, vulnerable) or None for help. Raises ValueError on bad args."""
+def _parse_limit(text: str) -> int:
+    if not text.isdigit() or int(text) < 1:
+        raise ValueError("Invalid --limit value (use a positive integer)")
+    return int(text)
+
+
+def _parse_cli(argv: list[str]) -> tuple[str, int, int | None] | None:
+    """Return (deal_arg, vulnerable, limit) or None for help.
+
+    limit is None when unrestricted. Raises ValueError on bad args.
+    """
     if len(argv) >= 2 and argv[1] in ("-h", "--help"):
         return None
 
     deal: str | None = None
     vulnerable = 0
+    limit: int | None = None
     i = 1
     while i < len(argv):
         arg = argv[i]
@@ -146,6 +156,12 @@ def _parse_cli(argv: list[str]) -> tuple[str, int] | None:
             if i + 1 >= len(argv):
                 raise ValueError("--vul requires a value (none|both|ns|ew or 0|1|2|3)")
             vulnerable = _parse_vulnerable(argv[i + 1])
+            i += 2
+            continue
+        if arg == "--limit":
+            if i + 1 >= len(argv):
+                raise ValueError("--limit requires a positive integer")
+            limit = _parse_limit(argv[i + 1])
             i += 2
             continue
         if arg.startswith("-") and arg != "-":
@@ -161,12 +177,13 @@ def _parse_cli(argv: list[str]) -> tuple[str, int] | None:
         else:
             raise ValueError("missing deal argument")
 
-    return deal, vulnerable
+    return deal, vulnerable, limit
 
 
 def _print_usage(prog: str) -> None:
     print(
-        f"Usage: {prog} [--vul none|both|ns|ew|0|1|2|3] <pbn_deal_or_file>\n"
+        f"Usage: {prog} [--vul none|both|ns|ew|0|1|2|3] [--limit N] "
+        f"<pbn_deal_or_file>\n"
         f"       {prog} -h | --help\n"
         "\n"
         "Calculate double-dummy tricks and par for all strains and leads.\n"
@@ -175,6 +192,7 @@ def _print_usage(prog: str) -> None:
         "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
         "  --vul              Vulnerability: none|both|ns|ew or 0|1|2|3"
         " (default: none)\n"
+        "  --limit            Solve only the first N unique deals\n"
         "\n"
         'If stdin is not a terminal, PBN is read from stdin (all [Deal "..."] tags).\n'
         "\n"
@@ -182,6 +200,7 @@ def _print_usage(prog: str) -> None:
         f'  {prog} "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 '
         f'5.A95432.7632.K6 AKJ9842.K.T8.J93"\n'
         f"  {prog} --vul ns hands/example.pbn\n"
+        f"  {prog} --limit 3 hands/multi_board.pbn\n"
         f"  {prog} < hands/example.pbn\n",
         file=sys.stderr,
     )
@@ -455,13 +474,16 @@ def main(argv: list[str] | None = None) -> int:
         _print_usage(prog)
         return 0
 
-    input_arg, vulnerable = parsed
+    input_arg, vulnerable, limit = parsed
 
     try:
         pbn_deals = _unique_deals(_load_deals(input_arg))
     except ValueError as exc:
         print(exc, file=sys.stderr)
         return 1
+
+    if limit is not None:
+        pbn_deals = pbn_deals[:limit]
 
     if any(len(deal) >= PBN_DEAL_MAX for deal in pbn_deals):
         print(

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -143,15 +143,14 @@ def _parse_cli(argv: list[str]) -> tuple[str, int, int | None] | None:
 
     limit is None when unrestricted. Raises ValueError on bad args.
     """
-    if len(argv) >= 2 and argv[1] in ("-h", "--help"):
-        return None
-
     deal: str | None = None
     vulnerable = 0
     limit: int | None = None
     i = 1
     while i < len(argv):
         arg = argv[i]
+        if arg in ("-h", "--help"):
+            return None
         if arg == "--vul":
             if i + 1 >= len(argv):
                 raise ValueError("--vul requires a value (none|both|ns|ew or 0|1|2|3)")

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -207,43 +207,51 @@ def _contract_body(side_contracts: str) -> str | None:
     if ":" not in side_contracts:
         return None
     body = side_contracts.split(":", 1)[1].strip()
-    if not body or "," in body:
+    return body or None
+
+
+def _first_seats(body: str) -> str | None:
+    match = _CONTRACT_RE.match(body.split(",", 1)[0].strip())
+    if match is None:
         return None
-    return body
+    return match.group(1).upper()
+
+
+def _declaring_score(par_results: dict, seats: str) -> int:
+    scores = par_results["par_score"]
+    ns_score = int(scores[0].split()[1])
+    ew_score = int(scores[1].split()[1])
+    if seats in ("NS", "N", "S"):
+        return ns_score
+    return ew_score
 
 
 def _format_par_line(par_results: dict, *, vulnerable: int) -> str | None:
-    """Return a one-line par summary, or None when verbose output is needed."""
+    """Return a one-line par summary for the declaring side."""
     scores = par_results["par_score"]
     contracts = par_results["par_contracts_string"]
 
     ns_score = int(scores[0].split()[1])
-    if ns_score == 0 and int(scores[1].split()[1]) == 0:
-        body = _contract_body(contracts[0])
-        if body is None:
-            return "Par: 0"
+    ew_score = int(scores[1].split()[1])
+    if ns_score == 0 and ew_score == 0:
         return "Par: 0"
 
     body = _contract_body(contracts[0])
     if body is None:
         return None
 
-    match = _CONTRACT_RE.match(body)
-    if match is None:
+    seats = _first_seats(body)
+    if seats is None:
         return None
 
-    seats, level, denom, doubled = match.groups()
-    seats = seats.upper()
-    contract = f"{level}{denom.upper()}"
-    if doubled:
-        contract += "x"
-
-    if doubled:
-        result = f"-{_sacrifice_undertricks(ns_score, vulnerable, seats)}"
+    score = _declaring_score(par_results, seats)
+    is_sacrifice = "x" in body.lower()
+    if is_sacrifice:
+        result = f"-{_sacrifice_undertricks(score, vulnerable, seats)}"
     else:
-        result = "+0"
+        result = "="
 
-    return f"Par: {seats} {contract} {result} {ns_score}"
+    return f"Par: {body} {result} {score}"
 
 
 def _print_par_verbose(par_results: dict) -> None:

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -79,6 +79,18 @@ def _extract_deal_tags(text: str) -> list[str]:
     return [match.group(1) for match in _DEAL_TAG_RE.finditer(text)]
 
 
+def _unique_deals(deals: list[str]) -> list[str]:
+    """Return deals in first-seen order with exact duplicates removed."""
+    unique: list[str] = []
+    seen: set[str] = set()
+    for deal in deals:
+        if deal in seen:
+            continue
+        seen.add(deal)
+        unique.append(deal)
+    return unique
+
+
 def _looks_like_path(arg: str) -> bool:
     """True when arg is more likely a filename than a raw PBN deal string."""
     if "/" in arg or "\\" in arg:
@@ -398,7 +410,7 @@ def main(argv: list[str] | None = None) -> int:
     input_arg, vulnerable = parsed
 
     try:
-        pbn_deals = _load_deals(input_arg)
+        pbn_deals = _unique_deals(_load_deals(input_arg))
     except ValueError as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -223,8 +223,8 @@ def _contract_body(side_contracts: str) -> str | None:
     return body or None
 
 
-def _normalize_contract_piece(piece: str) -> tuple[str, str] | None:
-    """Expand DDS multi-level encodings like 'EW 45S' into ('EW 4S', '+1')."""
+def _normalize_contract_piece(piece: str) -> tuple[str, str, str] | None:
+    """Expand DDS multi-level encodings like 'EW 45S' into ('EW', '4S', '+1')."""
     match = _CONTRACT_RE.match(piece.strip())
     if match is None:
         return None
@@ -236,12 +236,12 @@ def _normalize_contract_piece(piece: str) -> tuple[str, str] | None:
     level = digits[0]
     over = digits[-1] - digits[0]
 
+    contract = f"{level}{denom}{'x' if doubled else ''}"
     if doubled:
-        return f"{seats} {level}{denom}x", "="
+        return seats, contract, "="
 
-    contract = f"{seats} {level}{denom}"
     result = f"+{over}" if over > 0 else "="
-    return contract, result
+    return seats, contract, result
 
 
 def _normalize_par_body(body: str) -> tuple[str, str] | None:
@@ -256,11 +256,13 @@ def _normalize_par_body(body: str) -> tuple[str, str] | None:
         parsed = _normalize_contract_piece(piece)
         if parsed is None:
             return None
-        contract, piece_result = parsed
-        normalized.append(contract)
+        seats, contract, piece_result = parsed
         if i == 0:
+            normalized.append(f"{seats} {contract}")
             result = piece_result
-    return ",".join(normalized), result
+        else:
+            normalized.append(contract)
+    return ", ".join(normalized), result
 
 
 def _first_seats(body: str) -> str | None:

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -13,7 +13,8 @@ from pathlib import Path
 
 from dds3 import calc_all_tables_pbn, calc_par_from_table
 
-PBN_FILE_MAX = 8192
+PBN_FILE_MAX = 16 * 1024 * 1024  # safety cap for whole PBN exports
+PBN_DEAL_MAX = 80  # matches DdTableDealPBN::cards
 
 _CONTRACT_RE = re.compile(
     r"^(N|E|S|W|NS|EW)\s+(\d+)([SHDCN])(x)?$",
@@ -49,10 +50,13 @@ _DEAL_TAG_RE = re.compile(r'\[Deal\s*"([^"]*)"', re.IGNORECASE)
 
 
 def _read_pbn_stream(stream) -> str | None:
-    data = stream.read(PBN_FILE_MAX - 1)
+    data = stream.read(PBN_FILE_MAX)
     if not data:
         return None
-    return data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+    text = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+    if len(text) >= PBN_FILE_MAX:
+        raise ValueError(f"PBN input too large (max {PBN_FILE_MAX} characters)")
+    return text
 
 
 def _read_pbn_file(path: str) -> str | None:
@@ -62,20 +66,28 @@ def _read_pbn_file(path: str) -> str | None:
         candidates.append(Path(workspace) / path)
     for candidate in candidates:
         try:
-            return candidate.read_text(encoding="utf-8", errors="replace")[
-                : PBN_FILE_MAX - 1
-            ]
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+            if len(text) > PBN_FILE_MAX:
+                raise ValueError(f"PBN file too large (max {PBN_FILE_MAX} characters)")
+            return text
         except OSError:
             continue
     return None
 
 
-def _extract_deal_tag(text: str) -> str | None:
-    match = _DEAL_TAG_RE.search(text)
-    return match.group(1) if match else None
+def _extract_deal_tags(text: str) -> list[str]:
+    return [match.group(1) for match in _DEAL_TAG_RE.finditer(text)]
 
 
-def _load_deal(arg: str) -> str:
+def _looks_like_path(arg: str) -> bool:
+    """True when arg is more likely a filename than a raw PBN deal string."""
+    if "/" in arg or "\\" in arg:
+        return True
+    lower = arg.lower()
+    return lower.endswith(".pbn") or lower.endswith(".txt")
+
+
+def _load_deals(arg: str) -> list[str]:
     if arg == "-":
         text = _read_pbn_stream(sys.stdin)
         if text is None:
@@ -86,14 +98,17 @@ def _load_deal(arg: str) -> str:
         source = arg if text is not None else None
 
     if source is not None:
-        deal = _extract_deal_tag(text)
-        if deal is None:
+        deals = _extract_deal_tags(text)
+        if not deals:
             raise ValueError(f'No [Deal "..."] tag found in {source}')
-        return deal
+        return deals
 
-    if len(arg) >= PBN_FILE_MAX:
-        raise ValueError(f"PBN deal too long (max {PBN_FILE_MAX - 1} characters)")
-    return arg
+    if _looks_like_path(arg):
+        raise ValueError(f"Cannot read file: {arg}")
+
+    if len(arg) >= PBN_DEAL_MAX:
+        raise ValueError(f"PBN deal too long (max {PBN_DEAL_MAX - 1} characters)")
+    return [arg]
 
 
 def _parse_vulnerable(text: str) -> int:
@@ -148,7 +163,7 @@ def _print_usage(prog: str) -> None:
         "  <pbn_deal_or_file>  DDS PBN deal string, or path to a .pbn file\n"
         "  --vul              Vulnerability: none, both, ns, ew (default: none)\n"
         "\n"
-        'If stdin is not a terminal, PBN is read from stdin (uses [Deal "..."]).\n'
+        'If stdin is not a terminal, PBN is read from stdin (all [Deal "..."] tags).\n'
         "\n"
         "Examples:\n"
         f'  {prog} "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 '
@@ -375,32 +390,48 @@ def main(argv: list[str] | None = None) -> int:
     input_arg, vulnerable = parsed
 
     try:
-        pbn_deal = _load_deal(input_arg)
+        pbn_deals = _load_deals(input_arg)
     except ValueError as exc:
         print(exc, file=sys.stderr)
         return 1
 
-    try:
-        result = calc_all_tables_pbn([pbn_deal])
-    except (ValueError, RuntimeError) as exc:
-        print(f"DDS error: {exc}", file=sys.stderr)
+    if any(len(deal) >= PBN_DEAL_MAX for deal in pbn_deals):
+        print(
+            f"PBN deal too long (max {PBN_DEAL_MAX - 1} characters)",
+            file=sys.stderr,
+        )
         return 1
 
-    tables = result.get("tables")
-    if not tables:
-        print("DDS error: no table returned", file=sys.stderr)
-        return 1
+    deal_count = len(pbn_deals)
+    for deal_no, pbn_deal in enumerate(pbn_deals, start=1):
+        try:
+            result = calc_all_tables_pbn([pbn_deal])
+        except (ValueError, RuntimeError) as exc:
+            print(f"DDS error: {exc}", file=sys.stderr)
+            return 1
 
-    table = tables[0]
-    try:
-        par_results = calc_par_from_table(table, vulnerable=vulnerable)
-    except (ValueError, RuntimeError) as exc:
-        print(f"DDS error: {exc}", file=sys.stderr)
-        return 1
+        tables = result.get("tables")
+        if not tables:
+            print("DDS error: no table returned", file=sys.stderr)
+            return 1
 
-    _print_pbn_hand("dd_table_for_deal:\n", pbn_deal)
-    _print_table(table["res_table"])
-    _print_par(par_results, vulnerable=vulnerable)
+        table = tables[0]
+        try:
+            par_results = calc_par_from_table(table, vulnerable=vulnerable)
+        except (ValueError, RuntimeError) as exc:
+            print(f"DDS error: {exc}", file=sys.stderr)
+            return 1
+
+        title = (
+            "dd_table_for_deal:\n"
+            if deal_count == 1
+            else f"Deal {deal_no}:\n"
+        )
+        _print_pbn_hand(title, pbn_deal)
+        _print_table(table["res_table"])
+        _print_par(par_results, vulnerable=vulnerable)
+        if deal_count > 1:
+            print()
     return 0
 
 

--- a/python/examples/dd_table_for_deal.py
+++ b/python/examples/dd_table_for_deal.py
@@ -226,7 +226,7 @@ def _side_vulnerable(seats: str, vulnerable: int) -> bool:
 
 
 def _sacrifice_undertricks(score: int, vulnerable: int, seats: str) -> int:
-    """Infer sacrifice undertricks from the NS-view par score."""
+    """Infer sacrifice undertricks from the declaring-side par score."""
     is_vul = _side_vulnerable(seats, vulnerable)
     for tricks in range(1, 14):
         sacrifice_score = _rawscore_undertricks(tricks, is_vul)

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import io
+import tempfile
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest import mock
 
 from dd_table_for_deal import (
+    _extract_deal_tags,
     _format_par_line,
+    _load_deals,
     _parse_cli,
     _parse_vulnerable,
     _print_par,
@@ -18,6 +22,17 @@ from dd_table_for_deal import (
 _EXAMPLE_DEAL = (
     "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
     "5.A95432.7632.K6 AKJ9842.K.T8.J93"
+)
+_HAND0_DEAL = (
+    "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 "
+    "K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3"
+)
+_MULTI_DEAL_PBN = (
+    '{Board 1}\n'
+    f'[Deal "{_EXAMPLE_DEAL}"]\n'
+    "\n"
+    "{Board 2}\n"
+    f'[Deal "{_HAND0_DEAL}"]\n'
 )
 
 
@@ -71,6 +86,73 @@ class ParseCliTest(unittest.TestCase):
     def test_rejects_unknown_flags(self) -> None:
         with self.assertRaises(ValueError):
             _parse_cli(["prog", "--oops", _EXAMPLE_DEAL])
+
+
+class ExtractDealTagsTest(unittest.TestCase):
+    def test_finds_all_deal_tags_in_pbn_text(self) -> None:
+        self.assertEqual(
+            _extract_deal_tags(_MULTI_DEAL_PBN),
+            [_EXAMPLE_DEAL, _HAND0_DEAL],
+        )
+
+    def test_returns_empty_list_when_no_tags(self) -> None:
+        self.assertEqual(_extract_deal_tags("{comment only}"), [])
+
+
+class ReadPbnFileTest(unittest.TestCase):
+    def test_reads_entire_file_past_old_8k_limit(self) -> None:
+        """Regression: large PBN files must not be truncated at 8192 bytes."""
+        from dd_table_for_deal import _read_pbn_file
+
+        deals = [
+            f"N:{i:02d}.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
+            f"5.A95432.7632.K6 AKJ9842.K.T8.J93"
+            for i in range(10)
+        ]
+        chunks: list[str] = []
+        for deal in deals:
+            pad = "x" * max(0, 900 - len(deal))
+            chunks.append(f'{{pad {pad}}}\n[Deal "{deal}"]\n')
+        text = "".join(chunks)
+        self.assertGreater(len(text), 8192)
+
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".pbn", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(text)
+            path = tmp.name
+        try:
+            loaded = _read_pbn_file(path)
+            self.assertIsNotNone(loaded)
+            assert loaded is not None
+            self.assertEqual(len(loaded), len(text))
+            self.assertEqual(_extract_deal_tags(loaded), deals)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+
+class LoadDealsTest(unittest.TestCase):
+    def test_raw_string_returns_single_deal(self) -> None:
+        self.assertEqual(_load_deals(_EXAMPLE_DEAL), [_EXAMPLE_DEAL])
+
+    def test_pbn_file_returns_all_deals(self) -> None:
+        with mock.patch(
+            "dd_table_for_deal._read_pbn_file", return_value=_MULTI_DEAL_PBN
+        ):
+            self.assertEqual(
+                _load_deals("boards.pbn"),
+                [_EXAMPLE_DEAL, _HAND0_DEAL],
+            )
+
+    def test_missing_pbn_path_reports_file_not_found(self) -> None:
+        with mock.patch("dd_table_for_deal._read_pbn_file", return_value=None):
+            with self.assertRaisesRegex(ValueError, r"Cannot read file: boards\.pbn"):
+                _load_deals("boards.pbn")
+
+    def test_missing_path_with_slash_reports_file_not_found(self) -> None:
+        with mock.patch("dd_table_for_deal._read_pbn_file", return_value=None):
+            with self.assertRaisesRegex(ValueError, r"Cannot read file: hands/x\.pbn"):
+                _load_deals("hands/x.pbn")
 
 
 class FormatParLineTest(unittest.TestCase):
@@ -170,6 +252,44 @@ class MainParOutputTest(unittest.TestCase):
         par_mock.assert_called_once()
         args, kwargs = par_mock.call_args
         self.assertEqual(kwargs.get("vulnerable", args[1] if len(args) > 1 else None), 3)
+
+    def test_main_processes_all_deals_from_pbn_file(self) -> None:
+        fake_tables = {
+            "tables": [
+                {"res_table": [[0] * 4 for _ in range(5)]},
+                {"res_table": [[1] * 4 for _ in range(5)]},
+            ]
+        }
+        fake_par = {
+            "par_score": ["NS 0", "EW 0"],
+            "par_contracts_string": ["NS:", "EW:"],
+        }
+        with mock.patch(
+            "dd_table_for_deal._read_pbn_file", return_value=_MULTI_DEAL_PBN
+        ), mock.patch(
+            "dd_table_for_deal.calc_all_tables_pbn", return_value=fake_tables
+        ) as calc_mock, mock.patch(
+            "dd_table_for_deal.calc_par_from_table", return_value=fake_par
+        ) as par_mock, mock.patch(
+            "dd_table_for_deal._print_pbn_hand"
+        ) as hand_mock, mock.patch(
+            "dd_table_for_deal._print_table"
+        ), redirect_stdout(io.StringIO()) as buf:
+            rc = main(["dd_table_for_deal", "boards.pbn"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            [call.args[0] for call in calc_mock.call_args_list],
+            [[_EXAMPLE_DEAL], [_HAND0_DEAL]],
+        )
+        self.assertEqual(par_mock.call_count, 2)
+        self.assertEqual(hand_mock.call_count, 2)
+        titles = [call.args[0] for call in hand_mock.call_args_list]
+        self.assertEqual(titles[0], "Deal 1:\n")
+        self.assertEqual(titles[1], "Deal 2:\n")
+        out = buf.getvalue()
+        self.assertIn("Par: 0\n\n", out)
+        self.assertEqual(out.count("Par: 0\n\n"), 2)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -16,6 +16,7 @@ from dd_table_for_deal import (
     _parse_cli,
     _parse_vulnerable,
     _print_par,
+    _unique_deals,
     main,
 )
 
@@ -97,6 +98,12 @@ class ExtractDealTagsTest(unittest.TestCase):
 
     def test_returns_empty_list_when_no_tags(self) -> None:
         self.assertEqual(_extract_deal_tags("{comment only}"), [])
+
+
+class UniqueDealsTest(unittest.TestCase):
+    def test_preserves_first_seen_order_and_drops_duplicates(self) -> None:
+        deals = ["deal-a", "deal-b", "deal-a", "deal-c", "deal-b", "deal-a"]
+        self.assertEqual(_unique_deals(deals), ["deal-a", "deal-b", "deal-c"])
 
 
 class ReadPbnFileTest(unittest.TestCase):
@@ -293,6 +300,40 @@ class MainParOutputTest(unittest.TestCase):
         out = buf.getvalue()
         self.assertIn("Par: 0\n\n", out)
         self.assertEqual(out.count("Par: 0\n\n"), 2)
+
+    def test_main_solves_duplicate_deals_only_once(self) -> None:
+        duplicate_pbn = (
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+            f'[Deal "{_HAND0_DEAL}"]\n'
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+        )
+        fake_tables = {
+            "tables": [{"res_table": [[0] * 4 for _ in range(5)]}],
+        }
+        fake_par = {
+            "par_score": ["NS 0", "EW 0"],
+            "par_contracts_string": ["NS:", "EW:"],
+        }
+        with mock.patch(
+            "dd_table_for_deal._read_pbn_file", return_value=duplicate_pbn
+        ), mock.patch(
+            "dd_table_for_deal.calc_all_tables_pbn", return_value=fake_tables
+        ) as calc_mock, mock.patch(
+            "dd_table_for_deal.calc_par_from_table", return_value=fake_par
+        ), mock.patch(
+            "dd_table_for_deal._print_pbn_hand"
+        ) as hand_mock, mock.patch(
+            "dd_table_for_deal._print_table"
+        ), redirect_stdout(io.StringIO()):
+            rc = main(["dd_table_for_deal", "dupes.pbn"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            [call.args[0] for call in calc_mock.call_args_list],
+            [[_EXAMPLE_DEAL], [_HAND0_DEAL]],
+        )
+        self.assertEqual(hand_mock.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -340,6 +340,25 @@ class MainParOutputTest(unittest.TestCase):
         args, kwargs = par_mock.call_args
         self.assertEqual(kwargs.get("vulnerable", args[1] if len(args) > 1 else None), 3)
 
+    def test_main_returns_error_when_par_fails(self) -> None:
+        fake_tables = {
+            "tables": [{"res_table": [[0] * 4 for _ in range(5)]}],
+        }
+        with mock.patch(
+            "dd_table_for_deal.calc_all_tables_pbn", return_value=fake_tables
+        ), mock.patch(
+            "dd_table_for_deal.calc_par_from_table",
+            side_effect=RuntimeError("par failed"),
+        ), mock.patch(
+            "dd_table_for_deal._print_pbn_hand"
+        ), mock.patch(
+            "dd_table_for_deal._print_table"
+        ), redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()) as err:
+            rc = main(["dd_table_for_deal", _EXAMPLE_DEAL])
+
+        self.assertEqual(rc, 1)
+        self.assertIn("DDS error:", err.getvalue())
+
     def test_main_processes_all_deals_from_pbn_file(self) -> None:
         fake_tables = {
             "tables": [

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -226,7 +226,17 @@ class FormatParLineTest(unittest.TestCase):
         }
         self.assertEqual(
             _format_par_line(par_results, vulnerable=0),
-            "Par: EW 3Dx,EW 3Cx -1 -100",
+            "Par: EW 3Dx, 3Cx -1 -100",
+        )
+
+    def test_omits_repeated_declaring_side_when_seats_differ(self) -> None:
+        par_results = {
+            "par_score": ["NS 100", "EW -100"],
+            "par_contracts_string": ["NS:EW 4Hx,E 5Cx", "EW:EW 4Hx,E 5Cx"],
+        }
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: EW 4Hx, 5Cx -1 -100",
         )
 
     def test_passed_out(self) -> None:
@@ -256,7 +266,7 @@ class PrintParTest(unittest.TestCase):
         buf = io.StringIO()
         with redirect_stdout(buf):
             _print_par(par_results, vulnerable=0)
-        self.assertEqual(buf.getvalue(), "Par: EW 3Dx,EW 3Cx -1 -100\n")
+        self.assertEqual(buf.getvalue(), "Par: EW 3Dx, 3Cx -1 -100\n")
         self.assertNotIn("NS score:", buf.getvalue())
 
 

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -173,15 +173,18 @@ class FormatParLineTest(unittest.TestCase):
         }
         self.assertEqual(
             _format_par_line(par_results, vulnerable=0),
-            "Par: EW 2S +0 -110",
+            "Par: EW 2S = 110",
         )
 
-    def test_multiple_contracts_returns_none(self) -> None:
+    def test_multiple_sacrifice_contracts_on_one_line(self) -> None:
         par_results = {
-            "par_score": ["NS -600", "EW 600"],
-            "par_contracts_string": ["NS:EW 2S,EW 3S", "EW:EW 2S,EW 3S"],
+            "par_score": ["NS 100", "EW -100"],
+            "par_contracts_string": ["NS:EW 3Dx,EW 3Cx", "EW:EW 3Dx,EW 3Cx"],
         }
-        self.assertIsNone(_format_par_line(par_results, vulnerable=0))
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: EW 3Dx,EW 3Cx -1 -100",
+        )
 
     def test_passed_out(self) -> None:
         par_results = {
@@ -202,16 +205,16 @@ class PrintParTest(unittest.TestCase):
             _print_par(par_results, vulnerable=0)
         self.assertEqual(buf.getvalue(), "Par: NS 5Hx -2 -300\n")
 
-    def test_multiple_pars_use_verbose_format(self) -> None:
+    def test_multiple_pars_use_compact_line(self) -> None:
         par_results = {
-            "par_score": ["NS -600", "EW 600"],
-            "par_contracts_string": ["NS:EW 2S,EW 3S", "EW:EW 2S,EW 3S"],
+            "par_score": ["NS 100", "EW -100"],
+            "par_contracts_string": ["NS:EW 3Dx,EW 3Cx", "EW:EW 3Dx,EW 3Cx"],
         }
         buf = io.StringIO()
         with redirect_stdout(buf):
             _print_par(par_results, vulnerable=0)
-        self.assertIn("NS score:", buf.getvalue())
-        self.assertIn("NS list :", buf.getvalue())
+        self.assertEqual(buf.getvalue(), "Par: EW 3Dx,EW 3Cx -1 -100\n")
+        self.assertNotIn("NS score:", buf.getvalue())
 
 
 class MainParOutputTest(unittest.TestCase):

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -67,19 +67,44 @@ class ParseVulnerableTest(unittest.TestCase):
 
 class ParseCliTest(unittest.TestCase):
     def test_deal_only_defaults_vulnerable_to_none(self) -> None:
-        deal, vulnerable = _parse_cli(["prog", _EXAMPLE_DEAL])
+        deal, vulnerable, limit = _parse_cli(["prog", _EXAMPLE_DEAL])
         self.assertEqual(deal, _EXAMPLE_DEAL)
         self.assertEqual(vulnerable, 0)
+        self.assertIsNone(limit)
 
     def test_vul_flag_before_deal(self) -> None:
-        deal, vulnerable = _parse_cli(["prog", "--vul", "ns", _EXAMPLE_DEAL])
+        deal, vulnerable, limit = _parse_cli(["prog", "--vul", "ns", _EXAMPLE_DEAL])
         self.assertEqual(deal, _EXAMPLE_DEAL)
         self.assertEqual(vulnerable, 2)
+        self.assertIsNone(limit)
 
     def test_vul_flag_after_deal(self) -> None:
-        deal, vulnerable = _parse_cli(["prog", _EXAMPLE_DEAL, "--vul", "both"])
+        deal, vulnerable, limit = _parse_cli(["prog", _EXAMPLE_DEAL, "--vul", "both"])
         self.assertEqual(deal, _EXAMPLE_DEAL)
         self.assertEqual(vulnerable, 1)
+        self.assertIsNone(limit)
+
+    def test_limit_flag(self) -> None:
+        deal, vulnerable, limit = _parse_cli(
+            ["prog", "--limit", "3", _EXAMPLE_DEAL]
+        )
+        self.assertEqual(deal, _EXAMPLE_DEAL)
+        self.assertEqual(vulnerable, 0)
+        self.assertEqual(limit, 3)
+
+    def test_limit_and_vul_together(self) -> None:
+        deal, vulnerable, limit = _parse_cli(
+            ["prog", "--vul", "ns", "--limit", "1", "boards.pbn"]
+        )
+        self.assertEqual(deal, "boards.pbn")
+        self.assertEqual(vulnerable, 2)
+        self.assertEqual(limit, 1)
+
+    def test_rejects_non_positive_limit(self) -> None:
+        for bad in ("0", "-1", "x", ""):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    _parse_cli(["prog", "--limit", bad, _EXAMPLE_DEAL])
 
     def test_help_returns_none(self) -> None:
         self.assertIsNone(_parse_cli(["prog", "-h"]))
@@ -92,6 +117,12 @@ class ParseCliTest(unittest.TestCase):
         text = buf.getvalue()
         self.assertIn("none|both|ns|ew", text)
         self.assertIn("0|1|2|3", text)
+
+    def test_usage_documents_limit(self) -> None:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            _print_usage("prog")
+        self.assertIn("--limit", buf.getvalue())
 
     def test_rejects_unknown_flags(self) -> None:
         with self.assertRaises(ValueError):
@@ -346,6 +377,41 @@ class MainParOutputTest(unittest.TestCase):
         out = buf.getvalue()
         self.assertIn("Par: 0\n\n", out)
         self.assertEqual(out.count("Par: 0\n\n"), 2)
+
+    def test_main_limit_solves_only_first_n_unique_deals(self) -> None:
+        duplicate_pbn = (
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+            f'[Deal "{_HAND0_DEAL}"]\n'
+            f'[Deal "{_EXAMPLE_DEAL}"]\n'
+        )
+        fake_tables = {
+            "tables": [{"res_table": [[0] * 4 for _ in range(5)]}],
+        }
+        fake_par = {
+            "par_score": ["NS 0", "EW 0"],
+            "par_contracts_string": ["NS:", "EW:"],
+        }
+        with mock.patch(
+            "dd_table_for_deal._read_pbn_file", return_value=duplicate_pbn
+        ), mock.patch(
+            "dd_table_for_deal.calc_all_tables_pbn", return_value=fake_tables
+        ) as calc_mock, mock.patch(
+            "dd_table_for_deal.calc_par_from_table", return_value=fake_par
+        ), mock.patch(
+            "dd_table_for_deal._print_pbn_hand"
+        ) as hand_mock, mock.patch(
+            "dd_table_for_deal._print_table"
+        ), redirect_stdout(io.StringIO()):
+            rc = main(["dd_table_for_deal", "--limit", "1", "dupes.pbn"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            [call.args[0] for call in calc_mock.call_args_list],
+            [[_EXAMPLE_DEAL]],
+        )
+        self.assertEqual(hand_mock.call_count, 1)
+        self.assertEqual(hand_mock.call_args.args[0], "dd_table_for_deal:\n")
 
     def test_main_solves_duplicate_deals_only_once(self) -> None:
         duplicate_pbn = (

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -1,0 +1,176 @@
+"""Tests for par output in dd_table_for_deal."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from dd_table_for_deal import (
+    _format_par_line,
+    _parse_cli,
+    _parse_vulnerable,
+    _print_par,
+    main,
+)
+
+_EXAMPLE_DEAL = (
+    "N:73.QJT.AQ54.T752 QT6.876.KJ9.AQ84 "
+    "5.A95432.7632.K6 AKJ9842.K.T8.J93"
+)
+
+
+class ParseVulnerableTest(unittest.TestCase):
+    def test_accepts_aliases_and_numeric_codes(self) -> None:
+        cases = {
+            "none": 0,
+            "None": 0,
+            "0": 0,
+            "both": 1,
+            "BOTH": 1,
+            "1": 1,
+            "ns": 2,
+            "NS": 2,
+            "2": 2,
+            "ew": 3,
+            "EW": 3,
+            "3": 3,
+        }
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(_parse_vulnerable(text), expected)
+
+    def test_rejects_unknown_values(self) -> None:
+        for text in ("", "maybe", "4", "-1", "north"):
+            with self.subTest(text=text):
+                with self.assertRaises(ValueError):
+                    _parse_vulnerable(text)
+
+
+class ParseCliTest(unittest.TestCase):
+    def test_deal_only_defaults_vulnerable_to_none(self) -> None:
+        deal, vulnerable = _parse_cli(["prog", _EXAMPLE_DEAL])
+        self.assertEqual(deal, _EXAMPLE_DEAL)
+        self.assertEqual(vulnerable, 0)
+
+    def test_vul_flag_before_deal(self) -> None:
+        deal, vulnerable = _parse_cli(["prog", "--vul", "ns", _EXAMPLE_DEAL])
+        self.assertEqual(deal, _EXAMPLE_DEAL)
+        self.assertEqual(vulnerable, 2)
+
+    def test_vul_flag_after_deal(self) -> None:
+        deal, vulnerable = _parse_cli(["prog", _EXAMPLE_DEAL, "--vul", "both"])
+        self.assertEqual(deal, _EXAMPLE_DEAL)
+        self.assertEqual(vulnerable, 1)
+
+    def test_help_returns_none(self) -> None:
+        self.assertIsNone(_parse_cli(["prog", "-h"]))
+        self.assertIsNone(_parse_cli(["prog", "--help"]))
+
+    def test_rejects_unknown_flags(self) -> None:
+        with self.assertRaises(ValueError):
+            _parse_cli(["prog", "--oops", _EXAMPLE_DEAL])
+
+
+class FormatParLineTest(unittest.TestCase):
+    def test_single_sacrifice_contract(self) -> None:
+        par_results = {
+            "par_score": ["NS -300", "EW 300"],
+            "par_contracts_string": ["NS:NS 5Hx", "EW:NS 5Hx"],
+        }
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: NS 5Hx -2 -300",
+        )
+
+    def test_single_making_contract(self) -> None:
+        par_results = {
+            "par_score": ["NS -110", "EW 110"],
+            "par_contracts_string": ["NS:EW 2S", "EW:EW 2S"],
+        }
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: EW 2S +0 -110",
+        )
+
+    def test_multiple_contracts_returns_none(self) -> None:
+        par_results = {
+            "par_score": ["NS -600", "EW 600"],
+            "par_contracts_string": ["NS:EW 2S,EW 3S", "EW:EW 2S,EW 3S"],
+        }
+        self.assertIsNone(_format_par_line(par_results, vulnerable=0))
+
+    def test_passed_out(self) -> None:
+        par_results = {
+            "par_score": ["NS 0", "EW 0"],
+            "par_contracts_string": ["NS:", "EW:"],
+        }
+        self.assertEqual(_format_par_line(par_results, vulnerable=0), "Par: 0")
+
+
+class PrintParTest(unittest.TestCase):
+    def test_single_par_uses_compact_line(self) -> None:
+        par_results = {
+            "par_score": ["NS -300", "EW 300"],
+            "par_contracts_string": ["NS:NS 5Hx", "EW:NS 5Hx"],
+        }
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_par(par_results, vulnerable=0)
+        self.assertEqual(buf.getvalue(), "Par: NS 5Hx -2 -300\n")
+
+    def test_multiple_pars_use_verbose_format(self) -> None:
+        par_results = {
+            "par_score": ["NS -600", "EW 600"],
+            "par_contracts_string": ["NS:EW 2S,EW 3S", "EW:EW 2S,EW 3S"],
+        }
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_par(par_results, vulnerable=0)
+        self.assertIn("NS score:", buf.getvalue())
+        self.assertIn("NS list :", buf.getvalue())
+
+
+class MainParOutputTest(unittest.TestCase):
+    def test_main_prints_compact_par_for_example_deal(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["dd_table_for_deal", _EXAMPLE_DEAL])
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        self.assertIn("Par: NS 5Hx -2 -300", out)
+        self.assertNotIn("NS score:", out)
+        self.assertLess(out.index("North"), out.index("Par:"))
+
+    def test_main_passes_vulnerable_to_par(self) -> None:
+        fake_tables = {
+            "tables": [
+                {
+                    "res_table": [[0] * 4 for _ in range(5)],
+                }
+            ]
+        }
+        fake_par = {
+            "par_score": ["NS 0", "EW 0"],
+            "par_contracts_string": ["NS:", "EW:"],
+        }
+        with mock.patch(
+            "dd_table_for_deal.calc_all_tables_pbn", return_value=fake_tables
+        ), mock.patch(
+            "dd_table_for_deal.calc_par_from_table", return_value=fake_par
+        ) as par_mock, mock.patch(
+            "dd_table_for_deal._print_pbn_hand"
+        ), mock.patch(
+            "dd_table_for_deal._print_table"
+        ), redirect_stdout(io.StringIO()):
+            rc = main(["dd_table_for_deal", "--vul", "ew", _EXAMPLE_DEAL])
+
+        self.assertEqual(rc, 0)
+        par_mock.assert_called_once()
+        args, kwargs = par_mock.call_args
+        self.assertEqual(kwargs.get("vulnerable", args[1] if len(args) > 1 else None), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -16,6 +16,7 @@ from dd_table_for_deal import (
     _parse_cli,
     _parse_vulnerable,
     _print_par,
+    _print_usage,
     _unique_deals,
     main,
 )
@@ -83,6 +84,14 @@ class ParseCliTest(unittest.TestCase):
     def test_help_returns_none(self) -> None:
         self.assertIsNone(_parse_cli(["prog", "-h"]))
         self.assertIsNone(_parse_cli(["prog", "--help"]))
+
+    def test_usage_documents_numeric_vul_codes(self) -> None:
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            _print_usage("prog")
+        text = buf.getvalue()
+        self.assertIn("none|both|ns|ew", text)
+        self.assertIn("0|1|2|3", text)
 
     def test_rejects_unknown_flags(self) -> None:
         with self.assertRaises(ValueError):

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -138,6 +138,22 @@ class ReadPbnFileTest(unittest.TestCase):
             Path(path).unlink(missing_ok=True)
 
 
+class ReadPbnStreamTest(unittest.TestCase):
+    def test_allows_input_exactly_at_max(self) -> None:
+        import dd_table_for_deal as mod
+
+        with mock.patch.object(mod, "PBN_FILE_MAX", 16):
+            text = mod._read_pbn_stream(io.StringIO("x" * 16))
+        self.assertEqual(text, "x" * 16)
+
+    def test_rejects_input_over_max(self) -> None:
+        import dd_table_for_deal as mod
+
+        with mock.patch.object(mod, "PBN_FILE_MAX", 16):
+            with self.assertRaises(ValueError):
+                mod._read_pbn_stream(io.StringIO("x" * 17))
+
+
 class LoadDealsTest(unittest.TestCase):
     def test_raw_string_returns_single_deal(self) -> None:
         self.assertEqual(_load_deals(_EXAMPLE_DEAL), [_EXAMPLE_DEAL])

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -183,6 +183,17 @@ class FormatParLineTest(unittest.TestCase):
             "Par: EW 2S = 110",
         )
 
+    def test_making_contract_expands_multi_level_encoding(self) -> None:
+        """DDS Par strings encode overtricks as concatenated levels (e.g. 45S)."""
+        par_results = {
+            "par_score": ["NS -450", "EW 450"],
+            "par_contracts_string": ["NS:EW 45S", "EW:EW 45S"],
+        }
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: EW 4S +1 450",
+        )
+
     def test_multiple_sacrifice_contracts_on_one_line(self) -> None:
         par_results = {
             "par_score": ["NS 100", "EW -100"],

--- a/python/tests/test_dd_table_for_deal_par.py
+++ b/python/tests/test_dd_table_for_deal_par.py
@@ -110,6 +110,10 @@ class ParseCliTest(unittest.TestCase):
         self.assertIsNone(_parse_cli(["prog", "-h"]))
         self.assertIsNone(_parse_cli(["prog", "--help"]))
 
+    def test_help_accepted_after_other_flags(self) -> None:
+        self.assertIsNone(_parse_cli(["prog", "--vul", "ns", "--help"]))
+        self.assertIsNone(_parse_cli(["prog", _EXAMPLE_DEAL, "-h"]))
+
     def test_usage_documents_numeric_vul_codes(self) -> None:
         buf = io.StringIO()
         with redirect_stderr(buf):

--- a/specs/examples-cli.md
+++ b/specs/examples-cli.md
@@ -25,7 +25,7 @@ build ports to the browser. They are demonstrations, not a supported product CLI
   - **Solve a board:** `solve_board`, `solve_board_pbn`, `solve_all_boards`.
   - **Double-dummy tables:** `calc_dd_table`, `calc_dd_table_pbn`,
     `calc_all_tables`, `calc_all_tables_pbn`, `dd_table_for_deal`
-    (also prints `Par()` results; optional `--vul`).
+    (also prints `Par()` results; optional `--vul`, `--limit`).
   - **Par scoring:** `par`, `dealer_par`.
   - **Play analysis:** `AnalysePlayBin` (source `analyse_play_bin.cpp`),
     `analyse_play_pbn`, `analyse_all_plays_bin`, `analyse_all_plays_pbn`.

--- a/specs/examples-cli.md
+++ b/specs/examples-cli.md
@@ -1,7 +1,7 @@
 ---
 capability: examples-cli
 owners: [examples]
-last-updated: 2026-07-18
+last-updated: 2026-08-06
 ---
 
 # Example CLIs
@@ -24,7 +24,8 @@ build ports to the browser. They are demonstrations, not a supported product CLI
 - **Grouped by what they demonstrate:**
   - **Solve a board:** `solve_board`, `solve_board_pbn`, `solve_all_boards`.
   - **Double-dummy tables:** `calc_dd_table`, `calc_dd_table_pbn`,
-    `calc_all_tables`, `calc_all_tables_pbn`, `dd_table_for_deal`.
+    `calc_all_tables`, `calc_all_tables_pbn`, `dd_table_for_deal`
+    (also prints `Par()` results; optional `--vul`).
   - **Par scoring:** `par`, `dealer_par`.
   - **Play analysis:** `AnalysePlayBin` (source `analyse_play_bin.cpp`),
     `analyse_play_pbn`, `analyse_all_plays_bin`, `analyse_all_plays_pbn`.


### PR DESCRIPTION
## Summary
- Extend C++ and Python `dd_table_for_deal` to print compact par after the DD table (`--vul none|both|ns|ew`)
- Process every unique deal in multi-board PBN files (higher read limit, clear missing-file errors, dedupe exact deal strings)
- Match Python multi-level Par encodings (`45S`) to C++ (`4S +1`); extract C++ helpers into a tested library; add an anonymized multi-board example PBN

## Test plan
- [x] `bazelisk test //examples:dd_table_for_deal_test //python:dd_table_for_deal_par_test`
- [x] `bazelisk run //examples:dd_table_for_deal -- hands/example.pbn` and compare par with Python
- [x] `bazelisk run //python/examples:dd_table_for_deal -- --vul ns hands/multi_board.pbn` (unique deals only, blank lines between boards)
- [x] Confirm making contracts show `=` / `+N` and sacrifices show undertricks with declaring-side score