### PR TITLE
Removed dtest --min/--max flags. 

### DIFF
--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -56,11 +56,13 @@ cc_test(
     ],
 )
 
-# Standalone calc_par API test
+# Standalone calc_par API test.
+# medium: MSAN can spend ~80s on the remaining suite alone (small = 120s under
+# --config=msan), so keep headroom against runner load variance.
 cc_test(
     name = "calc_par_test",
     srcs = ["calc_par_test.cpp"],
-    size = "small",
+    size = "medium",
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
     local_defines = DDS_LOCAL_DEFINES,

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -8,7 +8,6 @@
 */
 
 
-#include <algorithm>
 #include <ctime>
 #include <iostream>
 #include <iomanip>
@@ -45,11 +44,6 @@ void TestTimer::reset()
   user_cum_ = 0;
   user_cum_old_ = 0;
   sys_cum_ = 0;
-  user_min_ = 0;
-  user_max_ = 0;
-  sys_min_ = 0;
-  sys_max_ = 0;
-  batch_count_ = 0;
   pending_hands_ = 0;
   sys_time_known_ = true;
 }
@@ -120,52 +114,6 @@ void TestTimer::record(const int hands, const long user_ms, const long sys_ms)
   count_ += hands;
   user_cum_ += user_ms;
   sys_cum_ += sys_ms;
-
-  const double user_per_hand = user_ms / static_cast<double>(hands);
-  const double sys_per_hand = sys_ms / static_cast<double>(hands);
-  if (batch_count_ == 0)
-  {
-    user_min_ = user_max_ = user_per_hand;
-    sys_min_ = sys_max_ = sys_per_hand;
-  }
-  else
-  {
-    user_min_ = std::min(user_min_, user_per_hand);
-    user_max_ = std::max(user_max_, user_per_hand);
-    sys_min_ = std::min(sys_min_, sys_per_hand);
-    sys_max_ = std::max(sys_max_, sys_per_hand);
-  }
-  batch_count_++;
-}
-
-
-bool TestTimer::has_batch_times() const
-{
-  return batch_count_ > 0;
-}
-
-
-double TestTimer::user_min_ms() const
-{
-  return user_min_;
-}
-
-
-double TestTimer::user_max_ms() const
-{
-  return user_max_;
-}
-
-
-double TestTimer::sys_min_ms() const
-{
-  return sys_min_;
-}
-
-
-double TestTimer::sys_max_ms() const
-{
-  return sys_max_;
 }
 
 
@@ -226,10 +174,7 @@ void TestTimer::print_basic() const
 }
 
 
