### PR TITLE
Improve dtest -r per-deal timing report

### DIFF
--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -87,7 +87,7 @@ auto solve_all_boards_n(
         dds::internal::worker_solver_context(),
         bds.deals[bno], bds.target[bno], bds.solutions[bno],
         bds.mode[bno], &fut);
-      auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+      auto dur = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - t0).count();
       if (dur < 0) dur = 0;
       scheduler.SetBoardTime(bno, static_cast<int>(dur));
@@ -280,7 +280,7 @@ auto solve_all_boards_n_seq(
       dds::internal::worker_solver_context(),
       bds.deals[bno], bds.target[bno], bds.solutions[bno],
       bds.mode[bno], &fut);
-    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(
+    auto dur = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::steady_clock::now() - t0).count();
     if (dur < 0) dur = 0;
     scheduler.SetBoardTime(bno, static_cast<int>(dur));

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -89,8 +89,7 @@ auto solve_all_boards_n(
         bds.mode[bno], &fut);
       auto dur = std::chrono::duration_cast<std::chrono::microseconds>(
         std::chrono::steady_clock::now() - t0).count();
-      if (dur < 0) dur = 0;
-      scheduler.SetBoardTime(bno, static_cast<int>(dur));
+      scheduler.SetBoardTime(bno, dur);
 
       if (res == RETURN_NO_FAULT)
         solved.solved_board[bno] = fut;
@@ -282,8 +281,7 @@ auto solve_all_boards_n_seq(
       bds.mode[bno], &fut);
     auto dur = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::steady_clock::now() - t0).count();
-    if (dur < 0) dur = 0;
-    scheduler.SetBoardTime(bno, static_cast<int>(dur));
+    scheduler.SetBoardTime(bno, dur);
 
     if (res == 1)
       solved.solved_board[bno] = fut;

--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 #include "deal_fanout.hpp"
 #include "scheduler.hpp"
@@ -990,13 +991,23 @@ void Scheduler::GetBoardTimes(std::vector<std::pair<int,int>>& outVec) const
 }
 
 
-void Scheduler::SetBoardTime(int boardIndex, int time_us)
+void Scheduler::SetBoardTime(int boardIndex, long long time_us)
 {
   if (boardIndex < 0 || boardIndex >= MAXNOOFBOARDS) return;
   // store in the hand time field; this is a lightweight fallback
   // for when DDS_SCHEDULER isn't enabled. No locking required for
   // single-writer per-board usage pattern from the solver threads.
-  hands[boardIndex].time = time_us;
+  hands[boardIndex].time = saturate_board_time_us(time_us);
+}
+
+auto saturate_board_time_us(long long time_us) -> int
+{
+  if (time_us <= 0)
+    return 0;
+  constexpr auto kMax = static_cast<long long>(std::numeric_limits<int>::max());
+  if (time_us >= kMax)
+    return std::numeric_limits<int>::max();
+  return static_cast<int>(time_us);
 }
 
 

--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -990,13 +990,13 @@ void Scheduler::GetBoardTimes(std::vector<std::pair<int,int>>& outVec) const
 }
 
 
-void Scheduler::SetBoardTime(int boardIndex, int timeMs)
+void Scheduler::SetBoardTime(int boardIndex, int time_us)
 {
   if (boardIndex < 0 || boardIndex >= MAXNOOFBOARDS) return;
   // store in the hand time field; this is a lightweight fallback
   // for when DDS_SCHEDULER isn't enabled. No locking required for
   // single-writer per-board usage pattern from the solver threads.
-  hands[boardIndex].time = timeMs;
+  hands[boardIndex].time = time_us;
 }
 
 

--- a/library/src/system/scheduler.hpp
+++ b/library/src/system/scheduler.hpp
@@ -210,14 +210,15 @@ class Scheduler
   /**
    * @brief Retrieve per-board raw times collected by the scheduler.
    *
-   * Fills outVec with pairs (boardIndex, userTimeMs) for each board in
-   * the current run. This is intended for post-run reporting.
+   * Fills outVec with pairs (boardIndex, userTimeUs) for each board in
+   * the current run. Times are wall-clock microseconds. This is intended
+   * for post-run reporting.
    */
   void GetBoardTimes(std::vector<std::pair<int,int>>& outVec) const;
 
-  // Lightweight API to set a board's time in ms for reporting when
+  // Lightweight API to set a board's time in microseconds for reporting when
   // full DDS_SCHEDULER timing is not enabled. Thread-safe for single-writer per-board.
