### PR TITLE
Fix DDS_AB_STATS build by binding thrp in apply_ab_tt_lookup

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -53,11 +53,15 @@ jobs:
       - name: Build all targets
         run: bazelisk build --verbose_failures //...
 
-      # 7️⃣ Run all tests (including Python)
+      # 7️⃣ Build with DDS_AB_STATS (off by default; compile-gated AB counters)
+      - name: Build with ab_stats define
+        run: bazelisk build --define=ab_stats=true --verbose_failures //library/src:dds
+
+      # 8️⃣ Run all tests (including Python)
       - name: Run all tests
         run: bazelisk test --verbose_failures //...
 
-      # 8️⃣ Upload test logs
+      # 9️⃣ Upload test logs
       - name: Upload test logs - Linux
         if: always()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Build with ab_stats define
         run: bazelisk build --define=ab_stats=true --verbose_failures //library/src:dds
 
+      - name: Test with ab_stats define
+        run: bazelisk test --define=ab_stats=true --verbose_failures --test_output=errors //library/tests/ab_search:ab_stats_test //library/tests/ab_search:tt_lookup_test
+
       # 8️⃣ Build with DDS_SCHEDULER (off by default; compile-gated timing path)
       - name: Build with scheduler define
         run: bazelisk build --define=scheduler=true --verbose_failures //library/src:dds

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -139,7 +139,7 @@ runtime), the rpath major is likely out of sync with the installed toolchain.
 
 | Workflow | Job | Command |
 |----------|-----|---------|
-| `ci_linux.yml` | `build_and_test` | also `bazelisk build --define=ab_stats=true //library/src:dds` and `--define=scheduler=true` (gated diagnostic paths) |
+| `ci_linux.yml` | `build_and_test` | also `bazelisk build --define=ab_stats=true //library/src:dds`, `bazelisk test --define=ab_stats=true //library/tests/ab_search:ab_stats_test //library/tests/ab_search:tt_lookup_test`, and `bazelisk build --define=scheduler=true //library/src:dds` |
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -139,6 +139,7 @@ runtime), the rpath major is likely out of sync with the installed toolchain.
 
 | Workflow | Job | Command |
 |----------|-----|---------|
+| `ci_linux.yml` | `build_and_test` | also `bazelisk build --define=ab_stats=true //library/src:dds` (compiles `DDS_AB_STATS` path) |
 | `ci_linux.yml` | `asan` | `bazelisk test --config=asan //library/tests/...` |
 | `ci_linux.yml` | `tsan` | `bazelisk test --config=tsan //library/tests/system/...` |
 | `ci_linux.yml` | `ubsan` | `bazelisk test --config=ubsan //library/tests/...` |

