### PR TITLE
Add MemorySanitizer build/test config and Linux CI job.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -105,3 +105,15 @@ build:ubsan --compilation_mode=dbg
 test:ubsan --test_timeout=120,300,900,3600
 # Hardcoded rpath: .../lib/clang/21/... must match MODULE.bazel llvm major and Xcode.
 build:ubsan_macos --linkopt=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin
+
+# MemorySanitizer configuration (Linux x86_64 only)
+# Usage: bazel test --config=msan //path:target
+# Selects @llvm_toolchain_msan (instrumented libc++ overlay) and enables the
+# toolchains_llvm `msan` feature. See docs/BUILD_SYSTEM.md (MSAN section).
+# Not supported on macOS/Windows; do not combine with asan/tsan/ubsan.
+build:msan --extra_toolchains=@llvm_toolchain_msan//:all
+build:msan --features=msan
+build:msan --strip=never
+build:msan --features=dbg
+build:msan --compilation_mode=dbg
+test:msan --test_timeout=120,300,900,3600

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,9 @@ bazelisk build --config=asan //...
 
 # Build with UndefinedBehaviorSanitizer (standalone; see docs/BUILD_SYSTEM.md)
 bazelisk build --config=ubsan //...
+
+# Build with MemorySanitizer (Linux x86_64 only; see docs/BUILD_SYSTEM.md)
+bazelisk build --config=msan //...
 ```
 
 ### Build Time Expectations
@@ -209,6 +212,9 @@ bazelisk test --config=asan //...
 
 # Check for undefined behavior
 bazelisk test --config=ubsan //...
+
+# Check for uninitialized reads (Linux x86_64 only)
+bazelisk test --config=msan //...
 
 # Performance test with real hands
 bazelisk build //library/tests:dtest

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -206,7 +206,9 @@ jobs:
           retention-days: 30
 
   msan:
-    runs-on: ubuntu-latest
+    # Pin to 22.04: MODULE.bazel's MSAN LLVM + instrumented libc++ overlay are
+    # the Ubuntu 22.04 builds; ubuntu-latest drift would break the overlay match.
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -204,3 +204,49 @@ jobs:
           path: bazel-testlogs/
           if-no-files-found: ignore
           retention-days: 30
+
+  msan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Setup Bazelisk
+        uses: ./.github/actions/setup-bazelisk
+
+      - name: Prefetch external repos
+        run: |
+          max=3
+          for i in $(seq 1 "$max"); do
+            if bazelisk fetch --config=msan //library/tests/...; then
+              exit 0
+            fi
+            if [ "$i" -lt "$max" ]; then
+              echo "Fetch failed (attempt $i/$max). Retrying in 20s..."
+              sleep 20
+            fi
+          done
+          exit 1
+
+      - name: Run tests (MemorySanitizer)
+        run: bazelisk test --config=msan --verbose_failures --test_output=errors //library/tests/...
+
+      - name: Upload MSAN test logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: bazel-test-logs-linux-msan
+          path: bazel-testlogs/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,7 +89,6 @@ config_setting(
 exports_files([
     ".bazelrc",
     "MODULE.bazel",
-    "docs/BUILD_SYSTEM.md",
 ])
 
 filegroup(
@@ -97,7 +96,6 @@ filegroup(
     srcs = [
         ".bazelrc",
         "MODULE.bazel",
-        "docs/BUILD_SYSTEM.md",
     ],
     visibility = ["//python:__pkg__"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -84,6 +84,21 @@ config_setting(
     ],
 )
 
+# Config surfaces for CI guards (python/tests:ci_msan_test). Kept as a filegroup
+# so runfiles include the real paths under the repo root, not resolved execroots.
+exports_files([
+    ".bazelrc",
+    "MODULE.bazel",
+])
+
+filegroup(
+    name = "msan_ci_config_files",
+    srcs = [
+        ".bazelrc",
+        "MODULE.bazel",
+    ],
+    visibility = ["//python:__pkg__"],
+)
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,6 +89,7 @@ config_setting(
 exports_files([
     ".bazelrc",
     "MODULE.bazel",
+    "docs/BUILD_SYSTEM.md",
 ])
 
 filegroup(
@@ -96,6 +97,7 @@ filegroup(
     srcs = [
         ".bazelrc",
         "MODULE.bazel",
+        "docs/BUILD_SYSTEM.md",
     ],
     visibility = ["//python:__pkg__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,8 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "pybind11_bazel", version = "3.0.1")
 bazel_dep(name = "rules_python", version = "2.0.1")
-bazel_dep(name = "toolchains_llvm", version = "1.7.0")
+# 1.8.0+ adds --features=msan and libcxx_url for an instrumented libc++ overlay.
+bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 
 # Xcode CC toolchain for macOS AddressSanitizer builds (--config=asan). LLVM's ASAN
 # runtime hangs on current macOS; see .bazelrc build:asan_macos.
@@ -48,6 +49,7 @@ llvm.toolchain(
     name = "llvm_toolchain",
     # When bumping these versions, also update .bazelrc build:tsan_macos rpath
     # (clang/N) and confirm Xcode ships the same major; see docs/BUILD_SYSTEM.md.
+    # Keep MSAN_LLVM_VERSION / MSAN_DISTRIBUTION below on the same LLVM release.
     llvm_versions = {
         "darwin-aarch64": "21.1.8",
         "linux-x86_64": "21.1.8",
@@ -55,6 +57,29 @@ llvm.toolchain(
     },
 )
 use_repo(llvm, "llvm_toolchain")
+
+# MemorySanitizer toolchain (Linux x86_64 only). Not registered globally —
+# selected via --config=msan (--extra_toolchains=@llvm_toolchain_msan//:all).
+# Pinned to the exact Ubuntu 22.04 LLVM build that the instrumented libc++
+# overlay was compiled against; see toolchains_llvm tests/MODULE.bazel and
+# docs/BUILD_SYSTEM.md (MSAN section).
+MSAN_LLVM_VERSION = "21.1.8"
+MSAN_DISTRIBUTION = "clang+llvm-%s-x86_64-linux-gnu-ubuntu-22.04.tar.zst" % MSAN_LLVM_VERSION
+
+llvm.toolchain(
+    name = "llvm_toolchain_msan",
+    alternative_llvm_sources = [
+        "https://github.com/RealtimeRoboticsGroup/toolchains/releases/download/{llvm_version}/{basename}",
+    ],
+    distribution = MSAN_DISTRIBUTION,
+    extra_llvm_distributions = {
+        MSAN_DISTRIBUTION: "3e9ab559182f45143c36d761fcee6818935187a8f54354ecb043643b642769f0",
+    },
+    libcxx_sha256 = "56e33981bb71aba8704026534093f81ba9783cff0bf701681f1781d2ecb50a87",
+    libcxx_url = "https://github.com/RealtimeRoboticsGroup/toolchains/releases/download/%s/libcxx-msan-%s-x86_64-linux-gnu-ubuntu-22.04.tar.zst" % (MSAN_LLVM_VERSION, MSAN_LLVM_VERSION),
+    llvm_versions = {"": MSAN_LLVM_VERSION},
+)
+use_repo(llvm, "llvm_toolchain_msan")
 
 # Apple toolchain repo; selected only for --config=asan via .bazelrc (not registered globally).
 apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,8 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "pybind11_bazel", version = "3.0.1")
 bazel_dep(name = "rules_python", version = "2.0.1")
 # 1.8.0+ adds --features=msan and libcxx_url for an instrumented libc++ overlay.
+# BCR 1.8.0 still emits unused `-stdlib=libc++` under `-nostdinc++`, which fails
+# our Linux `-Werror` builds. Override to the #791 fix until BCR publishes >1.8.0.
 bazel_dep(name = "toolchains_llvm", version = "1.8.0")
 
 # Xcode CC toolchain for macOS AddressSanitizer builds (--config=asan). LLVM's ASAN
@@ -41,6 +43,19 @@ archive_override(
     urls = [
         "https://github.com/emscripten-core/emsdk/archive/refs/tags/5.0.7.tar.gz",
         "https://codeload.github.com/emscripten-core/emsdk/tar.gz/refs/tags/5.0.7",
+    ],
+)
+
+# toolchains_llvm#791: drop redundant `-stdlib=libc++` (unused with `-nostdinc++`).
+# Commit is the merge of that PR; drop this override when BCR ships a release
+# that includes it.
+archive_override(
+    module_name = "toolchains_llvm",
+    integrity = "sha256-spaFpVBa8JGs27s/9vk0Xb4gd8fJ9OFmnxaBYPeOt4o=",
+    strip_prefix = "toolchains_llvm-c3ac93f5c61cb78487765d2e81e7485ad3f8bf2c",
+    urls = [
+        "https://github.com/bazel-contrib/toolchains_llvm/archive/c3ac93f5c61cb78487765d2e81e7485ad3f8bf2c.tar.gz",
+        "https://codeload.github.com/bazel-contrib/toolchains_llvm/tar.gz/c3ac93f5c61cb78487765d2e81e7485ad3f8bf2c",
     ],
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -295,8 +295,6 @@
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/source.json": "4a620381df075a16cb3a7ed57bd1d05f7480222394c64a20fa51bdb636fda658",
     "https://bcr.bazel.build/modules/toml.bzl/0.3.0/MODULE.bazel": "5016e5dd1ad2200e119a4b28b2b3935e276c4b480f2fe3e952bea7eeba88f578",
     "https://bcr.bazel.build/modules/toml.bzl/0.3.0/source.json": "0cf7c878c419b37ddb55f3dd93dd7c0c409bd7c4efacb3da504e0748780b2fa9",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/MODULE.bazel": "68259b66e5fb84f94fa37125ad476c3eb8edf602a34bf58377cde9a16dd8fa98",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/source.json": "70d80fe5b626a3fadf812af41dda4a028640a1184f5a3c7e6cb20130d93ed783",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
@@ -610,7 +608,7 @@
     "@@toolchains_llvm+//toolchain/extensions:distributions.bzl%llvm_distributions": {
       "general": {
         "bzlTransitiveDigest": "gCdXpBt3HBBc280OILOFheHmO7lXWXJYnPgYiTtyapI=",
-        "usagesDigest": "VyKGZSw79ryPJ9gt0sqBfIkA7qGOU6tnlDHd7awkb6Q=",
+        "usagesDigest": "3B/1Qf38oum/lRpBvi3mnJwV6XMAQF+4//DH0B29rNA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "llvm_distributions_data": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -99,8 +99,8 @@
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "827f54f492a3ce549c940106d73de332c2b30cebd0c20c0bc5d786aba7f116cb",
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/MODULE.bazel": "3a4be20f6fc13be32ad44643b8252ef5af09eee936f1d943cd4fd7867fa92826",
-    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/source.json": "b129ab1828492de2c163785bbeb4065c166de52d932524b4317beb5b7f917994",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/MODULE.bazel": "9c20052fd3f1fb767c48b78c1bbc46f501a4ca69d14558429d1234e68e449f68",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.4.3/source.json": "e8c54d81e72633fb6f1d23c7e2d44e0b39b1caef2a256141136a2f63e6204b78",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
@@ -295,8 +295,8 @@
     "https://bcr.bazel.build/modules/tar.bzl/0.6.0/source.json": "4a620381df075a16cb3a7ed57bd1d05f7480222394c64a20fa51bdb636fda658",
     "https://bcr.bazel.build/modules/toml.bzl/0.3.0/MODULE.bazel": "5016e5dd1ad2200e119a4b28b2b3935e276c4b480f2fe3e952bea7eeba88f578",
     "https://bcr.bazel.build/modules/toml.bzl/0.3.0/source.json": "0cf7c878c419b37ddb55f3dd93dd7c0c409bd7c4efacb3da504e0748780b2fa9",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/MODULE.bazel": "55aca6a8c5b372651f663c5e22faf3664d81165e40074c98fb8a30ee5af83272",
-    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/source.json": "cda5fa1abeab5561e811860222952f6cb9373f34b88c5b3f4417459dca057a6d",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/MODULE.bazel": "68259b66e5fb84f94fa37125ad476c3eb8edf602a34bf58377cde9a16dd8fa98",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.8.0/source.json": "70d80fe5b626a3fadf812af41dda4a028640a1184f5a3c7e6cb20130d93ed783",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
@@ -602,6 +602,26 @@
                 ]
               },
               "toolchain_target_settings": {}
+            }
+          }
+        }
+      }
+    },
+    "@@toolchains_llvm+//toolchain/extensions:distributions.bzl%llvm_distributions": {
+      "general": {
+        "bzlTransitiveDigest": "gCdXpBt3HBBc280OILOFheHmO7lXWXJYnPgYiTtyapI=",
+        "usagesDigest": "VyKGZSw79ryPJ9gt0sqBfIkA7qGOU6tnlDHd7awkb6Q=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "llvm_distributions_data": {
+            "repoRuleId": "@@toolchains_llvm+//toolchain/internal:distributions_repo.bzl%llvm_distributions_repo",
+            "attributes": {
+              "srcs": [
+                "@@toolchains_llvm+//toolchain/distributions:pre_github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github_legacy.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:github.jsonc",
+                "@@toolchains_llvm+//toolchain/distributions:extra.jsonc"
+              ]
             }
           }
         }

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -105,6 +105,11 @@ enables `--features=msan`. That toolchain ships an instrumented libc++ overlay
 Ubuntu 22.04 LLVM release as `MSAN_LLVM_VERSION`. Keep those pins aligned when
 bumping LLVM. Do not combine MSAN with ASAN/TSAN/UBSAN.
 
+`MODULE.bazel` currently `archive_override`s `toolchains_llvm` past BCR 1.8.0
+to include [#791](https://github.com/bazel-contrib/toolchains_llvm/pull/791)
+(drops unused `-stdlib=libc++` that breaks Linux `-Werror` builds). Drop the
+override when BCR publishes a release that includes that fix.
+
 **When upgrading LLVM or Xcode**, update all coupled paths together:
 
 1. Bump `llvm_versions` in `MODULE.bazel` (and run

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -97,13 +97,15 @@ shared. Like TSAN, instrumentation uses hermetic LLVM and the runtime is loaded
 from Xcode via `build:ubsan_macos`. `-fno-sanitize-recover=undefined` makes the
 first UB report abort the process (required for CI).
 
-**MSAN (`--config=msan`).** Linux x86_64 only. MemorySanitizer reports false
-positives unless the C++ standard library is also instrumented, so
-`--config=msan` selects `@llvm_toolchain_msan` (not registered globally) and
-enables `--features=msan`. That toolchain ships an instrumented libc++ overlay
-(`libcxx_url` / `libcxx_sha256` in `MODULE.bazel`) built against the same
-Ubuntu 22.04 LLVM release as `MSAN_LLVM_VERSION`. Keep those pins aligned when
-bumping LLVM. Do not combine MSAN with ASAN/TSAN/UBSAN.
+**MSAN (`--config=msan`).** Linux x86_64 only. See the
+[Clang MemorySanitizer documentation](https://clang.llvm.org/docs/MemorySanitizer.html)
+for what MSAN detects and its limits (it is not a complete memory-safety proof).
+MemorySanitizer reports false positives unless the C++ standard library is also
+instrumented, so `--config=msan` selects `@llvm_toolchain_msan` (not registered
+globally) and enables `--features=msan`. That toolchain ships an instrumented
+libc++ overlay (`libcxx_url` / `libcxx_sha256` in `MODULE.bazel`) built against
+the same Ubuntu 22.04 LLVM release as `MSAN_LLVM_VERSION`. Keep those pins
+aligned when bumping LLVM. Do not combine MSAN with ASAN/TSAN/UBSAN.
 
 `MODULE.bazel` currently `archive_override`s `toolchains_llvm` past BCR 1.8.0
 to include [#791](https://github.com/bazel-contrib/toolchains_llvm/pull/791)

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -64,15 +64,16 @@ If you see runtime loader failures after a toolchain or OS change:
 2. Re-resolve Bazel toolchains (`bazelisk shutdown`, then `bazelisk clean --expunge`).
 3. Re-run `bazelisk test //...` to confirm runtime compatibility.
 
