### PR TITLE
Add dtest -r timing summary and two-decimal precision and fix for passouts

### DIFF
--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
             "test_timer_test.cpp",  # Uses GoogleTest, compiled separately
             "args_test.cpp",  # Uses GoogleTest, compiled separately
             "report_board_timings_test.cpp",  # Uses GoogleTest, compiled separately
+            "parse_par_test.cpp",  # Uses GoogleTest, compiled separately
         ],
     ),
 )
@@ -118,6 +119,23 @@ cc_test(
     linkopts = DDS_LINKOPTS,
     local_defines = DDS_LOCAL_DEFINES,
     deps = [
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "parse_par_test",
+    srcs = [
+        "parse_par_test.cpp",
+        "parse.cpp",
+        "parse.hpp",
+    ],
+    size = "small",
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    deps = [
+        "//library/src/api:api_definitions",
         "@googletest//:gtest_main",
     ],
 )

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -111,7 +111,7 @@ void usage(
     "\n" <<
     "-r, --report       Print per-deal timings in ms (two decimals) for every\n" <<
     "                   hand in the input (solve mode), longest first, plus\n" <<
-    "                   a min/max/mean/median summary.\n" <<
+    "                   a min/max/mean/median/stddev summary.\n" <<
     "\n" <<
     endl;
 }

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -109,7 +109,7 @@ void usage(
     "                   the modern SolverContext API, prefer configuring\n" <<
     "                   memory via SolverConfig instead of this option.)\n" <<
     "\n" <<
-    "-r, --report       Print per-deal timings in ms (one decimal) for every\n" <<
+    "-r, --report       Print per-deal timings in ms (two decimals) for every\n" <<
     "                   hand in the input (solve mode), longest first, plus\n" <<
     "                   a min/max/mean/median summary.\n" <<
     "\n" <<

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -110,7 +110,8 @@ void usage(
     "                   memory via SolverConfig instead of this option.)\n" <<
     "\n" <<
     "-r, --report       Print per-deal timings in ms (one decimal) for every\n" <<
-    "                   hand in the input (solve mode), longest first.\n" <<
+    "                   hand in the input (solve mode), longest first, plus\n" <<
+    "                   a min/max/mean/median summary.\n" <<
     "\n" <<
     endl;
 }

--- a/library/tests/parse.cpp
+++ b/library/tests/parse.cpp
@@ -376,9 +376,12 @@ bool parse_PAR(
   const vector<string>& list,
   ParResults * par)
 {
-  if (list.size() < 9)
+  // Minimum: PAR + 4 score tokens ("NS" score / "EW" score) + 2 contract
+  // tokens. Pass-out contracts ("NS:" / "EW:") have no internal spaces, so
+  // the line has only 7 whitespace tokens; normal contracts with spaces need 9+.
+  if (list.size() < 7)
   {
-    cout << "PAR list does not have 9+ elements: " << list.size() << endl;
+    cout << "PAR list does not have 7+ elements: " << list.size() << endl;
     return false;
   }
 

--- a/library/tests/parse_par_test.cpp
+++ b/library/tests/parse_par_test.cpp
@@ -1,0 +1,143 @@
+/// @file parse_par_test.cpp
+/// @brief Unit tests for dtest PAR-line parsing via read_file.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include <api/dll.h>
+
+#include "parse.hpp"
+
+namespace
+{
+
+auto write_temp_hand_list(const std::string& body) -> std::string
+{
+  const std::string path = "parse_par_test_hand.txt";
+  std::ofstream out(path);
+  out << "NUMBER 1 \n" << body;
+  out.close();
+  return path;
+}
+
+auto cleanup(const std::string& path) -> void
+{
+  std::remove(path.c_str());
+}
+
+}  // namespace
+
+TEST(ParsePar, AcceptsPassOutContractsWithoutInternalSpaces)
+{
+  // DDS pass-out contracts are "NS:" / "EW:" (no space). Whitespace-split that
+  // yields only 7 tokens; dtest must still accept the line.
+  const std::string path = write_temp_hand_list(
+      "PBN 0 2 4 0 \"N:AJ93.952.Q943.96 T74.84.AKJ6.QT72 K62.KJ6.872.AKJ3 "
+      "Q85.AQT73.T5.854\" \n"
+      "FUT 0 \n"
+      "TABLE 6 5 6 5 5 6 5 6 6 6 6 6 5 6 6 6 5 6 5 6 \n"
+      "PAR \"NS 0\" \"EW 0\" \"NS:\" \"EW:\" \n"
+      "PAR2 \"0\" \"pass\" \n"
+      "PLAY 0 \"\" \n"
+      "TRACE 1 0 \n");
+
+  int number = 0;
+  bool gib_mode = false;
+  int* dealer_list = nullptr;
+  int* vul_list = nullptr;
+  DealPBN* deal_list = nullptr;
+  FutureTricks* fut_list = nullptr;
+  DdTableResults* table_list = nullptr;
+  ParResults* par_list = nullptr;
+  ParResultsDealer* dealerpar_list = nullptr;
+  PlayTracePBN* play_list = nullptr;
+  SolvedPlay* trace_list = nullptr;
+
+  ASSERT_TRUE(read_file(
+      path,
+      number,
+      gib_mode,
+      &dealer_list,
+      &vul_list,
+      &deal_list,
+      &fut_list,
+      &table_list,
+      &par_list,
+      &dealerpar_list,
+      &play_list,
+      &trace_list));
+  ASSERT_EQ(number, 1);
+  ASSERT_NE(par_list, nullptr);
+  EXPECT_STREQ(par_list[0].par_score[0], "NS 0");
+  EXPECT_STREQ(par_list[0].par_score[1], "EW 0");
+  EXPECT_STREQ(par_list[0].par_contracts_string[0], "NS:");
+  EXPECT_STREQ(par_list[0].par_contracts_string[1], "EW:");
+
+  free(dealer_list);
+  free(vul_list);
+  free(deal_list);
+  free(fut_list);
+  free(table_list);
+  free(par_list);
+  free(dealerpar_list);
+  free(play_list);
+  free(trace_list);
+  cleanup(path);
+}
+
+TEST(ParsePar, StillAcceptsNormalContractsWithSpaces)
+{
+  const std::string path = write_temp_hand_list(
+      "PBN 0 0 0 0 \"N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 "
+      "AT942.AQ4.32.KJ3\" \n"
+      "FUT 0 \n"
+      "TABLE 5 8 5 8 6 6 6 6 5 7 5 7 7 5 7 5 6 6 6 6 \n"
+      "PAR \"NS -110\" \"EW 110\" \"NS:EW 2S\" \"EW:EW 2S\" \n"
+      "PAR2 \"-110\" \"2S-EW\" \n"
+      "PLAY 0 \"\" \n"
+      "TRACE 1 0 \n");
+
+  int number = 0;
+  bool gib_mode = false;
+  int* dealer_list = nullptr;
+  int* vul_list = nullptr;
+  DealPBN* deal_list = nullptr;
+  FutureTricks* fut_list = nullptr;
+  DdTableResults* table_list = nullptr;
+  ParResults* par_list = nullptr;
+  ParResultsDealer* dealerpar_list = nullptr;
+  PlayTracePBN* play_list = nullptr;
+  SolvedPlay* trace_list = nullptr;
+
+  ASSERT_TRUE(read_file(
+      path,
+      number,
+      gib_mode,
+      &dealer_list,
+      &vul_list,
+      &deal_list,
+      &fut_list,
+      &table_list,
+      &par_list,
+      &dealerpar_list,
+      &play_list,
+      &trace_list));
+  ASSERT_EQ(number, 1);
+  EXPECT_STREQ(par_list[0].par_contracts_string[0], "NS:EW 2S");
+  EXPECT_STREQ(par_list[0].par_contracts_string[1], "EW:EW 2S");
+
+  free(dealer_list);
+  free(vul_list);
+  free(deal_list);
+  free(fut_list);
+  free(table_list);
+  free(par_list);
+  free(dealerpar_list);
+  free(play_list);
+  free(trace_list);
+  cleanup(path);
+}

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -49,6 +49,42 @@ int ms_column_width(const std::vector<std::pair<int, int>>& times)
   return width;
 }
 
+/// @p times must be non-empty and sorted longest-first by time_us.
+struct TimingSummaryMs
+{
+  double min;
+  double max;
+  double mean;
+  double median;
+};
+
+auto timing_summary_ms(const std::vector<std::pair<int, int>>& times)
+    -> TimingSummaryMs
+{
+  const double min_ms = static_cast<double>(times.back().second) / 1000.0;
+  const double max_ms = static_cast<double>(times.front().second) / 1000.0;
+
+  double sum_us = 0.0;
+  for (const auto& p : times)
+    sum_us += static_cast<double>(p.second);
+  const double mean_ms = (sum_us / static_cast<double>(times.size())) / 1000.0;
+
+  const std::size_t n = times.size();
+  double median_ms = 0.0;
+  if (n % 2 == 1)
+  {
+    median_ms = static_cast<double>(times[n / 2].second) / 1000.0;
+  }
+  else
+  {
+    const double lo = static_cast<double>(times[n / 2].second);
+    const double hi = static_cast<double>(times[n / 2 - 1].second);
+    median_ms = ((lo + hi) / 2.0) / 1000.0;
+  }
+
+  return TimingSummaryMs{min_ms, max_ms, mean_ms, median_ms};
+}
+
 }  // namespace
 
 void print_per_board_timings(
@@ -75,6 +111,17 @@ void print_per_board_timings(
     out << std::right << std::setw(ms_width)
         << (static_cast<double>(p.second) / 1000.0) << "  "
         << std::setw(board_width) << p.first << "\n";
+  }
+
+  if (!times.empty())
+  {
+    const TimingSummaryMs summary = timing_summary_ms(times);
+    out << "\n"
+        << "min " << summary.min
+        << "  max " << summary.max
+        << "  mean " << summary.mean
+        << "  median " << summary.median
+        << "\n";
   }
 
   out.flags(saved_flags);

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -4,6 +4,7 @@
 #include "report_board_timings.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <iomanip>
 #include <sstream>
@@ -56,6 +57,7 @@ struct TimingSummaryMs
   double max;
   double mean;
   double median;
+  double stddev;
 };
 
 auto timing_summary_ms(const std::vector<std::pair<int, int>>& times)
@@ -82,7 +84,20 @@ auto timing_summary_ms(const std::vector<std::pair<int, int>>& times)
     median_ms = ((lo + hi) / 2.0) / 1000.0;
   }
 
