### PR TITLE
Add GitHub Pages deploy for DDS Web

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -1,0 +1,86 @@
+# .github/workflows/deploy_pages.yml
+# Build DDS Web (WASM) and publish to GitHub Pages.
+# COOP/COEP for SharedArrayBuffer come from web/coi-serviceworker.js (Pages
+# cannot set custom response headers).
+name: Deploy DDS Web to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - "library/**"
+      - "MODULE.bazel"
+      - "MODULE.bazel.lock"
+      - "CPPVARIABLES.bzl"
+      - "wasm_compat.bzl"
+      - ".bazelrc"
+      - ".github/workflows/deploy_pages.yml"
+      - ".github/actions/setup-bazelisk/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Setup Bazelisk
+        uses: ./.github/actions/setup-bazelisk
+
+      - name: Prefetch external repos
+        run: |
+          max=3
+          for i in $(seq 1 "$max"); do
+            if bazelisk fetch //web:dds_web_wasm; then
+              exit 0
+            fi
+            if [ "$i" -lt "$max" ]; then
+              echo "Fetch failed (attempt $i/$max). Retrying in 20s..."
+              sleep 20
+            fi
+          done
+          exit 1
+
+      - name: Build and stage DDS Web site
+        run: |
+          ./web/update_wasm.sh
+          python3 web/stage_github_pages.py --out _site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -6,7 +6,7 @@ name: Deploy DDS Web to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
     paths:
       - "web/**"
       - "library/**"

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -111,7 +111,7 @@ and loads it from `dds_web.html` so a service worker can inject the headers on
 first visit. Local `serve_web.py` already isolates the origin, so the worker
 does not register there.
 