-### AddressSanitizer, ThreadSanitizer, and UndefinedBehaviorSanitizer (macOS)
+### AddressSanitizer, ThreadSanitizer, UndefinedBehaviorSanitizer, and MemorySanitizer
 
-Sanitizer builds use `--config=asan`, `--config=tsan`, or `--config=ubsan`
-(see `.bazelrc`). Do not use `--define=asan=true`; that path is not supported.
-macOS-specific settings are chained automatically; you do not pass a separate
-`asan_macos`, `tsan_macos`, or `ubsan_macos` flag.
+Sanitizer builds use `--config=asan`, `--config=tsan`, `--config=ubsan`, or
+`--config=msan` (see `.bazelrc`). Do not use `--define=asan=true`; that path is
+not supported. macOS-specific settings for ASAN/TSAN/UBSAN are chained
+automatically; you do not pass a separate `asan_macos`, `tsan_macos`, or
+`ubsan_macos` flag. MSAN is Linux x86_64 only.
 
-**Clang / Xcode version coupling.** Three places must stay on the same **clang
-major** version (currently **21**):
+**Clang / Xcode version coupling (macOS ASAN/TSAN/UBSAN).** Three places must
+stay on the same **clang major** version (currently **21**):
 
 | Location | Role |
 |----------|------|
