### PR TITLE
Bump Pages deploy actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -70,7 +70,7 @@ jobs:
           python3 web/stage_github_pages.py --out _site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -83,4 +83,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Update `actions/upload-pages-artifact` from v4 to v5 so it no longer pins Node 20 `upload-artifact` (`ea165f8…`).
- Update `actions/deploy-pages` from v4 to v5 for a matching Node 24 runtime.

## Test plan
- [ ] Confirm the Deploy DDS Web to GitHub Pages workflow runs without the Node.js 20 deprecation warning
- [ ] Confirm Pages still deploys successfully after merge to `develop`


Made with [Cursor](https://cursor.com)