### PR TITLE
Run Playwright e2e tests in WASM CI

### DIFF
--- a/.github/workflows/ci_wasm.yml
+++ b/.github/workflows/ci_wasm.yml
@@ -47,9 +47,11 @@ jobs:
           done
           exit 1
 
-      # 5️⃣ Unit tests and WASM builds (hermetic emsdk toolchain downloaded by Bazel)
+      # 5️⃣ Unit tests and WASM builds (hermetic emsdk toolchain downloaded by Bazel).
+      # Empty --test_tag_filters= overrides .bazelrc's -e2e so Playwright in
+      # //web:web_system_tests actually runs (dds_mvp_e2e_test is tagged e2e).
       - name: Test web helpers, system tests, e2e, and CalcDDtablePBN
-        run: bazelisk test --verbose_failures //web:web_tests //web:web_system_tests //wasm:all
+        run: bazelisk test --verbose_failures --test_tag_filters= //web:web_tests //web:web_system_tests //wasm:all
 
       - name: Build WASM targets
         run: |

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -164,7 +164,7 @@ bazelisk test //web:web_tests //web:web_system_tests //web:web_e2e_tests
 bazelisk test //wasm:all
 ```
 
-`bazelisk test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazelisk test //web:web_e2e_tests` or `bazelisk test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazelisk test --test_tag_filters= //...`
+`bazelisk test //...` skips targets tagged `e2e` by default (see `.bazelrc`). Run Playwright tests explicitly, e.g. `bazelisk test //web:web_e2e_tests` or `bazelisk test --test_tag_filters=e2e //web:dds_mvp_e2e_test`. To run all tests, including the Playwright tests: `bazelisk test --test_tag_filters= //...`. The WASM CI workflow (`.github/workflows/ci_wasm.yml`) passes empty `--test_tag_filters=` so `//web:web_system_tests` includes Playwright.
 
 - **`//web:dds_mvp_wasm_system_test`** — builds `//web:dds_mvp_wasm`, runs `patch_mvp_wasm` / `gen_wasm_bin_js` / `verify_wasm_js`, then calls `dds_mvp_calc_table` via Node (`web/tests/dds_mvp_wasm_node.mjs`).
 - **`//web:dds_mvp_e2e_test`** — Playwright tests for `dds_mvp.html` over `file://` (UI) and isolated HTTP (part-score solve, COOP/COEP). Requires Node, network (Chromium download on first run), and `tags = ["no-sandbox"]`.

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -103,6 +103,18 @@ py_test(
     ],
 )
 