-void TestTimer::print_hands(
-  ostream& out,
-  const bool show_min,
-  const bool show_max) const
+void TestTimer::print_hands(ostream& out) const
 {
   struct StreamFormatGuard
   {
@@ -277,12 +222,6 @@ void TestTimer::print_hands(
     out << setw(21) << left << "Avg user time (ms)" <<
       setw(12) << right << fixed << setprecision(2) << user_cum_ / 
         static_cast<float>(count_) << "\n";
-    if (show_min && has_batch_times())
-      out << setw(21) << left << "Min user time (ms)" <<
-        setw(12) << right << fixed << setprecision(2) << user_min_ << "\n";
-    if (show_max && has_batch_times())
-      out << setw(21) << left << "Max user time (ms)" <<
-        setw(12) << right << fixed << setprecision(2) << user_max_ << "\n";
   }
 
   if (!sys_time_known_)
@@ -298,12 +237,6 @@ void TestTimer::print_hands(
     out << setw(21) << left << "Avg sys time (ms)" <<
       setw(12) << right << fixed << setprecision(2) << sys_cum_ / 
         static_cast<float>(count_) << "\n";
-    if (show_min && has_batch_times())
-      out << setw(21) << left << "Min sys time (ms)" <<
-        setw(12) << right << fixed << setprecision(2) << sys_min_ << "\n";
-    if (show_max && has_batch_times())
-      out << setw(21) << left << "Max sys time (ms)" <<
-        setw(12) << right << fixed << setprecision(2) << sys_max_ << "\n";
     if (user_cum_ > 0) {
       out << setw(21) << left << "Ratio" << 
         setw(12) << right << fixed << setprecision(2) << 

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -7,6 +7,7 @@
    See LICENSE and README.
 */
 
+
 #pragma once
 
 #include <ostream>
@@ -40,11 +41,6 @@ class TestTimer
     long user_cum_;         ///< Cumulative user time (milliseconds)
     long user_cum_old_;     ///< Previous cumulative user time (milliseconds)
     long sys_cum_;          ///< Cumulative system time (milliseconds)
-    double user_min_;       ///< Min per-hand user time across batches (ms)
-    double user_max_;       ///< Max per-hand user time across batches (ms)
-    double sys_min_;        ///< Min per-hand system time across batches (ms)
-    double sys_max_;        ///< Max per-hand system time across batches (ms)
-    long batch_count_;      ///< Number of completed batches
     int pending_hands_;     ///< Hands counted into the open start()/end() batch
     bool sys_time_known_;   ///< False when clock() is unusable (e.g. wasm32)
 
@@ -80,28 +76,12 @@ class TestTimer
     void end();
 
     /// Record one completed batch without wall-clock measurement.
-    /// Updates cumulative totals and per-hand min/max extremes.
-    /// Used by end() and by unit tests for deterministic extremes.
-    /// Non-positive hands is ignored (no cumulative or extreme updates).
+    /// Updates cumulative totals. Used by end() and by unit tests.
+    /// Non-positive hands is ignored (no cumulative updates).
     /// @param hands Number of hands in the batch
     /// @param user_ms Batch user (wall) time in milliseconds
     /// @param sys_ms Batch system (CPU) time in milliseconds
     void record(const int hands, const long user_ms, const long sys_ms);
-
-    /// Whether at least one batch has been recorded.
-    bool has_batch_times() const;
-
-    /// Minimum per-hand user time across batches (milliseconds).
-    double user_min_ms() const;
-
-    /// Maximum per-hand user time across batches (milliseconds).
-    double user_max_ms() const;
-
-    /// Minimum per-hand system time across batches (milliseconds).
-    double sys_min_ms() const;
-
-    /// Maximum per-hand system time across batches (milliseconds).
-    double sys_max_ms() const;
 
     /// Print timer status while running.
     /// @param reached Number of iterations completed so far
@@ -115,10 +95,5 @@ class TestTimer
     
     /// Print detailed per-hand timer results.
     /// @param out Output stream
-    /// @param show_min Include min per-hand times across batches
-    /// @param show_max Include max per-hand times across batches
-    void print_hands(
-        std::ostream& out = std::cout,
-        bool show_min = false,
-        bool show_max = false) const;
+    void print_hands(std::ostream& out = std::cout) const;
 };

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -42,7 +42,7 @@ struct optEntry
   unsigned numArgs;
 };
 
-#define DTEST_NUM_OPTIONS 7
+#define DTEST_NUM_OPTIONS 5
 
 enum DtestOpt
 {
@@ -50,9 +50,7 @@ enum DtestOpt
   OPT_SOLVER = 1,
   OPT_NUMTHR = 2,
   OPT_MEMORY = 3,
-  OPT_REPORT = 4,
-  OPT_MAX = 5,
-  OPT_MIN = 6
+  OPT_REPORT = 4
 };
 
 const optEntry optList[DTEST_NUM_OPTIONS] =
@@ -61,9 +59,7 @@ const optEntry optList[DTEST_NUM_OPTIONS] =
   {"s", "solver", 1},
   {"n", "numthr", 1},
   {"m", "memory", 1},
-  {"r", "report", 0},
-  {"", "max", 0},
-  {"", "min", 0}
+  {"r", "report", 0}
 };
 
 const vector<string> solverList =
@@ -115,10 +111,6 @@ void usage(
     "\n" <<
     "-r, --report       Print per-board timings sorted by longest first.\n" <<
     "\n" <<
-    "    --max          Also print max per-hand user/sys time across batches.\n" <<
-    "\n" <<
-    "    --min          Also print min per-hand user/sys time across batches.\n" <<
-    "\n" <<
     endl;
 }
 
@@ -167,8 +159,7 @@ int GetNextArgToken(
       else
         nextToken++;
 
-      // Return 1-based option index so --max/--min do not collide with
-      // --memory on the shared leading 'm'.
+      // Return 1-based option index so 0 can mean "done".
       return static_cast<int>(i) + 1;
     }
   }
