### PR TITLE
Fix dd_table_for_deal par seats when contracts differ

### DIFF
--- a/python/utilities/src/dd_table_for_deal.py
+++ b/python/utilities/src/dd_table_for_deal.py
@@ -270,16 +270,19 @@ def _normalize_par_body(body: str) -> tuple[str, str] | None:
 
     normalized: list[str] = []
     result = "="
+    prev_seats: str | None = None
     for i, piece in enumerate(pieces):
         parsed = _normalize_contract_piece(piece)
         if parsed is None:
             return None
         seats, contract, piece_result = parsed
-        if i == 0:
+        if i == 0 or seats != prev_seats:
             normalized.append(f"{seats} {contract}")
-            result = piece_result
+            if i == 0:
+                result = piece_result
         else:
             normalized.append(contract)
+        prev_seats = seats
     return ", ".join(normalized), result
 
 

--- a/python/utilities/tests/test_dd_table_for_deal_par.py
+++ b/python/utilities/tests/test_dd_table_for_deal_par.py
@@ -264,14 +264,25 @@ class FormatParLineTest(unittest.TestCase):
             "Par: EW 3Dx, 3Cx -1 -100",
         )
 
-    def test_omits_repeated_declaring_side_when_seats_differ(self) -> None:
+    def test_includes_declaring_side_when_seats_differ(self) -> None:
+        # thomas1-style: W hearts / E clubs sacrifices — both seats matter.
+        par_results = {
+            "par_score": ["NS 100", "EW -100"],
+            "par_contracts_string": ["NS:W 3Hx,E 3Cx", "EW:W 3Hx,E 3Cx"],
+        }
+        self.assertEqual(
+            _format_par_line(par_results, vulnerable=0),
+            "Par: W 3Hx, E 3Cx -1 -100",
+        )
+
+    def test_includes_seat_when_second_contract_narrows_declaring_side(self) -> None:
         par_results = {
             "par_score": ["NS 100", "EW -100"],
             "par_contracts_string": ["NS:EW 4Hx,E 5Cx", "EW:EW 4Hx,E 5Cx"],
         }
         self.assertEqual(
             _format_par_line(par_results, vulnerable=0),
-            "Par: EW 4Hx, 5Cx -1 -100",
+            "Par: EW 4Hx, E 5Cx -1 -100",
         )
 
     def test_passed_out(self) -> None:

--- a/utilities/src/dd_table_for_deal/dd_table_for_deal_lib.cpp
+++ b/utilities/src/dd_table_for_deal/dd_table_for_deal_lib.cpp
@@ -257,7 +257,9 @@ auto format_par_line(ParResultsMaster const sidesRes[2])
   std::string body;
   for (int i = 0; i < chosen.number; ++i)
   {
-    const auto piece = format_contract(chosen.contracts[i], /*include_seats=*/i == 0);
+    const bool include_seats =
+        i == 0 || chosen.contracts[i].seats != chosen.contracts[i - 1].seats;
+    const auto piece = format_contract(chosen.contracts[i], include_seats);
     if (!piece)
       return std::nullopt;
     if (i > 0)

--- a/utilities/tests/dd_table_for_deal_test.cpp
+++ b/utilities/tests/dd_table_for_deal_test.cpp
@@ -260,7 +260,26 @@ TEST(FormatParLine, MultipleSacrificesOnOneLine)
 }
 
 
-TEST(FormatParLine, OmitsRepeatedDeclaringSideWhenSeatsDiffer)
+TEST(FormatParLine, IncludesDeclaringSideWhenSeatsDiffer)
+{
+  // thomas1-style: W can sacrifice in hearts, E in clubs — both seats matter.
+  ParResultsMaster sides[2]{};
+  sides[0].score = 100;
+  sides[0].number = 2;
+  sides[0].contracts[0] = make_contract(/*W*/ 3, 3, /*H*/ 2, 1, 0);
+  sides[0].contracts[1] = make_contract(/*E*/ 1, 3, /*C*/ 4, 1, 0);
+  sides[1].score = -100;
+  sides[1].number = 2;
+  sides[1].contracts[0] = make_contract(/*W*/ 3, 3, /*H*/ 2, 1, 0);
+  sides[1].contracts[1] = make_contract(/*E*/ 1, 3, /*C*/ 4, 1, 0);
+
+  const auto line = dd_table_for_deal::format_par_line(sides);
+  ASSERT_TRUE(line.has_value());
+  EXPECT_EQ(*line, "Par: W 3Hx, E 3Cx -1 -100");
+}
+
+
+TEST(FormatParLine, IncludesSeatWhenSecondContractNarrowsDeclaringSide)
 {
   ParResultsMaster sides[2]{};
   sides[0].score = 100;
@@ -274,7 +293,7 @@ TEST(FormatParLine, OmitsRepeatedDeclaringSideWhenSeatsDiffer)
 
   const auto line = dd_table_for_deal::format_par_line(sides);
   ASSERT_TRUE(line.has_value());
-  EXPECT_EQ(*line, "Par: EW 4Hx, 5Cx -1 -100");
+  EXPECT_EQ(*line, "Par: EW 4Hx, E 5Cx -1 -100");
 }
 
 


### PR DESCRIPTION
## Summary
* Fixes compact par output so a later contract keeps its declaring seat when it differs from the previous one (e.g. thomas1: `Par: W 3Hx, E 3Cx -1 -100` instead of `Par: W 3Hx, 3Cx -1 -100`).
* Same logic in the C++ and Python `dd_table_for_deal` formatters, with unit coverage for W/E and EW→E cases.

Closes #324

## Test plan
- [x] `bazelisk test //utilities:dd_table_for_deal_test //python/utilities:dd_table_for_deal_par_test`
- [x] Optional: `bazelisk run //utilities:dd_table_for_deal -- hands/thomas1.pbn` (slow) and confirm par line shows both seats


Made with [Cursor](https://cursor.com)