### PR TITLE
Fix Bazel test timeout warnings for fast solver tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,7 +60,10 @@ build:asan --copt=-U_FORTIFY_SOURCE
 build:asan --strip=never
 build:asan --features=dbg
 build:asan --compilation_mode=dbg
-test:asan --test_timeout=120,300,900,3600
+# short=300: some small DDS solver tests need the moderate budget under
+# sanitizers; keep size="small" (no timeout="moderate") to avoid local
+# --test_verbose_timeout_warnings on fast non-sanitizer runs.
+test:asan --test_timeout=300,300,900,3600
 
 # GoogleTest headers can trigger conversion warnings on Clang; suppress them.
 # Scoped to `build` (not `test`) so the suppression also applies to plain
@@ -86,7 +89,7 @@ build:tsan --linkopt=-fsanitize=thread
 build:tsan --strip=never
 build:tsan --features=dbg
 build:tsan --compilation_mode=dbg
-test:tsan --test_timeout=120,300,900,3600
+test:tsan --test_timeout=300,300,900,3600
 # Hardcoded rpath: .../lib/clang/21/... must match MODULE.bazel llvm major and Xcode.
 build:tsan_macos --linkopt=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin
 
@@ -104,7 +107,7 @@ build:ubsan --copt=-fno-sanitize-recover=undefined
 build:ubsan --strip=never
 build:ubsan --features=dbg
 build:ubsan --compilation_mode=dbg
-test:ubsan --test_timeout=120,300,900,3600
+test:ubsan --test_timeout=300,300,900,3600
 # Hardcoded rpath: .../lib/clang/21/... must match MODULE.bazel llvm major and Xcode.
 build:ubsan_macos --linkopt=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/21/lib/darwin
 
@@ -118,4 +121,4 @@ build:msan --features=msan
 build:msan --strip=never
 build:msan --features=dbg
 build:msan --compilation_mode=dbg
-test:msan --test_timeout=120,300,900,3600
+test:msan --test_timeout=300,300,900,3600

--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -59,12 +59,13 @@ cc_test(
 )
 
 # Standalone calc_par API test.
-# medium: MSAN can spend ~80s on the remaining suite alone (small = 120s under
-# --config=msan), so keep headroom against runner load variance.
+# small: a few seconds normally. Sanitizer configs raise the short timeout in
+# .bazelrc so MSAN (~80s here) keeps headroom without timeout="moderate"
+# (which trips --test_verbose_timeout_warnings on fast local runs).
 cc_test(
     name = "calc_par_test",
     srcs = ["calc_par_test.cpp"],
-    size = "medium",
+    size = "small",
     copts = DDS_CPPOPTS,
     linkopts = DDS_LINKOPTS,
     local_defines = DDS_LOCAL_DEFINES,

--- a/library/tests/solve_board/BUILD.bazel
+++ b/library/tests/solve_board/BUILD.bazel
@@ -17,11 +17,12 @@ cc_test(
     copts = DDS_CPPOPTS,
 )
 
-# medium: MSAN can exceed the small-test limit (120s under --config=msan) on the
-# random-playout consistency suite, so keep headroom against runner load variance.
+# small: a few seconds normally. Sanitizer configs raise the short timeout in
+# .bazelrc so MSAN (can exceed 120s on this suite) keeps headroom without
+# timeout="moderate" (which trips --test_verbose_timeout_warnings on fast runs).
 cc_test(
     name = "analyse_play_consistency_test",
-    size = "medium",
+    size = "small",
     srcs = [
         "analyse_play_consistency.cpp",
     ],

--- a/library/tests/system/BUILD.bazel
+++ b/library/tests/system/BUILD.bazel
@@ -73,7 +73,7 @@ cc_test(
 
 cc_test(
     name = "calc_all_tables_x_test",
-    size = "medium",
+    size = "small",
     srcs = ["calc_all_tables_x_test.cpp"],
     deps = [
         "//library/src:testable_dds",


### PR DESCRIPTION
## Summary
- Reclassify `calc_par_test`, `analyse_play_consistency_test`, and `calc_all_tables_x_test` as `size = "small"` so fast local runs no longer warn under `--test_verbose_timeout_warnings`.
- Raise sanitizer short `--test_timeout` from 120s to 300s under ASAN/TSAN/UBSAN/MSAN so those tests keep the previous medium/MSAN headroom without `timeout = "moderate"`.

## Test plan
- [ ] `bazel test --test_verbose_timeout_warnings //library/tests:calc_par_test //library/tests/solve_board:analyse_play_consistency_test //library/tests/system:calc_all_tables_x_test`
- [ ] Confirm the MODERATE timeout warnings no longer appear
- [ ] CI sanitizer jobs (especially MSAN) still pass for these targets


Made with [Cursor](https://cursor.com)