@@ -184,8 +175,6 @@ void SetDefaults()
   options.num_threads_ = 0;
   options.memory_mb_ = 0;
   options.report_slow_boards_ = false;
-  options.show_min_ = false;
-  options.show_max_ = false;
 }
 
 
@@ -501,14 +490,6 @@ void read_args(
 
       case OPT_REPORT:
         options.report_slow_boards_ = true;
-        break;
-
-      case OPT_MAX:
-        options.show_max_ = true;
-        break;
-
-      case OPT_MIN:
-        options.show_min_ = true;
         break;
 
       default:

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -21,7 +21,6 @@
 /// - Number of threads
 /// - Memory allocation
 /// - Slow board reporting
-/// - Optional min/max per-hand timing summary across batches
 
 /// Print usage information.
 /// @param base Command name for usage message

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -213,8 +213,6 @@ TEST(Args, MakeDirFailsWhenPathIsExistingFile)
 
 TEST(Args, UnknownMinMaxFlagsAreRejected)
 {
-  // Former --min/--max batch-extreme flags must not be accepted.
-  // read_args prints to cout and exits(0); death tests only match stderr.
   const std::string path = make_temp_input_file();
   char arg0[] = "dtest";
   char arg_f[] = "-f";

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -219,8 +219,11 @@ TEST(Args, UnknownMinMaxFlagsAreRejected)
   char arg0[] = "dtest";
   char arg_f[] = "-f";
   char arg_min[] = "--min";
-  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_min};
-  EXPECT_EXIT(read_args(4, argv), ::testing::ExitedWithCode(0), ".*");
+  char arg_max[] = "--max";
+  char* argv_min[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_min};
+  char* argv_max[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_max};
+  EXPECT_EXIT(read_args(4, argv_min), ::testing::ExitedWithCode(0), ".*");
+  EXPECT_EXIT(read_args(4, argv_max), ::testing::ExitedWithCode(0), ".*");
 }
 
 TEST(Args, ResolvePrefersLiteralExistingPath)

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -192,17 +192,6 @@ class HandsLayoutFixture : public ::testing::Test
 
 }  // namespace
 
-TEST(Args, MaxAndMinFlagsDefaultOff)
-{
-  const std::string path = make_temp_input_file();
-  char arg0[] = "dtest";
-  char arg_f[] = "-f";
-  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str())};
-  read_args(3, argv);
-  EXPECT_FALSE(options.show_min_);
-  EXPECT_FALSE(options.show_max_);
-}
-
 TEST(Args, MakeDirSucceedsWhenDirectoryAlreadyExists)
 {
   const std::string dir =
@@ -222,42 +211,16 @@ TEST(Args, MakeDirFailsWhenPathIsExistingFile)
   EXPECT_FALSE(make_dir(path));
 }
 
-TEST(Args, MaxFlagEnablesShowMax)
+TEST(Args, UnknownMinMaxFlagsAreRejected)
 {
-  const std::string path = make_temp_input_file();
-  char arg0[] = "dtest";
-  char arg_f[] = "-f";
-  char arg_max[] = "--max";
-  char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_max};
-  read_args(4, argv);
-  EXPECT_TRUE(options.show_max_);
-  EXPECT_FALSE(options.show_min_);
-}
-
-TEST(Args, MinFlagEnablesShowMin)
-{
+  // Former --min/--max batch-extreme flags must not be accepted.
+  // read_args prints to cout and exits(0); death tests only match stderr.
   const std::string path = make_temp_input_file();
   char arg0[] = "dtest";
   char arg_f[] = "-f";
   char arg_min[] = "--min";
   char* argv[] = {arg0, arg_f, const_cast<char*>(path.c_str()), arg_min};
-  read_args(4, argv);
-  EXPECT_TRUE(options.show_min_);
-  EXPECT_FALSE(options.show_max_);
-}
-
-TEST(Args, MaxAndMinFlagsCanCombine)
-{
-  const std::string path = make_temp_input_file();
-  char arg0[] = "dtest";
-  char arg_f[] = "-f";
-  char arg_max[] = "--max";
-  char arg_min[] = "--min";
-  char* argv[] = {
-    arg0, arg_f, const_cast<char*>(path.c_str()), arg_max, arg_min};
-  read_args(5, argv);
-  EXPECT_TRUE(options.show_min_);
-  EXPECT_TRUE(options.show_max_);
+  EXPECT_EXIT(read_args(4, argv), ::testing::ExitedWithCode(0), ".*");
 }
 
 TEST(Args, ResolvePrefersLiteralExistingPath)