-  void SetBoardTime(int boardIndex, int timeMs);
+  void SetBoardTime(int boardIndex, int time_us);
 
     // Release timing storage early to avoid heavy destructor work at exit.
     void ClearTiming();

--- a/library/src/system/scheduler.hpp
+++ b/library/src/system/scheduler.hpp
@@ -218,7 +218,8 @@ class Scheduler
 
   // Lightweight API to set a board's time in microseconds for reporting when
   // full DDS_SCHEDULER timing is not enabled. Thread-safe for single-writer per-board.
-  void SetBoardTime(int boardIndex, int time_us);
+  // Values outside `[0, INT_MAX]` are saturated into `HandType::time` storage.
+  void SetBoardTime(int boardIndex, long long time_us);
 
     // Release timing storage early to avoid heavy destructor work at exit.
     void ClearTiming();
@@ -236,5 +237,8 @@ class Scheduler
 #endif
 
 };
+
+/// Saturate a microsecond duration into the `int` used by `HandType::time`.
+auto saturate_board_time_us(long long time_us) -> int;
 
 #endif

--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -12,6 +12,7 @@ filegroup(
             "calc_par_test.cpp",  # Uses GoogleTest, compiled separately
             "test_timer_test.cpp",  # Uses GoogleTest, compiled separately
             "args_test.cpp",  # Uses GoogleTest, compiled separately
+            "report_board_timings_test.cpp",  # Uses GoogleTest, compiled separately
         ],
     ),
 )
