### PR TITLE
Ensure DDS_SCHEDULER path compiles in Linux CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -53,11 +53,15 @@ jobs:
       - name: Build all targets
         run: bazelisk build --verbose_failures //...
 
-      # 7️⃣ Run all tests (including Python)
+      # 7️⃣ Build with DDS_SCHEDULER (off by default; compile-gated timing path)
+      - name: Build with scheduler define
+        run: bazelisk build --define=scheduler=true --verbose_failures //library/src:dds
+
+      # 8️⃣ Run all tests (including Python)
       - name: Run all tests
         run: bazelisk test --verbose_failures //...
 
-      # 8️⃣ Upload test logs
+      # 9️⃣ Upload test logs
       - name: Upload test logs - Linux
         if: always()
         uses: actions/upload-artifact@v6

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -139,6 +139,7 @@ runtime), the rpath major is likely out of sync with the installed toolchain.
 
 | Workflow | Job | Command |
 |----------|-----|---------|
+| `ci_linux.yml` | `build_and_test` | also `bazelisk build --define=scheduler=true //library/src:dds` (compiles `DDS_SCHEDULER` path) |
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |


### PR DESCRIPTION
## Summary
- Add a Linux CI step that builds `//library/src:dds` with `--define=scheduler=true` so the gated `DDS_SCHEDULER` timing path stays compile-clean.
- Document the step in `docs/BUILD_SYSTEM.md`.

## Test plan
- [x] Confirm Linux CI `build_and_test` runs the new scheduler define build step
- [x] Confirm `bazelisk build --define=scheduler=true //library/src:dds` succeeds locally


Made with [Cursor](https://cursor.com)