### PR TITLE
Stabilize dd-table-before-leads web JS ordering test

### DIFF
--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -42,6 +42,15 @@ function findDdsWebJsPath() {
     throw new Error("dds_web.js not found");
 }
 
+/** Reject if `promise` does not settle within `ms` (clears the timer either way). */
+function withTimeout(promise, ms, message) {
+    let timer;
+    const timeout = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), ms);
+    });
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 function createMockDocument(initialValues = {}) {
     const store = new Map();
     const listeners = new Map();
@@ -503,6 +512,20 @@ test("page has no double-dummy button", () => {
     assert.doesNotMatch(css, /#double-dummy-it/);
 });
 
+test("withTimeout rejects when the promise never settles", async () => {
+    await assert.rejects(
+        () => withTimeout(new Promise(() => {}), 20, "timed out waiting"),
+        /timed out waiting/
+    );
+});
+
+test("withTimeout propagates rejection from the wrapped promise", async () => {
+    await assert.rejects(
+        () => withTimeout(Promise.reject(new Error("lead failed")), 1000, "timed out"),
+        /lead failed/
+    );
+});
+
 test("updateActionButtons finishes dd table before opening-lead refresh", async () => {
     // Arrange: a selected contract must not race CalcDDtable vs SolveBoard.
     const document = createMockDocument();
@@ -523,11 +546,15 @@ test("updateActionButtons finishes dd table before opening-lead refresh", async 
     await ctx.scheduleDealSolve();
     order.length = 0;
 
-    const leadsDone = new Promise((resolve) => {
+    const leadsDone = new Promise((resolve, reject) => {
         const refreshLeads = ctx.refreshOpeningLeadTricks;
         ctx.refreshOpeningLeadTricks = async () => {
-            await refreshLeads();
-            resolve();
+            try {
+                await refreshLeads();
+                resolve();
+            } catch (err) {
+                reject(err);
+            }
         };
     });
 
@@ -538,7 +565,11 @@ test("updateActionButtons finishes dd table before opening-lead refresh", async 
             },
         },
     });
-    await leadsDone;
+    await withTimeout(
+        leadsDone,
+        1000,
+        "timed out waiting for refreshOpeningLeadTricks"
+    );
 
     // Assert: contract click runs DD then leads in one job.
     assert.deepEqual(order, ["dd-start", "dd-end", "leads"]);

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -519,8 +519,17 @@ test("updateActionButtons finishes dd table before opening-lead refresh", async 
     };
 
     ctx.fillFormWithPartScoreTestData();
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Drain fillForm's auto-solve so a late dd-end cannot land after we clear.
+    await ctx.scheduleDealSolve();
     order.length = 0;
+
+    const leadsDone = new Promise((resolve) => {
+        const refreshLeads = ctx.refreshOpeningLeadTricks;
+        ctx.refreshOpeningLeadTricks = async () => {
+            await refreshLeads();
+            resolve();
+        };
+    });
 
     ctx.handleResultTableClick({
         target: {
@@ -529,9 +538,9 @@ test("updateActionButtons finishes dd table before opening-lead refresh", async 
             },
         },
     });
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await leadsDone;
 
-    // Assert: contract click runs DD (skip/no-op ok) then leads in one job.
+    // Assert: contract click runs DD then leads in one job.
     assert.deepEqual(order, ["dd-start", "dd-end", "leads"]);
 });
 


### PR DESCRIPTION
## Summary
- Fixes a flaky `//web:dds_web_js_test` failure where a late `dd-end` from `fillForm` could land after clearing the recorded event order.
- Drains the auto-solve queue and awaits the lead-refresh promise instead of fixed timeouts.

Split out of #315 (hand-list work); unrelated to that PR.

## Test plan
- [ ] `bazelisk test //web:dds_web_js_test --nocache_test_results` (repeat a few times)
- [ ] CI – Linux `build_and_test` green


Made with [Cursor](https://cursor.com)