+# Guard: WASM CI clears .bazelrc's -e2e filter so Playwright e2e tests run.
+py_test(
+    name = "ci_wasm_e2e_test",
+    size = "small",
+    main = "tests/ci_wasm_e2e_test.py",
+    srcs = ["tests/ci_wasm_e2e_test.py"],
+    data = [
+        "//:.bazelrc",
+        "//.github/workflows:all_workflows",
+    ],
+)
+
 py_test(
     name = "python_interface_smoke_test",
     size = "small",

--- a/python/tests/ci_wasm_e2e_test.py
+++ b/python/tests/ci_wasm_e2e_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Guard that WASM CI overrides .bazelrc's -e2e filter so Playwright runs."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+def _repo_root(start: Path | None = None) -> Path:
+    # Do not Path.resolve() — under `bazel test` this file is often a runfiles
+    # symlink into the execroot/source tree, and resolving leaves the runfiles
+    # tree where //.github/workflows and other data deps live.
+    here = (start or Path(__file__)).absolute()
+    for parent in here.parents:
+        workflows = parent / ".github" / "workflows"
+        if workflows.is_dir() and any(workflows.glob("ci_*.yml")):
+            return parent
+    raise AssertionError("could not locate repository root from test file path")
+
+
+class TestBazelrcSkipsE2eByDefault(unittest.TestCase):
+    def test_bazelrc_excludes_e2e_tag(self) -> None:
+        bazelrc = (_repo_root() / ".bazelrc").read_text(encoding="utf-8")
+        self.assertRegex(
+            bazelrc,
+            r"(?m)^test\s+--test_tag_filters=-e2e\b",
+            "expected default test config to skip e2e (Playwright) targets",
+        )
+
+
+class TestWasmCiRunsE2e(unittest.TestCase):
+    def test_ci_wasm_clears_e2e_tag_filter(self) -> None:
+        """web_system_tests includes dds_mvp_e2e_test; CI must not inherit -e2e."""
+        text = (_repo_root() / ".github" / "workflows" / "ci_wasm.yml").read_text(
+            encoding="utf-8"
+        )
+        # Empty --test_tag_filters= overrides .bazelrc's -e2e so tagged tests run.
+        self.assertRegex(
+            text,
+            r"bazelisk\s+test\b[^\n]*--test_tag_filters=(?:\s|$)",
+            "ci_wasm.yml must pass empty --test_tag_filters= to run e2e targets",
+        )
+        self.assertRegex(
+            text,
+            r"bazelisk\s+test\b[^\n]*//web:web_tests\b",
+            "expected WASM CI to keep running //web:web_tests",
+        )
+        self.assertRegex(
+            text,
+            r"bazelisk\s+test\b[^\n]*//web:web_system_tests\b",
+            "expected WASM CI to keep running //web:web_system_tests (includes e2e)",
+        )
+        # Ensure we did not reintroduce an -e2e exclusion on the same invocation.
+        for match in re.finditer(r"bazelisk\s+test\b[^\n]+", text):
+            line = match.group(0)
+            if "--test_tag_filters=" in line:
+                self.assertNotRegex(
+                    line,
+                    r"--test_tag_filters=[^\n]*-e2e\b",
+                    "WASM CI test invocation must not exclude the e2e tag",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/build-system.md
+++ b/specs/build-system.md
@@ -76,7 +76,8 @@ than re-encoding toolchain knowledge.
 
 - `BUILD.bazel` (root) — all `config_setting`s, the `//:dds` / `//:testable_dds`
   façades, and the `doxygen_docs` genrule.
-- `.bazelrc` — C++20 cxxopts, hermetic JDK, default test tag filters (e.g. `-e2e`),
+- `.bazelrc` — C++20 cxxopts, hermetic JDK, default test tag filters (e.g. `-e2e`;
+  WASM CI clears the filter so Playwright runs),
   sanitizer configs (`asan` / `tsan` / `ubsan` / Linux-only `msan`).
 - `CPPVARIABLES.bzl` — `DDS_CPPOPTS`, `DDS_LINKOPTS`, `DDS_LOCAL_DEFINES`,
   `DDS_SCHEDULER_DEFINE`.

--- a/specs/web-mvp.md
+++ b/specs/web-mvp.md
@@ -1,7 +1,7 @@
 ---
 capability: web-mvp
 owners: [web]
-last-updated: 2026-07-24
+last-updated: 2026-08-07
 ---
 
 # Web MVP
@@ -57,7 +57,8 @@ a full application.
     `dds_mvp_wasm_node.mjs`) **and** `dds_mvp_e2e_test`.
   - **E2E-only** (`web_e2e_tests`): `dds_mvp_e2e_test` alone — Playwright/Chromium
     against the served page, tagged `e2e`, `no-sandbox`, `requires-network`
-    (first run downloads Chromium). Default `.bazelrc` filters `-e2e`.
+    (first run downloads Chromium). Default `.bazelrc` filters `-e2e`; WASM CI
+    (`ci_wasm.yml`) clears that filter so `web_system_tests` runs e2e there.
 - **Post-build patch is MVP-owned.** `web/patch_mvp_wasm.py` (driven by
   `./web/update_wasm.sh`) fixes Emscripten's generated `isFileURI` helper for
   browser/`file://` safety on `//web:dds_mvp_wasm` only — not the example WASM


### PR DESCRIPTION
## Summary
- Clear the `.bazelrc` `-e2e` filter in `ci_wasm.yml` with empty `--test_tag_filters=` so Playwright (`dds_mvp_e2e_test` inside `//web:web_system_tests`) actually runs in CI.
- Add `//python:ci_wasm_e2e_test` to guard that WASM CI keeps clearing the filter.
- Note the CI override in `specs/web-mvp.md`, `specs/build-system.md`, and `docs/wasm_build.md`.

Fixes #256

## Test plan
- [x] `bazelisk test //python:ci_wasm_e2e_test`
- [x] Confirm CI – WASM job runs `dds_mvp_e2e_test` (not filtered by `-e2e`)
- [x] Spot-check that unit/system targets in the same step still pass


Made with [Cursor](https://cursor.com)