@@ -95,6 +96,22 @@ cc_test(
         "args.cpp",
         "args.hpp",
         "cst.hpp",
+    ],
+    size = "small",
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    deps = [
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "report_board_timings_test",
+    srcs = [
+        "report_board_timings_test.cpp",
+        "report_board_timings.cpp",
+        "report_board_timings.hpp",
     ],
     size = "small",
     copts = DDS_CPPOPTS,

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -109,7 +109,8 @@ void usage(
     "                   the modern SolverContext API, prefer configuring\n" <<
     "                   memory via SolverConfig instead of this option.)\n" <<
     "\n" <<
-    "-r, --report       Print per-board timings sorted by longest first.\n" <<
+    "-r, --report       Print per-deal timings for every hand in the input\n"
+    "                   (solve mode), sorted by longest first.\n" <<
     "\n" <<
     endl;
 }

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -109,8 +109,8 @@ void usage(
     "                   the modern SolverContext API, prefer configuring\n" <<
     "                   memory via SolverConfig instead of this option.)\n" <<
     "\n" <<
-    "-r, --report       Print per-deal timings for every hand in the input\n"
-    "                   (solve mode), sorted by longest first.\n" <<
+    "-r, --report       Print per-deal timings in ms (one decimal) for every\n"
+    "                   hand in the input (solve mode), longest first.\n" <<
     "\n" <<
     endl;
 }

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -109,7 +109,7 @@ void usage(
     "                   the modern SolverContext API, prefer configuring\n" <<
     "                   memory via SolverConfig instead of this option.)\n" <<
     "\n" <<
-    "-r, --report       Print per-deal timings in ms (one decimal) for every\n"
+    "-r, --report       Print per-deal timings in ms (one decimal) for every\n" <<
     "                   hand in the input (solve mode), longest first.\n" <<
     "\n" <<
     endl;

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -17,10 +17,13 @@
 #include "compare.hpp"
 #include "print.hpp"
 #include <vector>
+#include <utility>
 
 #include "cst.hpp"
 #include "dtest_parallel.hpp"
+#include "report_board_timings.hpp"
 #include <solve_board.hpp>
+#include "system/scheduler.hpp"
 
 using std::cout;
 using std::endl;
@@ -32,6 +35,7 @@ using std::right;
 
 extern TestTimer timer;
 extern OptionsType options;
+extern Scheduler scheduler;
 
 
 void loop_solve(
@@ -40,7 +44,8 @@ void loop_solve(
   DealPBN * deal_list,
   FutureTricks * fut_list,
   const int number,
-  const int stepsize)
+  const int stepsize,
+  std::vector<std::pair<int, int>>* board_times)
 {
 #ifdef BATCHTIMES
   cout << setw(8) << left << "Hand no." << 
@@ -78,6 +83,13 @@ void loop_solve(
       exit(0);
     }
     timer.end();
+
+    if (board_times != nullptr)
+    {
+      std::vector<std::pair<int, int>> batch_times;
+      scheduler.GetBoardTimes(batch_times);
+      append_batch_board_times(*board_times, batch_times, i);
+    }
 
 #ifdef BATCHTIMES
     timer.print_running(i+count, number);

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -8,17 +8,16 @@
 */
 
 
-#include <iostream>
-#include <iomanip>
 #include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+#include <vector>
 
 #include "loop.hpp"
 #include "TestTimer.hpp"
 #include "compare.hpp"
 #include "print.hpp"
-#include <vector>
-#include <utility>
-
 #include "cst.hpp"
 #include "dtest_parallel.hpp"
 #include "report_board_timings.hpp"

--- a/library/tests/loop.hpp
+++ b/library/tests/loop.hpp
@@ -10,6 +10,8 @@
 #pragma once
 
 #include <api/dll.h>
+#include <utility>
+#include <vector>
 
 /// @file loop.hpp
 /// @brief Main test loop implementations for DDS solver testing.
@@ -23,14 +25,17 @@
 /// @param deal_list Input deals in PBN format
 /// @param fut_list Expected future tricks results
 /// @param number Number of deals in test set
-/// @param stepsize Reporting frequency
+/// @param stepsize Boards per solve batch (typically `MAXNOOFBOARDS`)
+/// @param board_times When non-null, appends per-deal timings for every batch
+///        with file-relative board indices (for `dtest -r`)
 void loop_solve(
     BoardsPBN * bop,
     SolvedBoards * solvedbdp,
     DealPBN * deal_list,
     FutureTricks * fut_list,
     const int number,
-    const int stepsize);
+    const int stepsize,
+    std::vector<std::pair<int, int>>* board_times = nullptr);
 
 /// Calculate loop: CalcAllTablesPBNX for the full deal list in one parallel job.
 /// Allocates its own flat deal/result buffers (unbounded X API); no legacy

--- a/library/tests/loop.hpp
+++ b/library/tests/loop.hpp
@@ -9,9 +9,10 @@
 
 #pragma once
 
-#include <api/dll.h>
 #include <utility>
 #include <vector>
+
+#include <api/dll.h>
 
 /// @file loop.hpp
 /// @brief Main test loop implementations for DDS solver testing.

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -62,7 +62,7 @@ void print_per_board_timings(
   const int ms_width = ms_column_width(times);
   const int board_width = board_column_width(times);
 
-  out << "Per-board timings (ms) sorted by longest first:\n";
+  out << "\nPer-board timings (ms) sorted by longest first:\n\n";
   out << std::right << std::setw(ms_width) << "ms" << "  "
       << std::setw(board_width) << "board" << "\n";
   out << std::fixed << std::setprecision(1);
@@ -72,7 +72,6 @@ void print_per_board_timings(
         << (static_cast<double>(p.second) / 1000.0) << "  "
         << std::setw(board_width) << p.first << "\n";
   }
-  out << "\n";
 }
 
 void append_batch_board_times(

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -1,0 +1,21 @@
+/// @file report_board_timings.cpp
+/// @brief Format dtest `-r` / `--report` per-board timing output.
+
+#include "report_board_timings.hpp"
+
+#include <algorithm>
+
+void print_per_board_timings(
+  std::ostream& out,
+  std::vector<std::pair<int, int>> times)
+{
+  std::sort(times.begin(), times.end(), [](const auto& a, const auto& b) {
+    return a.second > b.second;
+  });
+
+  out << "Per-board timings (ms) sorted by longest first:\n";
+  out << "ms\tboard\n";
+  for (const auto& p : times)
+    out << p.second << "\t" << p.first << "\n";
+  out << "\n";
+}

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -52,8 +52,8 @@ int ms_column_width(const std::vector<std::pair<int, int>>& times)
 }  // namespace
 
 void print_per_board_timings(
-  std::ostream& out,
-  std::vector<std::pair<int, int>> times)
+    std::ostream& out,
+    std::vector<std::pair<int, int>> times)
 {
   std::sort(times.begin(), times.end(), [](const auto& a, const auto& b) {
     return a.second > b.second;
@@ -82,9 +82,9 @@ void print_per_board_timings(
 }
 
 void append_batch_board_times(
-  std::vector<std::pair<int, int>>& accumulated,
-  const std::vector<std::pair<int, int>>& batch_times,
-  int file_offset)
+    std::vector<std::pair<int, int>>& accumulated,
+    const std::vector<std::pair<int, int>>& batch_times,
+    int file_offset)
 {
   accumulated.reserve(accumulated.size() + batch_times.size());
   for (const auto& p : batch_times)

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -4,6 +4,7 @@
 #include "report_board_timings.hpp"
 
 #include <algorithm>
+#include <iomanip>
 
 void print_per_board_timings(
   std::ostream& out,
@@ -15,8 +16,9 @@ void print_per_board_timings(
 
   out << "Per-board timings (ms) sorted by longest first:\n";
   out << "ms\tboard\n";
+  out << std::fixed << std::setprecision(1);
   for (const auto& p : times)
-    out << p.second << "\t" << p.first << "\n";
+    out << (static_cast<double>(p.second) / 1000.0) << "\t" << p.first << "\n";
   out << "\n";
 }
 

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -4,7 +4,52 @@
 #include "report_board_timings.hpp"
 
 #include <algorithm>
+#include <cstdlib>
 #include <iomanip>
+#include <sstream>
+
+namespace
+{
+
+int decimal_digits(int value)
+{
+  const int n = std::abs(value);
+  int digits = 1;
+  int x = n;
+  while (x >= 10)
+  {
+    x /= 10;
+    ++digits;
+  }
+  if (value < 0)
+    ++digits;
+  return digits;
+}
+
+int board_column_width(const std::vector<std::pair<int, int>>& times)
+{
+  constexpr int kHeaderWidth = 5;  // "board"
+  int width = kHeaderWidth;
+  for (const auto& p : times)
+    width = std::max(width, decimal_digits(p.first));
+  return width;
+}
+
+int ms_column_width(const std::vector<std::pair<int, int>>& times)
+{
+  constexpr int kHeaderWidth = 2;  // "ms"
+  int width = kHeaderWidth;
+  for (const auto& p : times)
+  {
+    std::ostringstream formatted;
+    formatted << std::fixed << std::setprecision(1)
+              << (static_cast<double>(p.second) / 1000.0);
+    width = std::max(width, static_cast<int>(formatted.str().size()));
+  }
+  return width;
+}
+
+}  // namespace
 
 void print_per_board_timings(
   std::ostream& out,
@@ -14,11 +59,19 @@ void print_per_board_timings(
     return a.second > b.second;
   });
 
+  const int ms_width = ms_column_width(times);
+  const int board_width = board_column_width(times);
+
   out << "Per-board timings (ms) sorted by longest first:\n";
-  out << "ms\tboard\n";
+  out << std::right << std::setw(ms_width) << "ms" << "  "
+      << std::setw(board_width) << "board" << "\n";
   out << std::fixed << std::setprecision(1);
   for (const auto& p : times)
-    out << (static_cast<double>(p.second) / 1000.0) << "\t" << p.first << "\n";
+  {
+    out << std::right << std::setw(ms_width)
+        << (static_cast<double>(p.second) / 1000.0) << "  "
+        << std::setw(board_width) << p.first << "\n";
+  }
   out << "\n";
 }
 

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -62,6 +62,10 @@ void print_per_board_timings(
   const int ms_width = ms_column_width(times);
   const int board_width = board_column_width(times);
 
+  // Preserve caller formatting; setw is one-shot but fixed/precision/align persist.
+  const auto saved_flags = out.flags();
+  const auto saved_precision = out.precision();
+
   out << "\nPer-board timings (ms) sorted by longest first:\n\n";
   out << std::right << std::setw(ms_width) << "ms" << "  "
       << std::setw(board_width) << "board" << "\n";
@@ -72,6 +76,9 @@ void print_per_board_timings(
         << (static_cast<double>(p.second) / 1000.0) << "  "
         << std::setw(board_width) << p.first << "\n";
   }
+
+  out.flags(saved_flags);
+  out.precision(saved_precision);
 }
 
 void append_batch_board_times(

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -19,3 +19,13 @@ void print_per_board_timings(
     out << p.second << "\t" << p.first << "\n";
   out << "\n";
 }
+
+void append_batch_board_times(
+  std::vector<std::pair<int, int>>& accumulated,
+  const std::vector<std::pair<int, int>>& batch_times,
+  int file_offset)
+{
+  accumulated.reserve(accumulated.size() + batch_times.size());
+  for (const auto& p : batch_times)
+    accumulated.emplace_back(p.first + file_offset, p.second);
+}

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -9,9 +9,20 @@
 
 /// Print per-board timings sorted by longest first.
 ///
-/// Each element of @p times is `(board_index, time_ms)`. Output includes a
-/// title line, a column-heading line (`ms` then `board`), then one row per
-/// board as `ms\\tboard`.
+/// Each element of @p times is `(board_index, time_ms)`, where `board_index`
+/// is the 0-based deal index in the input file. Output includes a title line,
+/// a column-heading line (`ms` then `board`), then one row per board as
+/// `ms\\tboard`.
 void print_per_board_timings(
   std::ostream& out,
   std::vector<std::pair<int, int>> times);
+
+/// Append one solve-batch's scheduler timings into a file-wide report.
+///
+/// @p batch_times entries use batch-local indices `(0 .. batch_size-1)`.
+/// Each is remapped to `board_index + file_offset` so multi-batch runs
+/// (chunks of `MAXNOOFBOARDS`) report every deal in the input file.
+void append_batch_board_times(
+  std::vector<std::pair<int, int>>& accumulated,
+  const std::vector<std::pair<int, int>>& batch_times,
+  int file_offset);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -15,8 +15,8 @@
 /// Both the `ms` and `board` columns are right-aligned with spaces (no tabs).
 /// Output includes a title line, a heading line, then one row per board.
 void print_per_board_timings(
-  std::ostream& out,
-  std::vector<std::pair<int, int>> times);
+    std::ostream& out,
+    std::vector<std::pair<int, int>> times);
 
 /// Append one solve-batch's scheduler timings into a file-wide report.
 ///
@@ -24,6 +24,6 @@ void print_per_board_timings(
 /// Each is remapped to `board_index + file_offset` so multi-batch runs
 /// (chunks of `MAXNOOFBOARDS`) report every deal in the input file.
 void append_batch_board_times(
-  std::vector<std::pair<int, int>>& accumulated,
-  const std::vector<std::pair<int, int>>& batch_times,
-  int file_offset);
+    std::vector<std::pair<int, int>>& accumulated,
+    const std::vector<std::pair<int, int>>& batch_times,
+    int file_offset);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -12,8 +12,8 @@
 /// Each element of @p times is `(board_index, time_us)`, where `board_index`
 /// is the 0-based deal index in the input file and `time_us` is wall time in
 /// microseconds. Printed times are milliseconds with one decimal place.
-/// Output includes a title line, a column-heading line (`ms` then `board`),
-/// then one row per board as `ms\\tboard`.
+/// Both the `ms` and `board` columns are right-aligned with spaces (no tabs).
+/// Output includes a title line, a heading line, then one row per board.
 void print_per_board_timings(
   std::ostream& out,
   std::vector<std::pair<int, int>> times);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -9,10 +9,11 @@
 
 /// Print per-board timings sorted by longest first.
 ///
-/// Each element of @p times is `(board_index, time_ms)`, where `board_index`
-/// is the 0-based deal index in the input file. Output includes a title line,
-/// a column-heading line (`ms` then `board`), then one row per board as
-/// `ms\\tboard`.
+/// Each element of @p times is `(board_index, time_us)`, where `board_index`
+/// is the 0-based deal index in the input file and `time_us` is wall time in
+/// microseconds. Printed times are milliseconds with one decimal place.
+/// Output includes a title line, a column-heading line (`ms` then `board`),
+/// then one row per board as `ms\\tboard`.
 void print_per_board_timings(
   std::ostream& out,
   std::vector<std::pair<int, int>> times);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -1,0 +1,17 @@
+/// @file report_board_timings.hpp
+/// @brief Format dtest `-r` / `--report` per-board timing output.
+
+#pragma once
+
+#include <ostream>
+#include <utility>
+#include <vector>
+
+/// Print per-board timings sorted by longest first.
+///
+/// Each element of @p times is `(board_index, time_ms)`. Output includes a
+/// title line, a column-heading line (`ms` then `board`), then one row per
+/// board as `ms\\tboard`.
+void print_per_board_timings(
+  std::ostream& out,
+  std::vector<std::pair<int, int>> times);

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -28,12 +28,12 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
   // Assert
   EXPECT_EQ(
     out.str(),
-    "Per-board timings (ms) sorted by longest first:\n"
+    "\nPer-board timings (ms) sorted by longest first:\n"
+    "\n"
     "  ms  board\n"
     "42.5      5\n"
     "10.1      2\n"
-    " 7.0      1\n"
-    "\n");
+    " 7.0      1\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
@@ -48,11 +48,11 @@ TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
 
   EXPECT_EQ(
     out.str(),
-    "Per-board timings (ms) sorted by longest first:\n"
+    "\nPer-board timings (ms) sorted by longest first:\n"
+    "\n"
     " ms  board\n"
     "2.0   3456\n"
-    "1.0     12\n"
-    "\n");
+    "1.0     12\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
@@ -71,13 +71,13 @@ TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
 
   EXPECT_EQ(
     out.str(),
-    "Per-board timings (ms) sorted by longest first:\n"
+    "\nPer-board timings (ms) sorted by longest first:\n"
+    "\n"
     "   ms  board\n"
     "202.0      1\n"
     "164.1     13\n"
     "158.4      7\n"
-    "148.3     92\n"
-    "\n");
+    "148.3     92\n");
 }
 
 TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
@@ -87,9 +87,9 @@ TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
 
   EXPECT_EQ(
     out.str(),
-    "Per-board timings (ms) sorted by longest first:\n"
-    "ms  board\n"
-    "\n");
+    "\nPer-board timings (ms) sorted by longest first:\n"
+    "\n"
+    "ms  board\n");
 }
 
 TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iomanip>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -90,6 +91,22 @@ TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
     "\nPer-board timings (ms) sorted by longest first:\n"
     "\n"
     "ms  board\n");