--- a/library/tests/calc_par_test.cpp
+++ b/library/tests/calc_par_test.cpp
@@ -379,26 +379,3 @@ TEST_F(CalcParTest, CalcParContextOverloadMatchesNonContext)
             << "Hand " << hand_idx << " EW contracts differ";
     }
 }
-
-// Performance test: context reuse should work efficiently
-TEST_F(CalcParTest, ContextReusePerformance)
-{
-    SolverContext ctx;
-    
-    // Run multiple calculations with same context
-    const int num_iterations = 10;
-    for (int i = 0; i < num_iterations; i++) {
-        DdTableResults table;
-        ParResults par;
-        
-        // Alternate between different deals
-        DdTableDeal* deal = (i % 2 == 0) ? &deal0_ : &deal1_;
-        int vuln = vulnerability_[i % 2];
-        
-        int result = calc_par(ctx, *deal, vuln, &table, &par);
-        ASSERT_EQ(result, RETURN_NO_FAULT) << "Iteration " << i << " should succeed";
-    }
-    
-    // If we got here, context reuse is working
-    SUCCEED();
-}

--- a/library/tests/cst.hpp
+++ b/library/tests/cst.hpp
@@ -36,7 +36,5 @@ struct OptionsType
   int num_threads_;                         ///< Number of threads to use
   int memory_mb_;                           ///< Memory allocation in MB
   bool report_slow_boards_;                 ///< Report slow-executing hands
-  bool show_min_;                           ///< Report min per-hand time across batches
-  bool show_max_;                           ///< Report max per-hand time across batches
 };
 

--- a/library/tests/solve_board/BUILD.bazel
+++ b/library/tests/solve_board/BUILD.bazel
@@ -17,9 +17,11 @@ cc_test(
     copts = DDS_CPPOPTS,
 )
 
+# medium: MSAN can exceed the small-test limit (120s under --config=msan) on the
+# random-playout consistency suite, so keep headroom against runner load variance.
 cc_test(
     name = "analyse_play_consistency_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "analyse_play_consistency.cpp",
     ],

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -96,10 +96,14 @@ TEST(TestTimer, RecordAccumulatesHandsAndTimes)
   timer.record(5, 20, 10);
 
   const std::string out = capture_print_hands(timer);
-  EXPECT_NE(out.find("Number of hands"), std::string::npos);
-  EXPECT_NE(out.find("15"), std::string::npos);   // 10 + 5 hands
-  EXPECT_NE(out.find("120"), std::string::npos);  // 100 + 20 user ms
-  EXPECT_NE(out.find("8.00"), std::string::npos); // avg user 120/15
+  // Anchor values to their labels so digits elsewhere in the report cannot
+  // satisfy the assertions (e.g. "15" matching inside "150").
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(Number of hands\s+15\s*(?:\n|$))")));  // 10 + 5
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(User time \(ms\)\s+120\s*(?:\n|$))")));  // 100 + 20
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(Avg user time \(ms\)\s+8\.00\s*(?:\n|$))")));  // 120/15
   EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
   EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
 }
@@ -112,9 +116,12 @@ TEST(TestTimer, RecordIgnoresNonPositiveHands)
   timer.record(-3, 999, 999);
 
   const std::string out = capture_print_hands(timer);
-  EXPECT_NE(out.find("Number of hands"), std::string::npos);
-  EXPECT_NE(out.find("100"), std::string::npos);
-  EXPECT_NE(out.find("10.00"), std::string::npos);
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(Number of hands\s+10\s*(?:\n|$))")));
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(User time \(ms\)\s+100\s*(?:\n|$))")));
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(Avg user time \(ms\)\s+10\.00\s*(?:\n|$))")));
   EXPECT_EQ(out.find("999"), std::string::npos);
 }
 

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -1,5 +1,5 @@
 /// @file test_timer_test.cpp