-Deploy workflow: `.github/workflows/deploy_pages.yml` (push to `main` under
+Deploy workflow: `.github/workflows/deploy_pages.yml` (push to `develop` under
 `web/` / WASM deps, or `workflow_dispatch`). It builds WASM, stages with
 `python3 web/stage_github_pages.py --out _site`, and publishes via
 `actions/deploy-pages`.

--- a/docs/wasm_build.md
+++ b/docs/wasm_build.md
@@ -103,6 +103,30 @@ load but solving reports that `SharedArrayBuffer` is unavailable.
 `file://` is still fine for UI-only browsing; run a solve over the isolated HTTP
 server.
 
+### GitHub Pages
+
+GitHub Pages cannot set custom COOP/COEP headers. DDS Web vendors
+`web/coi-serviceworker.js` (MIT, [coi-serviceworker](https://github.com/gzuidhof/coi-serviceworker))
+and loads it from `dds_web.html` so a service worker can inject the headers on
+first visit. Local `serve_web.py` already isolates the origin, so the worker
+does not register there.
+
+Deploy workflow: `.github/workflows/deploy_pages.yml` (push to `main` under
+`web/` / WASM deps, or `workflow_dispatch`). It builds WASM, stages with
+`python3 web/stage_github_pages.py --out _site`, and publishes via
+`actions/deploy-pages`.
+
+One-time repo setup: **Settings → Pages → Build and deployment → Source:
+GitHub Actions**. After a successful run the site is at
+`https://<owner>.github.io/<repo>/` (`index.html` is a copy of `dds_web.html`).
+
+Manual stage (after `./web/update_wasm.sh`):
+
+```bash
+python3 web/stage_github_pages.py --out _site
+# serve _site with COOP/COEP, or rely on coi-serviceworker.js on Pages
+```
+
 DDS Web loads wasm from `dds_web_wasm_bin.js` (base64, no network fetch). Run
 `./web/update_wasm.sh` to refresh `dds_web_wasm.{js,wasm,bin.js}` (includes a
 small post-process step for Emscripten `isFileURI`; see **Emscripten / emsdk

--- a/specs/web.md
+++ b/specs/web.md
@@ -1,7 +1,7 @@
 ---
 capability: web
 owners: [web]
-last-updated: 2026-08-09
+last-updated: 2026-08-10
 ---
 
 # DDS Web
@@ -45,7 +45,10 @@ DOM wiring) with an automated test pyramid.
   `python3 web/serve_web.py` (not plain `http.server`). `file://` remains useful
   for UI-only checks; instantiating the solver module for a solve needs HTTP +
   those headers on any host. Guarded by `dds_web_e2e_test` (`test_http_is_cross_origin_isolated`,
-  HTTP part-score solve / auto-filled DD table).
+  HTTP part-score solve / auto-filled DD table). GitHub Pages cannot set those
+  headers; `coi-serviceworker.js` (loaded from `dds_web.html`) injects them via
+  a service worker. Staging for Pages is `web/stage_github_pages.py`; deploy is
+  `.github/workflows/deploy_pages.yml`.
 - **Three test tiers, with suite membership as wired in BUILD:**
   - **Unit / JS** (`web_tests`): `dds_web_wasm_test` (native `cc_test` over the
     solve logic with `DDS_WEB_WASM_NO_MAIN`), `dds_web_js_test` (Node runs
@@ -79,11 +82,14 @@ DOM wiring) with an automated test pyramid.
 
 ## Key entry points
 
-- `web/BUILD.bazel` — `dds_web_wasm(_cc)`, `web_site`, the five test targets
-  (`dds_web_wasm_test`, three `py_test`s, `dds_web_e2e_test`), and the
+- `web/BUILD.bazel` — `dds_web_wasm(_cc)`, `web_site`, the test targets
+  (`dds_web_wasm_test`, py_tests, `dds_web_e2e_test`), and the
   `web_tests` / `web_system_tests` / `web_e2e_tests` suites; `WASM_WEB_LINKOPTS`.
 - `web/dds_web_wasm.cpp` — the native WASM bridge (`dds_web_calc_table`).
 - `web/{dds_web.html,dds_web.css,dds_web.js}` — the page and JS glue.
+- `web/coi-serviceworker.js` — COOP/COEP via service worker for hosts without
+  custom headers (GitHub Pages).
+- `web/stage_github_pages.py` — stage static site + `index.html` for Pages.
 - `web/serve_web.py` — local HTTP server with COOP/COEP.
 - `web/{gen_wasm_bin_js,patch_web_wasm,verify_wasm_js}.py` — build/patch helpers.
 

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -82,7 +82,18 @@ py_test(
     size = "small",
     main = "tests/test_web_html.py",
     srcs = ["tests/test_web_html.py"],
-    data = ["dds_web.html"],
+    data = [
+        "coi-serviceworker.js",
+        "dds_web.html",
+    ],
+)
+
+py_test(
+    name = "stage_github_pages_test",
+    size = "small",
+    main = "tests/test_stage_github_pages.py",
+    srcs = ["tests/test_stage_github_pages.py"],
+    data = ["stage_github_pages.py"],
 )
 
 py_test(
@@ -106,6 +117,7 @@ py_test(
     srcs = ["tests/test_wasm_system.py"],
     data = [
         ":dds_web_wasm",
+        "coi-serviceworker.js",
         "dds_web.css",
         "dds_web.html",
         "dds_web.js",
@@ -127,6 +139,7 @@ py_test(
     srcs = ["tests/test_web_e2e.py"],
     data = [
         ":dds_web_wasm",
+        "coi-serviceworker.js",
         "dds_web.css",
         "dds_web.html",
         "dds_web.js",
@@ -150,6 +163,7 @@ test_suite(
         ":dds_web_html_test",
         ":dds_web_js_test",
         ":dds_web_wasm_test",
+        ":stage_github_pages_test",
         ":wasm_scripts_test",
     ],
 )

--- a/web/coi-serviceworker.js
+++ b/web/coi-serviceworker.js
@@ -1,0 +1,146 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}

--- a/web/dds_web.html
+++ b/web/dds_web.html
@@ -11,11 +11,13 @@
        python3 web/serve_web.py
      Then open http://127.0.0.1:8080/dds_web.html
      (file:// UI works; solving needs SharedArrayBuffer via HTTP + COOP/COEP.)
+     GitHub Pages cannot set COOP/COEP; coi-serviceworker.js supplies them.
 -->
 
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <script src="coi-serviceworker.js"></script>
     <link rel="stylesheet" type="text/css" href="dds_web.css">
     <title>
         DDS Web

--- a/web/stage_github_pages.py
+++ b/web/stage_github_pages.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Stage a publishable DDS Web directory for GitHub Pages (or any static host).
+
+Expects web/ to already contain patched WASM artifacts from ./web/update_wasm.sh.
+Copies the static site plus an index.html (same as dds_web.html) for the Pages root.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+DEPLOY_FILES = (
+    "dds_web.html",
+    "dds_web.css",
+    "dds_web.js",
+    "coi-serviceworker.js",
+    "dds_web_wasm.js",
+    "dds_web_wasm.wasm",
+    "dds_web_wasm_bin.js",
+)
+
+
+def stage_github_pages(web_root: Path, dest: Path) -> Path:
+    """Copy deployable DDS Web files from *web_root* into *dest*."""
+    missing = [name for name in DEPLOY_FILES if not (web_root / name).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"missing {missing[0]} under {web_root} "
+            "(run ./web/update_wasm.sh before staging)"
+        )
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in DEPLOY_FILES:
+        shutil.copyfile(web_root / name, dest / name)
+    shutil.copyfile(dest / "dds_web.html", dest / "index.html")
+    return dest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--web-root",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="Directory with DDS Web sources and WASM artifacts (default: web/)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Output directory for the staged site",
+    )
+    args = parser.parse_args()
+    try:
+        out = stage_github_pages(args.web_root.resolve(), args.out.resolve())
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Staged GitHub Pages site at {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/tests/test_stage_github_pages.py
+++ b/web/tests/test_stage_github_pages.py
@@ -1,0 +1,84 @@
+"""Tests for staging DDS Web artifacts for GitHub Pages."""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+WEB_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_stage_github_pages():
+    path = WEB_ROOT / "stage_github_pages.py"
+    spec = importlib.util.spec_from_file_location("stage_github_pages", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class StageGithubPagesTest(unittest.TestCase):
+    def test_stage_copies_site_wasm_coi_and_index(self) -> None:
+        stage = _load_stage_github_pages()
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as dest_dir:
+            src = Path(src_dir)
+            dest = Path(dest_dir)
+            for name in (
+                "dds_web.html",
+                "dds_web.css",
+                "dds_web.js",
+                "coi-serviceworker.js",
+                "dds_web_wasm.js",
+                "dds_web_wasm.wasm",
+                "dds_web_wasm_bin.js",
+            ):
+                (src / name).write_text(f"content:{name}", encoding="utf-8")
+
+            # Act
+            out = stage.stage_github_pages(src, dest)
+
+            # Assert
+            self.assertEqual(out, dest)
+            for name in (
+                "dds_web.html",
+                "dds_web.css",
+                "dds_web.js",
+                "coi-serviceworker.js",
+                "dds_web_wasm.js",
+                "dds_web_wasm.wasm",
+                "dds_web_wasm_bin.js",
+                "index.html",
+            ):
+                path = dest / name
+                self.assertTrue(path.is_file(), msg=f"missing {name}")
+            self.assertEqual(
+                (dest / "index.html").read_text(encoding="utf-8"),
+                (dest / "dds_web.html").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                (dest / "coi-serviceworker.js").read_text(encoding="utf-8"),
+                "content:coi-serviceworker.js",
+            )
+
+    def test_stage_fails_when_required_file_missing(self) -> None:
+        stage = _load_stage_github_pages()
+        with tempfile.TemporaryDirectory() as src_dir, tempfile.TemporaryDirectory() as dest_dir:
+            src = Path(src_dir)
+            dest = Path(dest_dir)
+            (src / "dds_web.html").write_text("<html></html>", encoding="utf-8")
+            with self.assertRaises(FileNotFoundError) as ctx:
+                stage.stage_github_pages(src, dest)
+            self.assertIn("dds_web.css", str(ctx.exception))
+            self.assertEqual(list(dest.iterdir()), [])
+
+    def test_deploy_file_list_matches_static_plus_wasm(self) -> None:
+        stage = _load_stage_github_pages()
+        self.assertIn("coi-serviceworker.js", stage.DEPLOY_FILES)
+        self.assertIn("dds_web_wasm_bin.js", stage.DEPLOY_FILES)
+        self.assertNotIn("index.html", stage.DEPLOY_FILES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/tests/test_web_html.py
+++ b/web/tests/test_web_html.py
@@ -1,4 +1,4 @@
-"""Static checks for web/dds_web.html encoding."""
+"""Static checks for web/dds_web.html encoding and GitHub Pages COI wiring."""
 from __future__ import annotations
 
 import re
@@ -7,6 +7,7 @@ from pathlib import Path
 
 WEB_ROOT = Path(__file__).resolve().parents[1]
 HTML_PATH = WEB_ROOT / "dds_web.html"
+COI_PATH = WEB_ROOT / "coi-serviceworker.js"
 
 
 class DdsWebHtmlCharsetTest(unittest.TestCase):
@@ -37,6 +38,33 @@ class DdsWebHtmlCharsetTest(unittest.TestCase):
         text = HTML_PATH.read_text(encoding="utf-8")
         for glyph in ("♠", "♥", "♦", "♣"):
             self.assertIn(glyph, text)
+
+
+class DdsWebHtmlCoiTest(unittest.TestCase):
+    def test_loads_coi_serviceworker_in_head_before_app_scripts(self) -> None:
+        # GitHub Pages cannot set COOP/COEP; coi-serviceworker.js injects them.
+        # Load it in <head> before the large WASM scripts so the first-visit
+        # reload does not waste a full module download.
+        text = HTML_PATH.read_text(encoding="utf-8")
+        head_match = re.search(r"<head\b[^>]*>(.*?)</head>", text, re.I | re.S)
+        self.assertIsNotNone(head_match)
+        self.assertRegex(
+            head_match.group(1),
+            r'<script\s+src="coi-serviceworker\.js"\s*>\s*</script>',
+        )
+        coi_at = text.index('src="coi-serviceworker.js"')
+        wasm_at = text.index('src="dds_web_wasm.js"')
+        app_at = text.index('src="dds_web.js"')
+        self.assertLess(coi_at, wasm_at)
+        self.assertLess(coi_at, app_at)
+
+    def test_coi_serviceworker_sets_cross_origin_isolation_headers(self) -> None:
+        self.assertTrue(COI_PATH.is_file(), msg="vendored coi-serviceworker.js missing")
+        text = COI_PATH.read_text(encoding="utf-8")
+        self.assertIn("Cross-Origin-Opener-Policy", text)
+        self.assertIn("same-origin", text)
+        self.assertIn("Cross-Origin-Embedder-Policy", text)
+        self.assertIn("require-corp", text)
 
 
 if __name__ == "__main__":

--- a/web/tests/web_site.py
+++ b/web/tests/web_site.py
@@ -7,7 +7,12 @@ import os
 import shutil
 from pathlib import Path
 
-STATIC_FILES = ("dds_web.html", "dds_web.css", "dds_web.js")
+STATIC_FILES = (
+    "dds_web.html",
+    "dds_web.css",
+    "dds_web.js",
+    "coi-serviceworker.js",
+)
 
 # Required for SharedArrayBuffer / WASM pthreads in Chromium.
 CROSS_ORIGIN_ISOLATION_HEADERS = {


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds DDS Web WASM and publishes it to GitHub Pages from `develop`.
- Vendor `coi-serviceworker.js` and load it from `dds_web.html` so SharedArrayBuffer / pthread solves work on Pages (which cannot set COOP/COEP headers).
- Add `web/stage_github_pages.py` plus tests/docs for staging the static site (`index.html` + assets).

## Test plan
- [ ] `bazelisk test //web:dds_web_html_test //web:stage_github_pages_test //web:wasm_scripts_test`
- [ ] In a fork or after merge: set Pages source to **GitHub Actions**, run **Deploy DDS Web to GitHub Pages**, confirm `https://<owner>.github.io/<repo>/` loads and a solve succeeds after the first-visit COI reload
- [ ] Local: `python3 web/serve_web.py` still isolates without needing the service worker


Made with [Cursor](https://cursor.com)