### PR TITLE
.gitignore local Cursor settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Ignore Cursor or VS Code workspace files
 *.code-workspace
 
+# Ignore Cursor settings - For now, they are developer-specific.
+.cursor/*
+
 # Ignore Visual Studio directory and files
 .vs
 #*/.vs/*


### PR DESCRIPTION
## Summary
- Add `.cursor/*` to `.gitignore` so local Cursor IDE settings stay out of the repo.
- Cursor config is developer-specific for now, similar to how `.vscode/*` is handled.

## Test plan
- [x] Verified `.gitignore` syntax is valid
- [ ] Confirm no tracked files under `.cursor/` are removed unintentionally


Made with [Cursor](https://cursor.com)