@@ -96,20 +97,32 @@ shared. Like TSAN, instrumentation uses hermetic LLVM and the runtime is loaded
 from Xcode via `build:ubsan_macos`. `-fno-sanitize-recover=undefined` makes the
 first UB report abort the process (required for CI).
 
+**MSAN (`--config=msan`).** Linux x86_64 only. MemorySanitizer reports false
+positives unless the C++ standard library is also instrumented, so
+`--config=msan` selects `@llvm_toolchain_msan` (not registered globally) and
+enables `--features=msan`. That toolchain ships an instrumented libc++ overlay
+(`libcxx_url` / `libcxx_sha256` in `MODULE.bazel`) built against the same
+Ubuntu 22.04 LLVM release as `MSAN_LLVM_VERSION`. Keep those pins aligned when
+bumping LLVM. Do not combine MSAN with ASAN/TSAN/UBSAN.
+
 **When upgrading LLVM or Xcode**, update all coupled paths together:
 
 1. Bump `llvm_versions` in `MODULE.bazel` (and run
    `bazelisk mod deps --lockfile_mode=update` to refresh `MODULE.bazel.lock`).
-2. Update the `clang/N` segment in `build:tsan_macos` and `build:ubsan_macos` in
+2. For MSAN, bump `MSAN_LLVM_VERSION` / `MSAN_DISTRIBUTION` / `libcxx_*` to a
+   matching instrumented-libc++ release (see toolchains_llvm's
+   `tests/MODULE.bazel` for the overlay hosting pattern).
+3. Update the `clang/N` segment in `build:tsan_macos` and `build:ubsan_macos` in
    `.bazelrc` to match the new major version.