--- a/library/src/ab_search.cpp
+++ b/library/src/ab_search.cpp
@@ -39,6 +39,8 @@ auto apply_ab_tt_lookup(
   SolverContext& ctx,
   bool& scoreFlag) -> bool
 {
+  [[maybe_unused]] ThreadData* thrp = ctx.thread_ptr();
+
   int limit;
   if (ctx.search().node_type_store(0) == MAXNODE)
     limit = target - posPoint->tricks_max - 1;
@@ -57,7 +59,7 @@ auto apply_ab_tt_lookup(
     return false;
 
 #ifdef DDS_AB_HITS
-  DumpRetrieved(ctx.thread_ptr()->fileRetrieved.GetStream(),
+  DumpRetrieved(thrp->fileRetrieved.GetStream(),
     * posPoint, *cardsP, target, depth);
 #endif
 

--- a/library/src/ab_stats.cpp
+++ b/library/src/ab_stats.cpp
@@ -62,6 +62,9 @@ void ABstats::Reset()
 
 void ABstats::ResetCum()
 {
+  for (int depth = 0; depth < DDS_MAXDEPTH; depth++)
+    ABnodesCum.list[depth] = 0;
+
   ABnodesCum.sumCum = 0;
   ABnodesCum.sumCumWeighted = 0;
 

--- a/library/src/ab_stats.cpp
+++ b/library/src/ab_stats.cpp
@@ -134,6 +134,15 @@ int ABstats::GetNodes() const
 }
 
 
+int ABstats::GetPosCount(const ABCountType no) const
+{
+  if (no < 0 || no >= AB_SIZE)
+    return 0;
+
+  return ABplaces[no].sum;
+}
+
+
 void ABstats::PrintHeaderPosition(ofstream& fout) const
 {
   fout << "No " <<

--- a/library/src/ab_stats.cpp
+++ b/library/src/ab_stats.cpp
@@ -22,6 +22,7 @@ using namespace std;
 ABstats::ABstats()
 {
   ABstats::Reset();
+  ABstats::ResetCum();
   ABstats::SetNames();
 }
 

--- a/library/src/ab_stats.cpp
+++ b/library/src/ab_stats.cpp
@@ -134,7 +134,7 @@ int ABstats::GetNodes() const
 }
 
 
-int ABstats::GetPosCount(const ABCountType no) const
+int ABstats::GetPosCount(const int no) const
 {
   if (no < 0 || no >= AB_SIZE)
     return 0;

--- a/library/src/ab_stats.hpp
+++ b/library/src/ab_stats.hpp
@@ -135,7 +135,7 @@ class ABstats
 
     int GetNodes() const;
 
-    int GetPosCount(ABCountType no) const;
+    int GetPosCount(int no) const;
 
     void PrintStats(std::ofstream& fout);
 };

--- a/library/src/ab_stats.hpp
+++ b/library/src/ab_stats.hpp
@@ -135,6 +135,8 @@ class ABstats
 
     int GetNodes() const;
 
+    int GetPosCount(ABCountType no) const;
+
     void PrintStats(std::ofstream& fout);
 };
 

--- a/library/tests/ab_search/BUILD.bazel
+++ b/library/tests/ab_search/BUILD.bazel
@@ -33,3 +33,14 @@ cc_test(
     ],
     copts = DDS_CPPOPTS,
 )
+
+cc_test(
+    name = "ab_stats_test",
+    size = "small",
+    srcs = ["ab_stats_test.cpp"],
+    deps = [
+        "//library/src:ab_stats",
+        "@googletest//:gtest_main",
+    ],
+    copts = DDS_CPPOPTS,
+)

--- a/library/tests/ab_search/ab_stats_test.cpp
+++ b/library/tests/ab_search/ab_stats_test.cpp
@@ -36,3 +36,13 @@ TEST(ABstatsTest, GetPosCountRejectsOutOfRangePlace)
   EXPECT_EQ(stats.GetPosCount(AB_SIZE), 0);
   EXPECT_EQ(stats.GetPosCount(100), 0);
 }
+
+TEST(ABstatsTest, IncrNodeAfterConstructionUsesZeroedCumNodeList)
+{
+  // ResetCum must clear ABnodesCum.list[]; otherwise IncrNode increments
+  // indeterminate values (UBSan) and PrintStatsDepth reads garbage.
+  ABstats stats;
+  stats.IncrNode(/*depth=*/5);
+
+  EXPECT_EQ(stats.GetNodes(), 1);
+}

--- a/library/tests/ab_search/ab_stats_test.cpp
+++ b/library/tests/ab_search/ab_stats_test.cpp
@@ -29,6 +29,7 @@ TEST(ABstatsTest, GetPosCountRejectsOutOfRangePlace)
   ABstats stats;
   stats.Reset();
 
-  EXPECT_EQ(stats.GetPosCount(static_cast<ABCountType>(-1)), 0);
+  EXPECT_EQ(stats.GetPosCount(-1), 0);
   EXPECT_EQ(stats.GetPosCount(AB_SIZE), 0);
+  EXPECT_EQ(stats.GetPosCount(100), 0);
 }

--- a/library/tests/ab_search/ab_stats_test.cpp
+++ b/library/tests/ab_search/ab_stats_test.cpp
@@ -9,6 +9,7 @@ TEST(ABstatsTest, GetPosCountStartsAtZeroAfterReset)
 {
   ABstats stats;
   stats.Reset();
+  stats.ResetCum();
 
   EXPECT_EQ(stats.GetPosCount(AB_MAIN_LOOKUP), 0);
 }