+}
+
+TEST(ReportBoardTimings, RestoresStreamFormattingState)
+{
+  // Arrange: caller-owned formatting that must survive the report printer.
+  std::ostringstream out;
+  out << std::scientific << std::setprecision(4) << std::left;
+  const auto flags_before = out.flags();
+  const auto precision_before = out.precision();
+
+  // Act
+  print_per_board_timings(out, {{1, 1000}});
+
+  // Assert
+  EXPECT_EQ(out.flags(), flags_before);
+  EXPECT_EQ(out.precision(), precision_before);
 }
 
 TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -13,6 +13,8 @@
 TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
 {
   // Arrange: stored times are microseconds; report shows ms with one decimal.
+  // Both columns are space-padded and right-aligned (no tabs — tab stops
+  // shift when the ms field width varies).
   std::vector<std::pair<int, int>> times = {
     {2, 10100},
     {5, 42500},
@@ -27,10 +29,54 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
   EXPECT_EQ(
     out.str(),
     "Per-board timings (ms) sorted by longest first:\n"
-    "ms\tboard\n"
-    "42.5\t5\n"
-    "10.1\t2\n"
-    "7.0\t1\n"
+    "  ms  board\n"
+    "42.5      5\n"
+    "10.1      2\n"
+    " 7.0      1\n"
+    "\n");
+}
+
+TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
+{
+  std::vector<std::pair<int, int>> times = {
+    {12, 1000},
+    {3456, 2000},
+  };
+  std::ostringstream out;
+
+  print_per_board_timings(out, times);
+
+  EXPECT_EQ(
+    out.str(),
+    "Per-board timings (ms) sorted by longest first:\n"
+    " ms  board\n"
+    "2.0   3456\n"
+    "1.0     12\n"
+    "\n");
+}
+
+TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
+{
+  // Tab-separated layout breaks once ms strings cross a tab stop; spaces keep
+  // the board column fixed.
+  std::vector<std::pair<int, int>> times = {
+    {1, 202000},
+    {13, 164100},
+    {7, 158400},
+    {92, 148300},
+  };
+  std::ostringstream out;
+
+  print_per_board_timings(out, times);
+
+  EXPECT_EQ(
+    out.str(),
+    "Per-board timings (ms) sorted by longest first:\n"
+    "   ms  board\n"
+    "202.0      1\n"
+    "164.1     13\n"
+    "158.4      7\n"
+    "148.3     92\n"
     "\n");
 }
 
@@ -42,7 +88,7 @@ TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
   EXPECT_EQ(
     out.str(),
     "Per-board timings (ms) sorted by longest first:\n"
-    "ms\tboard\n"
+    "ms  board\n"
     "\n");
 }
 

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -45,3 +45,37 @@ TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
     "ms\tboard\n"
     "\n");
 }