-3. Confirm Xcode ships that major:  
+4. Confirm Xcode ships that major:  
    `xcrun clang++ --version`  
    `xcrun clang -print-file-name=libclang_rt.tsan_osx_dynamic.dylib`  
    `xcrun clang -print-file-name=libclang_rt.ubsan_osx_dynamic.dylib`
-4. Re-run sanitizer smoke tests, e.g.  
+5. Re-run sanitizer smoke tests, e.g.  
    `bazelisk test --config=asan //library/tests/system:context_tt_facade_test`  
    `bazelisk test --config=tsan //library/tests/system:thread_safety_stress_test`  
-   `bazelisk test --config=ubsan //library/tests/system:context_tt_facade_test`
+   `bazelisk test --config=ubsan //library/tests/system:context_tt_facade_test`  
+   `bazelisk test --config=msan //library/tests/system:context_tt_facade_test` (Linux)
 
 If TSAN or UBSAN fails to start after an Xcode upgrade (dyld cannot load the
 runtime), the rpath major is likely out of sync with the installed toolchain.
@@ -122,6 +135,7 @@ runtime), the rpath major is likely out of sync with the installed toolchain.
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |
+| `ci_linux.yml` | `msan` | `bazelisk test --config=msan //library/tests/...` (Linux only) |
 | `ci_macos.yml` | `sanitizers` | ASAN, TSAN, and UBSAN on `//library/tests/system/...` (validates macOS toolchain/rpath wiring) |
 
 

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -140,7 +140,7 @@ runtime), the rpath major is likely out of sync with the installed toolchain.
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |
-| `ci_linux.yml` | `msan` | `bazelisk test --config=msan //library/tests/...` (Linux only) |
+| `ci_linux.yml` | `msan` | `bazelisk test --config=msan //library/tests/...` on `ubuntu-22.04` (matches LLVM/libcxx overlay) |
 | `ci_macos.yml` | `sanitizers` | ASAN, TSAN, and UBSAN on `//library/tests/system/...` (validates macOS toolchain/rpath wiring) |
 
 