-/// @brief Unit tests for TestTimer batch min/max tracking and optional reporting.
+/// @brief Unit tests for TestTimer accumulation, printing, and clock helpers.
 
 #include <cstdint>
 #include <ctime>
@@ -14,13 +14,10 @@
 namespace
 {
 
-std::string capture_print_hands(
-  const TestTimer& timer,
-  const bool show_min,
-  const bool show_max)
+std::string capture_print_hands(const TestTimer& timer)
 {
   std::ostringstream out;
-  timer.print_hands(out, show_min, show_max);
+  timer.print_hands(out);
   return out.str();
 }
 
@@ -91,45 +88,19 @@ TEST(TestTimer, ClockDeltaToMsAvoids32BitOverflowForMultiSecondBatches)
   EXPECT_NE(clock_delta_to_ms(ticks), wrapped_ms);
 }
 
-TEST(TestTimer, RecordTracksMinAndMaxPerHandAcrossBatches)
+TEST(TestTimer, RecordAccumulatesHandsAndTimes)
 {
   TestTimer timer;
-
-  // Batch totals: (100ms / 10 hands), (300 / 10), (200 / 10)
   timer.record(10, 100, 50);
-  timer.record(10, 300, 80);
-  timer.record(10, 200, 40);
+  timer.record(5, 20, 10);
 
-  EXPECT_TRUE(timer.has_batch_times());
-  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 10.0);
-  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 30.0);
-  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 4.0);
-  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 8.0);
-}
-
-TEST(TestTimer, SingleBatchMinEqualsMaxEqualsPerHand)
-{
-  TestTimer timer;
-  timer.record(5, 42, 7);
-
-  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 8.4);
-  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 8.4);
-  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 1.4);
-  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 1.4);
-}
-
-TEST(TestTimer, UnevenBatchSizesUsePerHandNotBatchTotal)
-{
-  TestTimer timer;
-  // Slower per hand but smaller total: 50ms / 5 = 10.0
-  timer.record(5, 50, 10);
-  // Faster per hand but larger total: 90ms / 30 = 3.0
-  timer.record(30, 90, 30);
-
-  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 3.0);
-  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 10.0);
-  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 1.0);
-  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 2.0);
+  const std::string out = capture_print_hands(timer);
+  EXPECT_NE(out.find("Number of hands"), std::string::npos);
+  EXPECT_NE(out.find("15"), std::string::npos);   // 10 + 5 hands
+  EXPECT_NE(out.find("120"), std::string::npos);  // 100 + 20 user ms
+  EXPECT_NE(out.find("8.00"), std::string::npos); // avg user 120/15
+  EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
+  EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
 }
 
 TEST(TestTimer, RecordIgnoresNonPositiveHands)
@@ -139,41 +110,23 @@ TEST(TestTimer, RecordIgnoresNonPositiveHands)
   timer.record(0, 999, 999);
   timer.record(-3, 999, 999);
 
-  EXPECT_TRUE(timer.has_batch_times());
-  EXPECT_DOUBLE_EQ(timer.user_min_ms(), 10.0);
-  EXPECT_DOUBLE_EQ(timer.user_max_ms(), 10.0);
-  EXPECT_DOUBLE_EQ(timer.sys_min_ms(), 5.0);
-  EXPECT_DOUBLE_EQ(timer.sys_max_ms(), 5.0);
-
-  const std::string out = capture_print_hands(timer, false, false);
+  const std::string out = capture_print_hands(timer);
   EXPECT_NE(out.find("Number of hands"), std::string::npos);
   EXPECT_NE(out.find("100"), std::string::npos);
   EXPECT_NE(out.find("10.00"), std::string::npos);
   EXPECT_EQ(out.find("999"), std::string::npos);
 }
 
