### PR TITLE
Fix for WASM on iOS WebKit

### DIFF
--- a/web/dds_web.html
+++ b/web/dds_web.html
@@ -17,6 +17,11 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <!-- Safari / iOS WebKit (incl. Firefox on iPhone) ignore COEP credentialless
+         for isolation. DDS assets are same-origin, so require-corp is enough. -->
+    <script>
+    window.coi = { coepCredentialless: () => false };
+    </script>
     <script src="coi-serviceworker.js"></script>
     <link rel="stylesheet" type="text/css" href="dds_web.css">
     <title>

--- a/web/tests/test_web_html.py
+++ b/web/tests/test_web_html.py
@@ -58,6 +58,25 @@ class DdsWebHtmlCoiTest(unittest.TestCase):
         self.assertLess(coi_at, wasm_at)
         self.assertLess(coi_at, app_at)
 
+    def test_disables_coep_credentialless_before_coi_serviceworker(self) -> None:
+        # coi-serviceworker defaults to COEP: credentialless. Safari / iOS WebKit
+        # (including Firefox on iPhone) do not honor that value for isolation, so
+        # SharedArrayBuffer stays unavailable. DDS Web is same-origin only, so
+        # require-corp is correct — configure window.coi before the worker script.
+        text = HTML_PATH.read_text(encoding="utf-8")
+        head_match = re.search(r"<head\b[^>]*>(.*?)</head>", text, re.I | re.S)
+        self.assertIsNotNone(head_match)
+        head = head_match.group(1)
+        config_at = head.find("coepCredentialless")
+        worker_at = head.find('src="coi-serviceworker.js"')
+        self.assertNotEqual(config_at, -1, msg="must set window.coi.coepCredentialless")
+        self.assertNotEqual(worker_at, -1)
+        self.assertLess(config_at, worker_at)
+        self.assertRegex(
+            head,
+            r"coepCredentialless\s*:\s*\(\)\s*=>\s*false",
+        )
+
     def test_coi_serviceworker_sets_cross_origin_isolation_headers(self) -> None:
         self.assertTrue(COI_PATH.is_file(), msg="vendored coi-serviceworker.js missing")
         text = COI_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Force `coi-serviceworker` to use `COEP: require-corp` instead of `credentialless`, which Safari / iOS WebKit (including Chrome and Firefox on iPhone) do not treat as cross-origin isolation.
- DDS Web assets are all same-origin, so `require-corp` is sufficient and makes `SharedArrayBuffer` / pthread WASM reliable on GitHub Pages for iPhone browsers.
- Add an HTML unit test that the `window.coi` config is set before the worker script loads.

## Test plan
- [x] `bazel test //web:dds_web_html_test` (or `python3 -m unittest web.tests.test_web_html`)
- [ ] After merge + Pages deploy, open https://dds-bridge.github.io/dds/ on iPhone Safari/Firefox/Chrome
- [ ] Clear site data once if an old COI worker is stuck, reload, enter a test deal, confirm DD table solves (no SharedArrayBuffer error)
- [ ] Spot-check desktop Chrome/Firefox still solve as before


Made with [Cursor](https://cursor.com)