-  return TimingSummaryMs{min_ms, max_ms, mean_ms, median_ms};
+  double stddev_ms = 0.0;
+  if (n > 1)
+  {
+    const double mean_us = sum_us / static_cast<double>(n);
+    double sum_sq_us = 0.0;
+    for (const auto& p : times)
+    {
+      const double d = static_cast<double>(p.second) - mean_us;
+      sum_sq_us += d * d;
+    }
+    stddev_ms = std::sqrt(sum_sq_us / static_cast<double>(n - 1)) / 1000.0;
+  }
+
+  return TimingSummaryMs{min_ms, max_ms, mean_ms, median_ms, stddev_ms};
 }
 
 }  // namespace
@@ -117,10 +132,11 @@ void print_per_board_timings(
   {
     const TimingSummaryMs summary = timing_summary_ms(times);
     out << "\n"
-        << "min " << summary.min
+        << "ms min " << summary.min
         << "  max " << summary.max
         << "  mean " << summary.mean
         << "  median " << summary.median
+        << "  stddev " << summary.stddev
         << "\n";
   }
 

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -42,7 +42,7 @@ int ms_column_width(const std::vector<std::pair<int, int>>& times)
   for (const auto& p : times)
   {
     std::ostringstream formatted;
-    formatted << std::fixed << std::setprecision(1)
+    formatted << std::fixed << std::setprecision(2)
               << (static_cast<double>(p.second) / 1000.0);
     width = std::max(width, static_cast<int>(formatted.str().size()));
   }
@@ -105,7 +105,7 @@ void print_per_board_timings(
   out << "\nPer-board timings (ms) sorted by longest first:\n\n";
   out << std::right << std::setw(ms_width) << "ms" << "  "
       << std::setw(board_width) << "board" << "\n";
-  out << std::fixed << std::setprecision(1);
+  out << std::fixed << std::setprecision(2);
   for (const auto& p : times)
   {
     out << std::right << std::setw(ms_width)

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -60,8 +60,7 @@ struct TimingSummaryMs
   double stddev;
 };
 
-auto timing_summary_ms(const std::vector<std::pair<int, int>>& times)
-    -> TimingSummaryMs
+TimingSummaryMs timing_summary_ms(const std::vector<std::pair<int, int>>& times)
 {
   const double min_ms = static_cast<double>(times.back().second) / 1000.0;
   const double max_ms = static_cast<double>(times.front().second) / 1000.0;

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -14,8 +14,10 @@
 /// microseconds. Printed times are milliseconds with two decimal places.
 /// Both the `ms` and `board` columns are right-aligned with spaces (no tabs).
 /// Output includes a title line, a heading line, one row per board, then a
-/// blank line and a summary of min/max/mean/median when @p times is non-empty.
-/// For an even count, median is the average of the two middle values.
+/// blank line and a summary of min/max/mean/median/stddev when @p times is
+/// non-empty. For an even count, median is the average of the two middle
+/// values. ``stddev`` is the sample standard deviation (n-1); for a single
+/// board it is 0.
 void print_per_board_timings(
     std::ostream& out,
     std::vector<std::pair<int, int>> times);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -13,7 +13,9 @@
 /// is the 0-based deal index in the input file and `time_us` is wall time in
 /// microseconds. Printed times are milliseconds with one decimal place.
 /// Both the `ms` and `board` columns are right-aligned with spaces (no tabs).
-/// Output includes a title line, a heading line, then one row per board.
+/// Output includes a title line, a heading line, one row per board, then a
+/// blank line and a summary of min/max/mean/median when @p times is non-empty.
+/// For an even count, median is the average of the two middle values.
 void print_per_board_timings(
     std::ostream& out,
     std::vector<std::pair<int, int>> times);

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -16,7 +16,7 @@
 /// Output includes a title line, a heading line, one row per board, then a
 /// blank line and a summary of min/max/mean/median/stddev when @p times is
 /// non-empty. For an even count, median is the average of the two middle
-/// values. ``stddev`` is the sample standard deviation (n-1); for a single
+/// values. `stddev` is the sample standard deviation (n-1); for a single
 /// board it is 0.
 void print_per_board_timings(
     std::ostream& out,

--- a/library/tests/report_board_timings.hpp
+++ b/library/tests/report_board_timings.hpp
@@ -11,7 +11,7 @@
 ///
 /// Each element of @p times is `(board_index, time_us)`, where `board_index`
 /// is the 0-based deal index in the input file and `time_us` is wall time in
-/// microseconds. Printed times are milliseconds with one decimal place.
+/// microseconds. Printed times are milliseconds with two decimal places.
 /// Both the `ms` and `board` columns are right-aligned with spaces (no tabs).
 /// Output includes a title line, a heading line, one row per board, then a
 /// blank line and a summary of min/max/mean/median when @p times is non-empty.

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -13,11 +13,11 @@
 
 TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
 {
-  // Arrange: stored times are microseconds; report shows ms with one decimal.
+  // Arrange: stored times are microseconds; report shows ms with two decimals.
   // Both columns are space-padded and right-aligned (no tabs — tab stops
   // shift when the ms field width varies).
-  // Summary uses the same ms scale: min 7.0, max 42.5,
-  // mean (42.5+10.1+7.0)/3 = 19.9, median 10.1.
+  // Summary uses the same ms scale: min 7.00, max 42.50,
+  // mean (42.50+10.10+7.00)/3 = 19.87, median 10.10.
   std::vector<std::pair<int, int>> times = {
     {2, 10100},
     {5, 42500},
@@ -33,12 +33,12 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
     out.str(),
     "\nPer-board timings (ms) sorted by longest first:\n"
     "\n"
-    "  ms  board\n"
-    "42.5      5\n"
-    "10.1      2\n"
-    " 7.0      1\n"
+    "   ms  board\n"
+    "42.50      5\n"
+    "10.10      2\n"
+    " 7.00      1\n"
     "\n"
-    "min 7.0  max 42.5  mean 19.9  median 10.1\n");
+    "min 7.00  max 42.50  mean 19.87  median 10.10\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
@@ -56,19 +56,19 @@ TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
     out.str(),
     "\nPer-board timings (ms) sorted by longest first:\n"
     "\n"
-    " ms  board\n"
-    "2.0   3456\n"
-    "1.0     12\n"
+    "  ms  board\n"
+    "2.00   3456\n"
+    "1.00     12\n"
     "\n"
-    "min 1.0  max 2.0  mean 1.5  median 1.5\n");
+    "min 1.00  max 2.00  mean 1.50  median 1.50\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
 {
   // Tab-separated layout breaks once ms strings cross a tab stop; spaces keep
   // the board column fixed.
-  // mean (202.0+164.1+158.4+148.3)/4 = 168.2;
-  // median avg(158.4, 164.1) = 161.25 → prints as 161.2 (half-to-even).
+  // mean (202.00+164.10+158.40+148.30)/4 = 168.20;
+  // median avg(158.40, 164.10) = 161.25.
   std::vector<std::pair<int, int>> times = {
     {1, 202000},
     {13, 164100},
@@ -83,13 +83,13 @@ TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
     out.str(),
     "\nPer-board timings (ms) sorted by longest first:\n"
     "\n"
-    "   ms  board\n"
-    "202.0      1\n"
-    "164.1     13\n"
-    "158.4      7\n"
-    "148.3     92\n"
+    "    ms  board\n"
+    "202.00      1\n"
+    "164.10     13\n"
+    "158.40      7\n"
+    "148.30     92\n"
     "\n"
-    "min 148.3  max 202.0  mean 168.2  median 161.2\n");
+    "min 148.30  max 202.00  mean 168.20  median 161.25\n");
 }
 
 TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
@@ -129,10 +129,10 @@ TEST(ReportBoardTimings, SingleBoardSummaryHasEqualStats)
     out.str(),
     "\nPer-board timings (ms) sorted by longest first:\n"
     "\n"
-    "  ms  board\n"
-    "12.5      3\n"
+    "   ms  board\n"
+    "12.50      3\n"
     "\n"
-    "min 12.5  max 12.5  mean 12.5  median 12.5\n");
+    "min 12.50  max 12.50  mean 12.50  median 12.50\n");
 }
 
 TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -16,6 +16,8 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
   // Arrange: stored times are microseconds; report shows ms with one decimal.
   // Both columns are space-padded and right-aligned (no tabs — tab stops
   // shift when the ms field width varies).