+
+TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)
+{
+  // Arrange: two MAXNOOFBOARDS-sized chunks would look like this after
+  // RegisterRun resets scheduler times between batches.
+  std::vector<std::pair<int, int>> accumulated;
+  const std::vector<std::pair<int, int>> first_batch = {
+    {0, 11},
+    {1, 22},
+  };
+  const std::vector<std::pair<int, int>> second_batch = {
+    {0, 33},
+    {1, 44},
+  };
+
+  // Act
+  append_batch_board_times(accumulated, first_batch, /*file_offset=*/0);
+  append_batch_board_times(accumulated, second_batch, /*file_offset=*/200);
+
+  // Assert: every input deal is present with its file index, not batch index.
+  ASSERT_EQ(accumulated.size(), 4u);
+  EXPECT_EQ(accumulated[0], (std::pair<int, int>{0, 11}));
+  EXPECT_EQ(accumulated[1], (std::pair<int, int>{1, 22}));
+  EXPECT_EQ(accumulated[2], (std::pair<int, int>{200, 33}));
+  EXPECT_EQ(accumulated[3], (std::pair<int, int>{201, 44}));
+}
+
+TEST(AppendBatchBoardTimes, EmptyBatchIsNoOp)
+{
+  std::vector<std::pair<int, int>> accumulated = {{7, 1}};
+  append_batch_board_times(accumulated, {}, /*file_offset=*/200);
+  ASSERT_EQ(accumulated.size(), 1u);
+  EXPECT_EQ(accumulated[0], (std::pair<int, int>{7, 1}));
+}

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -1,0 +1,47 @@
+/// @file report_board_timings_test.cpp
+/// @brief Unit tests for dtest `-r` per-board timing report formatting.
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "report_board_timings.hpp"
+
+TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
+{
+  // Arrange
+  std::vector<std::pair<int, int>> times = {
+    {2, 10},
+    {5, 42},
+    {1, 7},
+  };
+  std::ostringstream out;
+
+  // Act
+  print_per_board_timings(out, times);
+
+  // Assert
+  EXPECT_EQ(
+    out.str(),
+    "Per-board timings (ms) sorted by longest first:\n"
+    "ms\tboard\n"
+    "42\t5\n"
+    "10\t2\n"
+    "7\t1\n"
+    "\n");
+}
+
+TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
+{
+  std::ostringstream out;
+  print_per_board_timings(out, {});
+
+  EXPECT_EQ(
+    out.str(),
+    "Per-board timings (ms) sorted by longest first:\n"
+    "ms\tboard\n"
+    "\n");
+}

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -142,3 +142,19 @@ TEST(AppendBatchBoardTimes, EmptyBatchIsNoOp)
   ASSERT_EQ(accumulated.size(), 1u);
   EXPECT_EQ(accumulated[0], (std::pair<int, int>{7, 1}));
 }