-TEST(TestTimer, ResetClearsBatchExtremes)
+TEST(TestTimer, ResetClearsAccumulatedStats)
 {
   TestTimer timer;
   timer.record(1, 10, 2);
   timer.reset();
 
-  EXPECT_FALSE(timer.has_batch_times());
-}
-
-TEST(TestTimer, PrintHandsOmitsMinMaxByDefault)
-{
-  TestTimer timer;
-  timer.set_name("Hand stats");
-  timer.record(2, 20, 4);
-
-  const std::string out = capture_print_hands(timer, false, false);
-
-  EXPECT_NE(out.find("Avg user time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Min sys time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Max sys time (ms)"), std::string::npos);
+  const std::string out = capture_print_hands(timer);
+  EXPECT_NE(out.find("Number of hands"), std::string::npos);
+  EXPECT_NE(out.find("0"), std::string::npos);
+  EXPECT_EQ(out.find("User time (ms)"), std::string::npos);
 }
 
 TEST(TestTimer, PrintHandsShowsSysNaWhenClockUnavailable)
@@ -184,43 +137,11 @@ TEST(TestTimer, PrintHandsShowsSysNaWhenClockUnavailable)
   timer.mark_sys_time_unavailable();
   timer.record(10, 100, 0);
 
-  const std::string out = capture_print_hands(timer, false, false);
+  const std::string out = capture_print_hands(timer);
 
   EXPECT_NE(out.find("Sys time (ms)"), std::string::npos);
   EXPECT_NE(out.find("n/a"), std::string::npos);
   EXPECT_EQ(out.find("zero"), std::string::npos);
-}
-
-TEST(TestTimer, PrintHandsShowsMinWhenRequested)
-{
-  TestTimer timer;
-  timer.record(2, 20, 4);  // 10.0 user / hand, 2.0 sys / hand
-  timer.record(2, 10, 8);  // 5.0 user / hand, 4.0 sys / hand
-
-  const std::string out = capture_print_hands(timer, true, false);
-
-  EXPECT_NE(out.find("Min user time (ms)"), std::string::npos);
-  EXPECT_NE(out.find("Min sys time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Max user time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Max sys time (ms)"), std::string::npos);
-  EXPECT_NE(out.find("5.00"), std::string::npos);
-  EXPECT_NE(out.find("2.00"), std::string::npos);
-}
-
-TEST(TestTimer, PrintHandsShowsMaxWhenRequested)
-{
-  TestTimer timer;
-  timer.record(2, 20, 4);  // 10.0 / 2.0
-  timer.record(2, 10, 8);  // 5.0 / 4.0
-
-  const std::string out = capture_print_hands(timer, false, true);
-
-  EXPECT_NE(out.find("Max user time (ms)"), std::string::npos);
-  EXPECT_NE(out.find("Max sys time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Min user time (ms)"), std::string::npos);
-  EXPECT_EQ(out.find("Min sys time (ms)"), std::string::npos);
-  EXPECT_NE(out.find("10.00"), std::string::npos);
-  EXPECT_NE(out.find("4.00"), std::string::npos);
 }
 
 TEST(TestTimer, PrintHandsRestoresStreamFormatState)
@@ -233,7 +154,7 @@ TEST(TestTimer, PrintHandsRestoresStreamFormatState)
   const auto flags_before = out.flags();
   const auto precision_before = out.precision();
 
-  timer.print_hands(out, true, true);
+  timer.print_hands(out);
 
   EXPECT_EQ(out.flags(), flags_before);
   EXPECT_EQ(out.precision(), precision_before);

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <iomanip>
 #include <limits>
+#include <regex>
 #include <sstream>
 #include <string>
 
@@ -124,8 +125,10 @@ TEST(TestTimer, ResetClearsAccumulatedStats)
   timer.reset();
 
   const std::string out = capture_print_hands(timer);
-  EXPECT_NE(out.find("Number of hands"), std::string::npos);
-  EXPECT_NE(out.find("0"), std::string::npos);
+  // Require the hands count field itself to be 0 (not a substring match like
+  // "10", which also contains '0').
+  EXPECT_TRUE(std::regex_search(
+    out, std::regex(R"(Number of hands\s+0\s*(?:\n|$))")));
   EXPECT_EQ(out.find("User time (ms)"), std::string::npos);
 }
 

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -141,7 +141,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     exit(0);
   }
 
-  timer.print_hands(cout, options.show_min_, options.show_max_);
+  timer.print_hands(cout);
 
   if (options.report_slow_boards_)
   {


### PR DESCRIPTION
--min/--max reported minimum and maximum batch averages, not single-deal times, so they were useless.

Use -r for per-board outliers instead.