+  // Summary uses the same ms scale: min 7.0, max 42.5,
+  // mean (42.5+10.1+7.0)/3 = 19.9, median 10.1.
   std::vector<std::pair<int, int>> times = {
     {2, 10100},
     {5, 42500},
@@ -34,11 +36,14 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
     "  ms  board\n"
     "42.5      5\n"
     "10.1      2\n"
-    " 7.0      1\n");
+    " 7.0      1\n"
+    "\n"
+    "min 7.0  max 42.5  mean 19.9  median 10.1\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
 {
+  // Even count: median is the average of the two middle values.
   std::vector<std::pair<int, int>> times = {
     {12, 1000},
     {3456, 2000},
@@ -53,13 +58,17 @@ TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
     "\n"
     " ms  board\n"
     "2.0   3456\n"
-    "1.0     12\n");
+    "1.0     12\n"
+    "\n"
+    "min 1.0  max 2.0  mean 1.5  median 1.5\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
 {
   // Tab-separated layout breaks once ms strings cross a tab stop; spaces keep
   // the board column fixed.
+  // mean (202.0+164.1+158.4+148.3)/4 = 168.2;
+  // median avg(158.4, 164.1) = 161.25 → prints as 161.2 (half-to-even).
   std::vector<std::pair<int, int>> times = {
     {1, 202000},
     {13, 164100},
@@ -78,7 +87,9 @@ TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
     "202.0      1\n"
     "164.1     13\n"
     "158.4      7\n"
-    "148.3     92\n");
+    "148.3     92\n"
+    "\n"
+    "min 148.3  max 202.0  mean 168.2  median 161.2\n");
 }
 
 TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