+
+TEST(AppendBatchBoardTimes, PreReserveKeepsCapacityAcrossBatches)
+{
+  // Arrange: dtest -r reserves one slot per input deal before multi-batch appends.
+  std::vector<std::pair<int, int>> accumulated;
+  accumulated.reserve(4);
+  const auto capacity_before = accumulated.capacity();
+
+  // Act
+  append_batch_board_times(accumulated, {{0, 11}, {1, 22}}, /*file_offset=*/0);
+  append_batch_board_times(accumulated, {{0, 33}, {1, 44}}, /*file_offset=*/2);
+
+  // Assert: no reallocation beyond the file-wide reserve.
+  ASSERT_EQ(accumulated.size(), 4u);
+  EXPECT_EQ(accumulated.capacity(), capacity_before);
+}

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -12,11 +12,11 @@
 
 TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
 {
-  // Arrange
+  // Arrange: stored times are microseconds; report shows ms with one decimal.
   std::vector<std::pair<int, int>> times = {
-    {2, 10},
-    {5, 42},
-    {1, 7},
+    {2, 10100},
+    {5, 42500},
+    {1, 7000},
   };
   std::ostringstream out;
 
@@ -28,9 +28,9 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
     out.str(),
     "Per-board timings (ms) sorted by longest first:\n"
     "ms\tboard\n"
-    "42\t5\n"
-    "10\t2\n"
-    "7\t1\n"
+    "42.5\t5\n"
+    "10.1\t2\n"
+    "7.0\t1\n"
     "\n");
 }
 