--- a/library/tests/system/BUILD.bazel
+++ b/library/tests/system/BUILD.bazel
@@ -108,6 +108,14 @@ cc_test(
     ],
 )
 
+exports_files(["parallel_boards_test.cpp"])
+
+filegroup(
+    name = "parallel_boards_test_src",
+    srcs = ["parallel_boards_test.cpp"],
+    visibility = ["//python:__pkg__"],
+)
+
 # max_threads override equivalence + rename/alias initialisation test
 cc_test(
     name = "max_threads_equivalence_test",

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -31,8 +31,10 @@ std::atomic<unsigned> allocations{0};
 #    define DDS_TEST_MEMORY_SANITIZER 1
 #  endif
 #endif
-#if defined(__SANITIZE_MEMORY__)
-#  define DDS_TEST_MEMORY_SANITIZER 1
+#ifndef DDS_TEST_MEMORY_SANITIZER
+#  if defined(__SANITIZE_MEMORY__)
+#    define DDS_TEST_MEMORY_SANITIZER 1
+#  endif
 #endif
 #ifndef DDS_TEST_MEMORY_SANITIZER
 #  define DDS_TEST_MEMORY_SANITIZER 0

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -23,6 +23,23 @@ std::atomic<unsigned> allocations{0};
 
 }  // namespace allocation_tracking
 