@@ -107,6 +118,21 @@ TEST(ReportBoardTimings, RestoresStreamFormattingState)
   // Assert
   EXPECT_EQ(out.flags(), flags_before);
   EXPECT_EQ(out.precision(), precision_before);
+}
+
+TEST(ReportBoardTimings, SingleBoardSummaryHasEqualStats)
+{
+  std::ostringstream out;
+  print_per_board_timings(out, {{3, 12500}});
+
+  EXPECT_EQ(
+    out.str(),
+    "\nPer-board timings (ms) sorted by longest first:\n"
+    "\n"
+    "  ms  board\n"
+    "12.5      3\n"
+    "\n"
+    "min 12.5  max 12.5  mean 12.5  median 12.5\n");
 }
 
 TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -17,7 +17,8 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
   // Both columns are space-padded and right-aligned (no tabs — tab stops
   // shift when the ms field width varies).
   // Summary uses the same ms scale: min 7.00, max 42.50,
-  // mean (42.50+10.10+7.00)/3 = 19.87, median 10.10.
+  // mean (42.50+10.10+7.00)/3 = 19.87, median 10.10,
+  // sample stddev = 19.66.
   std::vector<std::pair<int, int>> times = {
     {2, 10100},
     {5, 42500},
@@ -38,7 +39,7 @@ TEST(ReportBoardTimings, PrintsColumnHeadingsThenSortedRows)
     "10.10      2\n"
     " 7.00      1\n"
     "\n"
-    "min 7.00  max 42.50  mean 19.87  median 10.10\n");
+    "ms min 7.00  max 42.50  mean 19.87  median 10.10  stddev 19.66\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
@@ -60,7 +61,7 @@ TEST(ReportBoardTimings, RightAlignsBoardWiderThanHeader)
     "2.00   3456\n"
     "1.00     12\n"
     "\n"