@@ -17,6 +18,7 @@ TEST(ABstatsTest, IncrPosIncrementsGetPosCount)
 {
   ABstats stats;
   stats.Reset();
+  stats.ResetCum();
 
   stats.IncrPos(AB_MAIN_LOOKUP, /*side=*/true, /*depth=*/20);
 
@@ -28,6 +30,7 @@ TEST(ABstatsTest, GetPosCountRejectsOutOfRangePlace)
 {
   ABstats stats;
   stats.Reset();
+  stats.ResetCum();
 
   EXPECT_EQ(stats.GetPosCount(-1), 0);
   EXPECT_EQ(stats.GetPosCount(AB_SIZE), 0);

--- a/library/tests/ab_search/ab_stats_test.cpp
+++ b/library/tests/ab_search/ab_stats_test.cpp
@@ -1,0 +1,34 @@
+/// @file ab_stats_test.cpp
+/// @brief Unit tests for ABstats counters used by AB_COUNT instrumentation.
+
+#include <gtest/gtest.h>
+
+#include <ab_stats.hpp>
+
+TEST(ABstatsTest, GetPosCountStartsAtZeroAfterReset)
+{
+  ABstats stats;
+  stats.Reset();
+
+  EXPECT_EQ(stats.GetPosCount(AB_MAIN_LOOKUP), 0);
+}
+
+TEST(ABstatsTest, IncrPosIncrementsGetPosCount)
+{
+  ABstats stats;
+  stats.Reset();
+
+  stats.IncrPos(AB_MAIN_LOOKUP, /*side=*/true, /*depth=*/20);
+
+  EXPECT_EQ(stats.GetPosCount(AB_MAIN_LOOKUP), 1);
+  EXPECT_EQ(stats.GetPosCount(AB_MOVE_LOOP), 0);
+}
+
+TEST(ABstatsTest, GetPosCountRejectsOutOfRangePlace)
+{
+  ABstats stats;
+  stats.Reset();
+
+  EXPECT_EQ(stats.GetPosCount(static_cast<ABCountType>(-1)), 0);
+  EXPECT_EQ(stats.GetPosCount(AB_SIZE), 0);
+}

--- a/library/tests/ab_search/tt_lookup_test.cpp
+++ b/library/tests/ab_search/tt_lookup_test.cpp
@@ -134,3 +134,33 @@ TEST_F(AbTtLookupTest, WorksForShallowDepthPath)
   EXPECT_EQ(ctx_->search().best_move_tt(shallow_depth).suit, 1);
   EXPECT_EQ(ctx_->search().best_move_tt(shallow_depth).rank, 13);
 }
+
+#ifdef DDS_AB_STATS
+TEST_F(AbTtLookupTest, HitCountsMainLookup)
+{
+  // AB_COUNT(AB_MAIN_LOOKUP, ...) must resolve thrp from the SolverContext.
+  SeedTtEntry(/*suit*/ 0, /*rank*/ 0);
+  ThreadData* thrp = ctx_->thread_ptr();
+  ASSERT_NE(thrp, nullptr);
+  thrp->ABStats.Reset();
+
+  bool score_flag = false;
+  ASSERT_TRUE(apply_ab_tt_lookup(
+      &pos_, target_, depth_, tricks_, hand_, *ctx_, score_flag));
+
+  EXPECT_EQ(thrp->ABStats.GetPosCount(AB_MAIN_LOOKUP), 1);
+}
+
+TEST_F(AbTtLookupTest, MissDoesNotCountMainLookup)
+{
+  ThreadData* thrp = ctx_->thread_ptr();
+  ASSERT_NE(thrp, nullptr);
+  thrp->ABStats.Reset();
+
+  bool score_flag = true;
+  ASSERT_FALSE(apply_ab_tt_lookup(
+      &pos_, target_, depth_, tricks_, hand_, *ctx_, score_flag));
+
+  EXPECT_EQ(thrp->ABStats.GetPosCount(AB_MAIN_LOOKUP), 0);
+}
+#endif

--- a/library/tests/ab_search/tt_lookup_test.cpp
+++ b/library/tests/ab_search/tt_lookup_test.cpp
@@ -143,6 +143,7 @@ TEST_F(AbTtLookupTest, HitCountsMainLookup)
   ThreadData* thrp = ctx_->thread_ptr();
   ASSERT_NE(thrp, nullptr);
   thrp->ABStats.Reset();
+  thrp->ABStats.ResetCum();
 
   bool score_flag = false;
   ASSERT_TRUE(apply_ab_tt_lookup(
@@ -156,6 +157,7 @@ TEST_F(AbTtLookupTest, MissDoesNotCountMainLookup)
   ThreadData* thrp = ctx_->thread_ptr();
   ASSERT_NE(thrp, nullptr);
   thrp->ABStats.Reset();
+  thrp->ABStats.ResetCum();
 
   bool score_flag = true;
   ASSERT_FALSE(apply_ab_tt_lookup(


### PR DESCRIPTION
## Summary
- Fix `--define=ab_stats=true` compile failure: `apply_ab_tt_lookup` used `AB_COUNT` without a `thrp`.
- Add `ABstats::GetPosCount` plus unit/integration coverage for the TT-lookup counter path.
- Add a Linux CI step that builds `//library/src:dds` with `--define=ab_stats=true`.

## Test plan
- [x] `bazelisk build --define=ab_stats=true //library/src:dds`
- [x] `bazelisk test --define=ab_stats=true //library/tests/ab_search:tt_lookup_test`
- [x] `bazelisk test //library/tests/ab_search:ab_stats_test`
- [x] Confirm Linux CI runs the new ab_stats define build step


Made with [Cursor](https://cursor.com)