+// MemorySanitizer ships its own operator new/delete in libclang_rt.msan_cxx;
+// linking custom replacements produces duplicate-symbol errors. Allocation
+// counting therefore runs only when MSAN is off.
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+#    define DDS_TEST_MEMORY_SANITIZER 1
+#  endif
+#endif
+#if defined(__SANITIZE_MEMORY__)
+#  define DDS_TEST_MEMORY_SANITIZER 1
+#endif
+#ifndef DDS_TEST_MEMORY_SANITIZER
+#  define DDS_TEST_MEMORY_SANITIZER 0
+#endif
+
+#if !DDS_TEST_MEMORY_SANITIZER
+
 void* operator new(const std::size_t size)
 {
   if (allocation_tracking::enabled.load(std::memory_order_relaxed))
@@ -44,6 +61,8 @@ void operator delete(void* const memory, std::size_t) noexcept
 {
   std::free(memory);
 }
+
+#endif  // !DDS_TEST_MEMORY_SANITIZER
 
 namespace
 {
@@ -119,6 +138,9 @@ TEST(ParallelAllBoards, WrongSizedOrderFallsBackToIndexOrder)
 
 TEST(ParallelAllBoards, PermutationValidationUsesAtMostOneAllocation)
 {
+#if DDS_TEST_MEMORY_SANITIZER
+  GTEST_SKIP() << "Allocation counting needs custom operator new; disabled under MSAN";
+#else
   // Permutation checks may allocate a temporary "seen" bitmap; the board-slot
   // mapping itself must stay allocation-free (plain data, not std::function).
   // Arrange
@@ -142,6 +164,7 @@ TEST(ParallelAllBoards, PermutationValidationUsesAtMostOneAllocation)
   EXPECT_EQ(result, RETURN_NO_FAULT);
   EXPECT_LE(
     allocation_tracking::allocations.load(std::memory_order_relaxed), 1u);
+#endif
 }
 
 TEST(ParallelAllBoards, ZeroSizeNewReturnsNonNull)

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -90,6 +90,18 @@ py_test(
     data = ["//.github/workflows:all_workflows"],
 )
 
+# Guard: MemorySanitizer config + Linux CI job stay wired together.
+py_test(
+    name = "ci_msan_test",
+    size = "small",
+    main = "tests/ci_msan_test.py",
+    srcs = ["tests/ci_msan_test.py"],
+    data = [
+        "//:msan_ci_config_files",
+        "//.github/workflows:all_workflows",
+    ],
+)
+
 py_test(
     name = "python_interface_smoke_test",
     size = "small",

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -99,6 +99,7 @@ py_test(
     data = [
         "//:msan_ci_config_files",
         "//.github/workflows:all_workflows",
+        "//library/tests/system:parallel_boards_test_src",
     ],
 )
 

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -20,17 +20,6 @@ def _repo_root(start: Path | None = None) -> Path:
     raise AssertionError("could not locate repository root from test file path")
 
 
-class TestMsanDocs(unittest.TestCase):
-    def test_build_system_docs_link_clang_msan(self) -> None:
-        """Point readers at upstream MSAN docs (coverage limits, false positives)."""
-        text = (_repo_root() / "docs" / "BUILD_SYSTEM.md").read_text(encoding="utf-8")
-        self.assertIn(
-            "https://clang.llvm.org/docs/MemorySanitizer.html",
-            text,
-            "BUILD_SYSTEM.md must link the Clang MemorySanitizer documentation",
-        )
-
-
 class TestMsanBazelConfig(unittest.TestCase):
     def test_bazelrc_defines_msan_config(self) -> None:
         bazelrc = (_repo_root() / ".bazelrc").read_text(encoding="utf-8")

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -87,6 +87,13 @@ class TestMsanLinuxCi(unittest.TestCase):
             r"(?m)^  msan:\s*$",
             "expected a dedicated msan job in ci_linux.yml",
         )
+        # MODULE.bazel pins the MSAN LLVM + instrumented libc++ to the Ubuntu
+        # 22.04 distribution; keep the runner on that OS so the overlay matches.
+        self.assertRegex(
+            text,
+            r"(?m)^  msan:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+runs-on:\s*ubuntu-22\.04\s*$",
+            "msan CI must pin ubuntu-22.04 to match the MSAN toolchain overlay",
+        )
         self.assertRegex(
             text,
             r"bazelisk\s+test\s+--config=msan\b",
@@ -135,6 +142,19 @@ class TestMsanCompatibleParallelBoardsAllocHooks(unittest.TestCase):
             text,
             r"__has_feature\s*\(\s*memory_sanitizer\s*\)",
             "expected MSAN detection via __has_feature(memory_sanitizer)",
+        )
+        # Both Clang feature-test and GCC-style __SANITIZE_MEMORY__ may be set;
+        # defining DDS_TEST_MEMORY_SANITIZER twice triggers -Wmacro-redefined.
+        self.assertRegex(
+            text,
+            r"#\s*ifndef\s+DDS_TEST_MEMORY_SANITIZER[\s\S]*?"
+            r"#\s*if\s+defined\s*\(\s*__SANITIZE_MEMORY__\s*\)",
+            "second MSAN detect must be guarded to avoid macro redefinition",
+        )
+        self.assertEqual(
+            len(re.findall(r"#\s*define\s+DDS_TEST_MEMORY_SANITIZER\s+1\b", text)),
+            2,
+            "expected two paths that set DDS_TEST_MEMORY_SANITIZER to 1",
         )
         # Custom replacements must not be linked under MSAN (duplicate symbols).
         self.assertRegex(

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -111,5 +111,39 @@ class TestMsanNotOnMacosCi(unittest.TestCase):
         )
 
 
+class TestMsanCompatibleParallelBoardsAllocHooks(unittest.TestCase):
+    def test_custom_new_delete_are_disabled_under_memory_sanitizer(self) -> None:
+        """MSAN's runtime owns operator new/delete; custom defs duplicate-symbol.
+
+        parallel_boards_test.cpp overrides global new/delete for allocation
+        counting. Those symbols must not be compiled under MemorySanitizer.
+        """
+        path = (
+            _repo_root()
+            / "library"
+            / "tests"
+            / "system"
+            / "parallel_boards_test.cpp"
+        )
+        text = path.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r"void\*\s+operator\s+new\s*\(",
+            "expected a custom operator new for allocation tracking",
+        )
+        self.assertRegex(
+            text,
+            r"__has_feature\s*\(\s*memory_sanitizer\s*\)",
+            "expected MSAN detection via __has_feature(memory_sanitizer)",
+        )
+        # Custom replacements must not be linked under MSAN (duplicate symbols).
+        self.assertRegex(
+            text,
+            r"#\s*if\s*!DDS_TEST_MEMORY_SANITIZER[\s\S]*?"
+            r"void\*\s+operator\s+new\s*\(",
+            "custom operator new must be compiled only when MSAN is off",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Guard that MemorySanitizer is wired into Bazel config and Linux CI."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+def _repo_root(start: Path | None = None) -> Path:
+    # Do not Path.resolve() — under `bazel test` this file is often a runfiles
+    # symlink into the execroot/source tree, and resolving leaves the runfiles
+    # tree where //.github/workflows and other data deps live.
+    here = (start or Path(__file__)).absolute()
+    for parent in here.parents:
+        workflows = parent / ".github" / "workflows"
+        if workflows.is_dir() and any(workflows.glob("ci_*.yml")):
+            return parent
+    raise AssertionError("could not locate repository root from test file path")
+
+
+class TestMsanBazelConfig(unittest.TestCase):
+    def test_bazelrc_defines_msan_config(self) -> None:
+        bazelrc = (_repo_root() / ".bazelrc").read_text(encoding="utf-8")
+        self.assertRegex(
+            bazelrc,
+            r"(?m)^build:msan\s+--features=msan\b",
+            "expected build:msan to enable the toolchains_llvm msan feature",
+        )
+        self.assertRegex(
+            bazelrc,
+            r"(?m)^build:msan\s+--extra_toolchains=@llvm_toolchain_msan//:all\b",
+            "expected build:msan to select the instrumented-libc++ toolchain",
+        )
+        self.assertRegex(
+            bazelrc,
+            r"(?m)^test:msan\s+--test_timeout=",
+            "expected test:msan timeouts like the other sanitizer configs",
+        )
+
+    def test_module_defines_msan_toolchain_with_instrumented_libcxx(self) -> None:
+        module = (_repo_root() / "MODULE.bazel").read_text(encoding="utf-8")
+        self.assertIn(
+            'name = "llvm_toolchain_msan"',
+            module,
+            "expected a dedicated llvm_toolchain_msan for instrumented libc++",
+        )
+        self.assertRegex(
+            module,
+            r"libcxx_url\s*=",
+            "msan requires an instrumented libc++ archive via libcxx_url",
+        )
+        self.assertRegex(
+            module,
+            r"libcxx_sha256\s*=",
+            "msan libcxx_url must be pinned with libcxx_sha256",
+        )
+
+
+class TestMsanLinuxCi(unittest.TestCase):
+    def test_ci_linux_runs_msan_job(self) -> None:
+        text = (_repo_root() / ".github" / "workflows" / "ci_linux.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertRegex(
+            text,
+            r"(?m)^  msan:\s*$",
+            "expected a dedicated msan job in ci_linux.yml",
+        )
+        self.assertRegex(
+            text,
+            r"bazelisk\s+test\s+--config=msan\b",
+            "expected Linux CI to run tests under --config=msan",
+        )
+        # MSAN is Linux-only; keep the job scoped to library tests like ASAN/UBSAN.
+        self.assertRegex(
+            text,
+            r"bazelisk\s+test\s+--config=msan\b[^\n]*//library/tests/",
+            "expected msan CI to exercise //library/tests/...",
+        )
+
+
+class TestMsanNotOnMacosCi(unittest.TestCase):
+    def test_ci_macos_does_not_run_msan(self) -> None:
+        text = (_repo_root() / ".github" / "workflows" / "ci_macos.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIsNone(
+            re.search(r"--config=msan\b", text),
+            "MSAN is Linux-only; macOS CI must not enable --config=msan",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -57,6 +57,25 @@ class TestMsanBazelConfig(unittest.TestCase):
             "msan libcxx_url must be pinned with libcxx_sha256",
         )
 
+    def test_module_pins_toolchains_llvm_past_unused_stdlib_fix(self) -> None:
+        """BCR 1.8.0 emits unused -stdlib=libc++; -Werror breaks Linux builds.
+
+        toolchains_llvm #791 drops the redundant flag. Until BCR ships a release
+        that includes it, MODULE.bazel must archive_override past that commit.
+        """
+        module = (_repo_root() / "MODULE.bazel").read_text(encoding="utf-8")
+        self.assertRegex(
+            module,
+            r'archive_override\(\s*\n\s*module_name\s*=\s*"toolchains_llvm"',
+            "expected archive_override for toolchains_llvm until BCR > 1.8.0",
+        )
+        # Merge commit of bazel-contrib/toolchains_llvm#791.
+        self.assertIn(
+            "c3ac93f5c61cb78487765d2e81e7485ad3f8bf2c",
+            module,
+            "toolchains_llvm override must include the unused -stdlib=libc++ fix",
+        )
+
 
 class TestMsanLinuxCi(unittest.TestCase):
     def test_ci_linux_runs_msan_job(self) -> None:

--- a/python/tests/ci_msan_test.py
+++ b/python/tests/ci_msan_test.py
@@ -20,6 +20,17 @@ def _repo_root(start: Path | None = None) -> Path:
     raise AssertionError("could not locate repository root from test file path")
 
 
+class TestMsanDocs(unittest.TestCase):
+    def test_build_system_docs_link_clang_msan(self) -> None:
+        """Point readers at upstream MSAN docs (coverage limits, false positives)."""
+        text = (_repo_root() / "docs" / "BUILD_SYSTEM.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "https://clang.llvm.org/docs/MemorySanitizer.html",
+            text,
+            "BUILD_SYSTEM.md must link the Clang MemorySanitizer documentation",
+        )
+
+
 class TestMsanBazelConfig(unittest.TestCase):
     def test_bazelrc_defines_msan_config(self) -> None:
         bazelrc = (_repo_root() / ".bazelrc").read_text(encoding="utf-8")

--- a/specs/build-system.md
+++ b/specs/build-system.md
@@ -1,7 +1,7 @@
 ---
 capability: build-system
 owners: [//, CPPVARIABLES.bzl, wasm_compat.bzl]
-last-updated: 2026-07-19
+last-updated: 2026-08-07
 ---
 
 # Build System
@@ -77,11 +77,12 @@ than re-encoding toolchain knowledge.
 - `BUILD.bazel` (root) — all `config_setting`s, the `//:dds` / `//:testable_dds`
   façades, and the `doxygen_docs` genrule.
 - `.bazelrc` — C++20 cxxopts, hermetic JDK, default test tag filters (e.g. `-e2e`),
-  sanitizer configs.
+  sanitizer configs (`asan` / `tsan` / `ubsan` / Linux-only `msan`).
 - `CPPVARIABLES.bzl` — `DDS_CPPOPTS`, `DDS_LINKOPTS`, `DDS_LOCAL_DEFINES`,
   `DDS_SCHEDULER_DEFINE`.
 - `wasm_compat.bzl` — `WASM_LINKOPTS`.
-- `MODULE.bazel` — the Bazel module and its `bazel_dep` graph.
+- `MODULE.bazel` — the Bazel module and its `bazel_dep` graph (including
+  `@llvm_toolchain_msan` for MemorySanitizer).
 - Consumer guide: `docs/BUILD_SYSTEM.md`.
 
 ## Known gaps / non-goals


### PR DESCRIPTION
Introduce --config=msan with an instrumented-libc++ toolchain (toolchains_llvm 1.8.0) and run library tests under MSAN on Linux CI.