-    "min 1.00  max 2.00  mean 1.50  median 1.50\n");
+    "ms min 1.00  max 2.00  mean 1.50  median 1.50  stddev 0.71\n");
 }
 
 TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
@@ -68,7 +69,8 @@ TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
   // Tab-separated layout breaks once ms strings cross a tab stop; spaces keep
   // the board column fixed.
   // mean (202.00+164.10+158.40+148.30)/4 = 168.20;
-  // median avg(158.40, 164.10) = 161.25.
+  // median avg(158.40, 164.10) = 161.25;
+  // sample stddev = 23.46.
   std::vector<std::pair<int, int>> times = {
     {1, 202000},
     {13, 164100},
@@ -89,7 +91,7 @@ TEST(ReportBoardTimings, RightAlignsMixedMsWidthsWithSpaces)
     "158.40      7\n"
     "148.30     92\n"
     "\n"
-    "min 148.30  max 202.00  mean 168.20  median 161.25\n");
+    "ms min 148.30  max 202.00  mean 168.20  median 161.25  stddev 23.46\n");
 }
 
 TEST(ReportBoardTimings, EmptyInputPrintsTitleAndHeadingsOnly)
@@ -132,7 +134,7 @@ TEST(ReportBoardTimings, SingleBoardSummaryHasEqualStats)
     "   ms  board\n"
     "12.50      3\n"
     "\n"
-    "min 12.50  max 12.50  mean 12.50  median 12.50\n");
+    "ms min 12.50  max 12.50  mean 12.50  median 12.50  stddev 0.00\n");
 }
 
 TEST(AppendBatchBoardTimes, RemapsBatchLocalIndicesByFileOffset)


### PR DESCRIPTION
## Summary
- Add a min/max/mean/median/stddev summary line to `dtest -r` / `--report` output after the per-board timing table
- Print board and summary times with two decimal places instead of one
-- Bug fix - dtest could not handle passouts

## Test plan
- [x] `bazelisk test //library/tests:report_board_timings_test`
- [x] `bazelisk run //library/tests:dtest -- -f hands/list2.txt -s solve -r` and confirm the summary line and two-decimal formatting


Made with [Cursor](https://cursor.com)