--- a/library/tests/system/BUILD.bazel
+++ b/library/tests/system/BUILD.bazel
@@ -229,18 +229,17 @@ cc_test(
     ],
 )
 
-# Utilities snapshot tests
-# DISABLED: Tests for unimplemented log_snapshot() feature
 cc_test(
-    name = "utilities_log_snapshot_test",
-    srcs = ["utilities_log_snapshot_test.cpp"],
-    tags = ["manual"],
+    name = "scheduler_board_time_test",
+    size = "small",
+    srcs = ["scheduler_board_time_test.cpp"],
     deps = [
         "//library/src:testable_dds",
         "//library/src/api:api_definitions",
         "@googletest//:gtest_main",
     ],
 )
+
 
 # Utilities stats tests
 cc_test(

--- a/library/tests/system/BUILD.bazel
+++ b/library/tests/system/BUILD.bazel
@@ -240,6 +240,18 @@ cc_test(
     ],
 )
 
+# Utilities snapshot tests
+# DISABLED: Tests for unimplemented log_snapshot() feature
+cc_test(
+    name = "utilities_log_snapshot_test",
+    srcs = ["utilities_log_snapshot_test.cpp"],
+    tags = ["manual"],
+    deps = [
+        "//library/src:testable_dds",
+        "//library/src/api:api_definitions",
+        "@googletest//:gtest_main",
+    ],
+)
 
 # Utilities stats tests
 cc_test(

--- a/library/tests/system/scheduler_board_time_test.cpp
+++ b/library/tests/system/scheduler_board_time_test.cpp
@@ -1,0 +1,33 @@
+/// @file scheduler_board_time_test.cpp
+/// @brief Unit tests for saturating per-board microsecond timings into int storage.
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <system/scheduler.hpp>
+
+TEST(SaturateBoardTimeUs, ClampsAboveIntMax)
+{
+  // Arrange
+  const long long too_large =
+    static_cast<long long>(std::numeric_limits<int>::max()) + 1;
+
+  // Act / Assert
+  EXPECT_EQ(saturate_board_time_us(too_large), std::numeric_limits<int>::max());
+}
+
+TEST(SaturateBoardTimeUs, ClampsNegativeToZero)
+{
+  EXPECT_EQ(saturate_board_time_us(-1), 0);
+  EXPECT_EQ(saturate_board_time_us(-5), 0);
+}
+
+TEST(SaturateBoardTimeUs, PreservesInRangeValues)
+{
+  EXPECT_EQ(saturate_board_time_us(0), 0);
+  EXPECT_EQ(saturate_board_time_us(12345), 12345);
+  EXPECT_EQ(
+    saturate_board_time_us(std::numeric_limits<int>::max()),
+    std::numeric_limits<int>::max());
+}

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <utility>
 #include <vector>
 
 #include <api/dll.h>
@@ -112,9 +113,18 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
   PlayTracesPBN playsp;
   SolvedPlays solvedplp;
 
+  std::vector<std::pair<int, int>> board_times;
+
   if (options.solver_ == Solver::DTEST_SOLVER_SOLVE)
   {
-    loop_solve(&bop, &solvedbdp, deal_list, fut_list, number, stepsize);
+    loop_solve(
+      &bop,
+      &solvedbdp,
+      deal_list,
+      fut_list,
+      number,
+      stepsize,
+      options.report_slow_boards_ ? &board_times : nullptr);
   }
   else if (options.solver_ == Solver::DTEST_SOLVER_CALC)
   {
@@ -145,9 +155,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
 
   if (options.report_slow_boards_)
   {
-    std::vector<std::pair<int,int>> times;
-    scheduler.GetBoardTimes(times);
-    if (times.empty())
+    if (board_times.empty())
     {
       if (options.solver_ == Solver::DTEST_SOLVER_CALC)
       {
@@ -161,7 +169,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     }
     else
     {
-      print_per_board_timings(cout, times);
+      print_per_board_timings(cout, board_times);
     }
   }
 

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -169,7 +169,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     }
     else
     {
-      print_per_board_timings(cout, board_times);
+      print_per_board_timings(cout, std::move(board_times));
     }
   }
 

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -114,6 +114,8 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
   SolvedPlays solvedplp;
 
   std::vector<std::pair<int, int>> board_times;
+  if (options.report_slow_boards_)
+    board_times.reserve(static_cast<std::size_t>(number));
 
   if (options.solver_ == Solver::DTEST_SOLVER_SOLVE)
   {

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -10,7 +10,6 @@
 
 #include <iostream>
 #include <iomanip>
-#include <algorithm>
 #include <vector>
 
 #include <api/dll.h>
@@ -21,6 +20,7 @@
 #include "loop.hpp"
 #include "print.hpp"
 #include "cst.hpp"
+#include "report_board_timings.hpp"
 #include "system/scheduler.hpp"
 
 using std::cout;
@@ -161,15 +161,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
     }
     else
     {
-      // Sort by time desc
-      std::sort(times.begin(), times.end(), [](const auto &a, const auto &b){
-        return a.second > b.second;
-      });
-
-      cout << "Per-board timings (ms) sorted by longest first:\n";
-      for (const auto &p : times)
-        cout << p.second << "\t" << p.first << "\n";
-      cout << endl;
+      print_per_board_timings(cout, times);
     }
   }
 


### PR DESCRIPTION
## Summary
- Add column headings and right-aligned `ms` / `board` columns for `dtest -r` (space-padded, no tabs).
- Accumulate timings across every solve batch so reports cover all input deals, not only the last `MAXNOOFBOARDS` chunk; `board` is the 0-based file deal index.
- Measure in microseconds and print milliseconds with one decimal place; tighten blank lines around the report title.

## Test plan
- [x] `bazelisk test //library/tests:report_board_timings_test`
- [x] `bazelisk run //library/tests:dtest -- -f 100 -r` and confirm every deal appears with aligned columns
- [x] Spot-check a file larger than 200 deals so multi-batch accumulation is visible


Made with [Cursor](https://cursor.com)