### PR TITLE
Fix dtest -f relative paths under bazel run

### DIFF
--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -468,10 +468,10 @@ void read_args(
         }
 
         cout << "Input file '" << optarg << "' not found\n";
-        cout << "Also tried that path (and hands/list" << optarg <<
-          ".txt) under the current directory, "
+        cout << "Also tried that path under the current directory, "
           "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
-          "and relative to the dtest binary\n";
+          "and relative to the dtest binary; "
+          "for numeric -f N, also hands/listN.txt\n";
         nextToken -= 2;
         errFlag = true;
         break;

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -365,17 +365,6 @@ string resolve_dtest_input_file(
     return dir;
   };
 
-  if (const string found =
-        from_env_dir("BUILD_WORKING_DIRECTORY", arg); !found.empty())
-  {
-    return found;
-  }
-  if (const string found =
-        from_env_dir("BUILD_WORKSPACE_DIRECTORY", arg); !found.empty())
-  {
-    return found;
-  }
-
   const fs::path list_rel = fs::path("hands") / list_name;
   if (const string found =
         from_env_dir("BUILD_WORKING_DIRECTORY", list_rel); !found.empty())
@@ -388,19 +377,33 @@ string resolve_dtest_input_file(
     return found;
   }
 
+  // Prefer list shorthand under bazel dirs / argv0 before a bare relative
+  // name (so -f 42 keeps resolving to hands/list42.txt even if a file named
+  // "42" exists at the workspace root).
+  if (const string found =
+        from_env_dir("BUILD_WORKING_DIRECTORY", arg); !found.empty())
+  {
+    return found;
+  }
+  if (const string found =
+        from_env_dir("BUILD_WORKSPACE_DIRECTORY", arg); !found.empty())
+  {
+    return found;
+  }
+
   const fs::path root = workspace_root_from_argv0();
   if (root.empty())
     return string();
-
-  const string bin_literal =
-    normalize_logical_path((root / arg).string());
-  if (path_exists(bin_literal))
-    return bin_literal;
 
   const string bin_candidate =
     normalize_logical_path((root / "hands" / list_name).string());
   if (path_exists(bin_candidate))
     return bin_candidate;
+
+  const string bin_literal =
+    normalize_logical_path((root / arg).string());
+  if (path_exists(bin_literal))
+    return bin_literal;
 
   return string();
 }

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -326,6 +326,10 @@ string resolve_dtest_input_file(
     return arg;
   if (is_absolute_path(arg))
     return string();
+  // Windows drive-relative "C:foo" has a root-name; fs::path join may discard
+  // the BUILD_* / argv0 base. Only the literal path is attempted.
+  if (fs::path(arg).has_root_name())
+    return string();
 
   const string list_name = "list" + arg + ".txt";
   // Keep generic separators so cwd hits match the documented hands/listN.txt form.
@@ -338,6 +342,8 @@ string resolve_dtest_input_file(
   // shell cwd and the workspace root so relative -f paths still resolve.
   auto from_env_dir = [&](const char* env_name, const fs::path& rel) -> string
   {
+    if (rel.has_root_name() || rel.has_root_directory())
+      return string();
     const char* dir = std::getenv(env_name);
     if (dir == nullptr || dir[0] == '\0')
       return string();
@@ -467,10 +473,15 @@ void read_args(
         }
 
         cout << "Input file '" << optarg << "' not found\n";
-        cout << "Also tried that path under the current directory, "
-          "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
-          "and under the workspace root inferred from the dtest binary; "
-          "for numeric -f N, also hands/listN.txt\n";
+        // Absolute / drive-relative args only attempt the literal path.
+        if (!is_dtest_absolute_path(optarg) &&
+          !fs::path(optarg).has_root_name())
+        {
+          cout << "Also tried that path under the current directory, "
+            "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
+            "and under the workspace root inferred from the dtest binary; "
+            "for numeric -f N, also hands/listN.txt\n";
+        }
         nextToken -= 2;
         errFlag = true;
         break;

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -318,6 +318,21 @@ bool is_dtest_absolute_path(const string& path)
 }
 
 
+bool is_dtest_list_shorthand_arg(const string& arg)
+{
+  if (arg.empty())
+    return false;
+  for (unsigned char c : arg)
+  {
+    if (c == '/' || c == '\\')
+      return false;
+    if (!std::isdigit(c))
+      return false;
+  }
+  return true;
+}
+
+
 string resolve_dtest_input_file(
   const string& arg,
   const string& argv0)
@@ -331,12 +346,17 @@ string resolve_dtest_input_file(
   if (fs::path(arg).has_root_name())
     return string();
 
-  const string list_name = "list" + arg + ".txt";
-  // Keep generic separators so cwd hits match the documented hands/listN.txt form.
-  const string cwd_candidate =
-    (fs::path("hands") / list_name).generic_string();
-  if (path_exists(cwd_candidate))
-    return cwd_candidate;
+  const bool use_list_shorthand = is_dtest_list_shorthand_arg(arg);
+  const string list_name = use_list_shorthand ? "list" + arg + ".txt" : string();
+
+  if (use_list_shorthand)
+  {
+    // Keep generic separators so cwd hits match the documented hands/listN.txt form.
+    const string cwd_candidate =
+      (fs::path("hands") / list_name).generic_string();
+    if (path_exists(cwd_candidate))
+      return cwd_candidate;
+  }
 
   // bazel run moves CWD into the runfiles tree; it exports the invoke-time
   // shell cwd and the workspace root so relative -f paths still resolve.
@@ -371,16 +391,19 @@ string resolve_dtest_input_file(
     return dir;
   };
 
-  const fs::path list_rel = fs::path("hands") / list_name;
-  if (const string found =
-        from_env_dir("BUILD_WORKING_DIRECTORY", list_rel); !found.empty())
+  if (use_list_shorthand)
   {
-    return found;
-  }
-  if (const string found =
-        from_env_dir("BUILD_WORKSPACE_DIRECTORY", list_rel); !found.empty())
-  {
-    return found;
+    const fs::path list_rel = fs::path("hands") / list_name;
+    if (const string found =
+          from_env_dir("BUILD_WORKING_DIRECTORY", list_rel); !found.empty())
+    {
+      return found;
+    }
+    if (const string found =
+          from_env_dir("BUILD_WORKSPACE_DIRECTORY", list_rel); !found.empty())
+    {
+      return found;
+    }
   }
 
   // Prefer list shorthand under bazel dirs / argv0 before a bare relative
@@ -401,10 +424,13 @@ string resolve_dtest_input_file(
   if (root.empty())
     return string();
 
-  const string bin_candidate =
-    normalize_logical_path((root / "hands" / list_name).string());
-  if (path_exists(bin_candidate))
-    return bin_candidate;
+  if (use_list_shorthand)
+  {
+    const string bin_candidate =
+      normalize_logical_path((root / "hands" / list_name).string());
+    if (path_exists(bin_candidate))
+      return bin_candidate;
+  }
 
   const string bin_literal =
     normalize_logical_path((root / arg).string());

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -309,14 +309,6 @@ string absolute_path_logical(const string& path)
   return normalize_logical_path((cwd / path).string());
 }
 
-}  // namespace
-
-
-bool is_dtest_absolute_path(const string& path)
-{
-  return is_absolute_path(path);
-}
-
 
 bool is_dtest_list_shorthand_arg(const string& arg)
 {
@@ -330,6 +322,14 @@ bool is_dtest_list_shorthand_arg(const string& arg)
       return false;
   }
   return true;
+}
+
+}  // namespace
+
+
+bool is_dtest_absolute_path(const string& path)
+{
+  return is_absolute_path(path);
 }
 
 

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -93,8 +93,8 @@ void usage(
     "                   Relative paths (and '100' → hands/list100.txt) are\n" <<
     "                   resolved under the current directory, then under\n" <<
     "                   BUILD_WORKING_DIRECTORY / BUILD_WORKSPACE_DIRECTORY\n" <<
-    "                   (bazel run), else relative to the dtest binary\n" <<
-    "                   (bazel-bin/library/tests/).\n" <<
+    "                   (bazel run), else under the workspace root inferred\n" <<
+    "                   from the dtest binary (bazel-bin/library/tests/).\n" <<
     "                   (Default: input.txt)\n" <<
     "\n" <<
     "-s, --solver       One of: solve, calc, play, par, dealerpar.\n" <<
@@ -466,7 +466,7 @@ void read_args(
         cout << "Input file '" << optarg << "' not found\n";
         cout << "Also tried that path under the current directory, "
           "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
-          "and relative to the dtest binary; "
+          "and under the workspace root inferred from the dtest binary; "
           "for numeric -f N, also hands/listN.txt\n";
         nextToken -= 2;
         errFlag = true;

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -324,6 +324,8 @@ string resolve_dtest_input_file(
 {
   if (path_exists(arg))
     return arg;
+  if (is_absolute_path(arg))
+    return string();
 
   const string list_name = "list" + arg + ".txt";
   // Keep generic separators so cwd hits match the documented hands/listN.txt form.
@@ -363,18 +365,15 @@ string resolve_dtest_input_file(
     return dir;
   };
 
-  if (!is_absolute_path(arg))
+  if (const string found =
+        from_env_dir("BUILD_WORKING_DIRECTORY", arg); !found.empty())
   {
-    if (const string found =
-          from_env_dir("BUILD_WORKING_DIRECTORY", arg); !found.empty())
-    {
-      return found;
-    }
-    if (const string found =
-          from_env_dir("BUILD_WORKSPACE_DIRECTORY", arg); !found.empty())
-    {
-      return found;
-    }
+    return found;
+  }
+  if (const string found =
+        from_env_dir("BUILD_WORKSPACE_DIRECTORY", arg); !found.empty())
+  {
+    return found;
   }
 
   const fs::path list_rel = fs::path("hands") / list_name;
@@ -393,13 +392,10 @@ string resolve_dtest_input_file(
   if (root.empty())
     return string();
 
-  if (!is_absolute_path(arg))
-  {
-    const string bin_literal =
-      normalize_logical_path((root / arg).string());
-    if (path_exists(bin_literal))
-      return bin_literal;
-  }
+  const string bin_literal =
+    normalize_logical_path((root / arg).string());
+  if (path_exists(bin_literal))
+    return bin_literal;
 
   const string bin_candidate =
     normalize_logical_path((root / "hands" / list_name).string());

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -90,10 +90,10 @@ void usage(
   cout <<
     "Usage: " << basename << " [options]\n\n" <<
     "-f, --file s       Input file, or the number n;\n" <<
-    "                   '100' means hands/list100.txt under the current\n" <<
-    "                   directory (or BUILD_WORKING_DIRECTORY /\n" <<
-    "                   BUILD_WORKSPACE_DIRECTORY under bazel run), else\n" <<
-    "                   relative to the dtest binary\n" <<
+    "                   Relative paths (and '100' → hands/list100.txt) are\n" <<
+    "                   resolved under the current directory, then under\n" <<
+    "                   BUILD_WORKING_DIRECTORY / BUILD_WORKSPACE_DIRECTORY\n" <<
+    "                   (bazel run), else relative to the dtest binary\n" <<
     "                   (bazel-bin/library/tests/).\n" <<
     "                   (Default: input.txt)\n" <<
     "\n" <<
@@ -333,39 +333,76 @@ string resolve_dtest_input_file(
     return cwd_candidate;
 
   // bazel run moves CWD into the runfiles tree; it exports the invoke-time
-  // shell cwd and the workspace root so we can still find hands/.
-  auto from_env_dir = [&](const char* env_name) -> string
+  // shell cwd and the workspace root so relative -f paths still resolve.
+  auto from_env_dir = [&](const char* env_name, const fs::path& rel) -> string
   {
     const char* dir = std::getenv(env_name);
     if (dir == nullptr || dir[0] == '\0')
       return string();
-    const string candidate = normalize_logical_path(
-      (fs::path(dir) / "hands" / list_name).string());
+    const string candidate =
+      normalize_logical_path((fs::path(dir) / rel).string());
     if (path_exists(candidate))
       return candidate;
     return string();
   };
 
-  if (const string found = from_env_dir("BUILD_WORKING_DIRECTORY"); !found.empty())
-    return found;
-  if (const string found = from_env_dir("BUILD_WORKSPACE_DIRECTORY"); !found.empty())
-    return found;
-
   // Climb parents in the path *string* (do not use "/../" with filesystem
   // resolution — that follows a bazel-bin symlink into the execroot and misses
   // the workspace hands/ directory). bazel-bin/library/tests/dtest → four
   // parent_path steps to the repo root.
-  fs::path dir(absolute_path_logical(argv0));
-  for (unsigned i = 0; i < 4; ++i)
+  auto workspace_root_from_argv0 = [&]() -> fs::path
   {
-    const fs::path parent = dir.parent_path();
-    if (parent.empty())
-      return string();
-    dir = parent;
+    fs::path dir(absolute_path_logical(argv0));
+    for (unsigned i = 0; i < 4; ++i)
+    {
+      const fs::path parent = dir.parent_path();
+      if (parent.empty())
+        return {};
+      dir = parent;
+    }
+    return dir;
+  };
+
+  if (!is_absolute_path(arg))
+  {
+    if (const string found =
+          from_env_dir("BUILD_WORKING_DIRECTORY", arg); !found.empty())
+    {
+      return found;
+    }
+    if (const string found =
+          from_env_dir("BUILD_WORKSPACE_DIRECTORY", arg); !found.empty())
+    {
+      return found;
+    }
+  }
+
+  const fs::path list_rel = fs::path("hands") / list_name;
+  if (const string found =
+        from_env_dir("BUILD_WORKING_DIRECTORY", list_rel); !found.empty())
+  {
+    return found;
+  }
+  if (const string found =
+        from_env_dir("BUILD_WORKSPACE_DIRECTORY", list_rel); !found.empty())
+  {
+    return found;
+  }
+
+  const fs::path root = workspace_root_from_argv0();
+  if (root.empty())
+    return string();
+
+  if (!is_absolute_path(arg))
+  {
+    const string bin_literal =
+      normalize_logical_path((root / arg).string());
+    if (path_exists(bin_literal))
+      return bin_literal;
   }
 
   const string bin_candidate =
-    normalize_logical_path((dir / "hands" / list_name).string());
+    normalize_logical_path((root / "hands" / list_name).string());
   if (path_exists(bin_candidate))
     return bin_candidate;
 
@@ -431,8 +468,8 @@ void read_args(
         }
 
         cout << "Input file '" << optarg << "' not found\n";
-        cout << "Also tried hands/list" << optarg <<
-          ".txt under the current directory, "
+        cout << "Also tried that path (and hands/list" << optarg <<
+          ".txt) under the current directory, "
           "BUILD_WORKING_DIRECTORY, BUILD_WORKSPACE_DIRECTORY, "
           "and relative to the dtest binary\n";
         nextToken -= 2;

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -33,8 +33,8 @@ void print_options();
 /// Resolve `-f` / `--file` to an existing regular file.
 ///
 /// Tries, in order: the literal path under the current working directory;
-/// `hands/list{arg}.txt` under cwd (list shorthand, intended for numeric
-/// ids such as `"100"`); that list form, then the literal relative path,
+/// for purely numeric `arg` (e.g. `"100"`), `hands/list{arg}.txt` under cwd;
+/// that list form, then the literal relative path,
 /// under `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` (set by
 /// `bazel run`); then those same two forms under the workspace root inferred
 /// by climbing four parents from `argv0` (the usual

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -34,7 +34,7 @@ void print_options();
 ///
 /// Tries, in order: the literal path under the current working directory;
 /// `hands/list{arg}.txt` under cwd (list shorthand, intended for numeric
-/// ids such as `"100"`); the literal relative path, then that list form,
+/// ids such as `"100"`); that list form, then the literal relative path,
 /// under `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` (set by
 /// `bazel run`); then those same two forms under the workspace root inferred
 /// by climbing four parents from `argv0` (the usual

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -32,12 +32,13 @@ void print_options();
 
 /// Resolve `-f` / `--file` to an existing regular file.
 ///
-/// Order: (1) `arg` as a literal path under the current working directory;
-/// (2) `hands/list{arg}.txt` under cwd; (3) the same literal relative path,
-/// then `hands/list{arg}.txt`, under `BUILD_WORKING_DIRECTORY` /
-/// `BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`); (4) those same two forms
-/// relative to the directory of `argv0` (the usual `bazel-bin/library/tests/dtest`
-/// layout). Absolute paths skip the bazel / argv0 relative retries.
+/// Tries, in order: the literal path under the current working directory;
+/// `hands/list{arg}.txt` under cwd (list shorthand, intended for numeric
+/// ids such as `"100"`); the literal relative path, then that list form,
+/// under `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` (set by
+/// `bazel run`); then those same two forms relative to the directory of
+/// `argv0` (the usual `bazel-bin/library/tests/dtest` layout). Absolute
+/// paths only attempt the literal path as given.
 /// Directories are not accepted (avoids treating e.g. `-f hands` as a file).
 /// @return Resolved path, or empty if no regular file is found
 std::string resolve_dtest_input_file(

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -32,10 +32,12 @@ void print_options();
 
 /// Resolve `-f` / `--file` to an existing regular file.
 ///
-/// Order: (1) `arg` as a literal path; (2) `hands/list{arg}.txt` under the
-/// current working directory; (3) the same under `BUILD_WORKING_DIRECTORY` /
-/// `BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`); (4) relative to the
-/// directory of `argv0` (the usual `bazel-bin/library/tests/dtest` layout).
+/// Order: (1) `arg` as a literal path under the current working directory;
+/// (2) `hands/list{arg}.txt` under cwd; (3) the same literal relative path,
+/// then `hands/list{arg}.txt`, under `BUILD_WORKING_DIRECTORY` /
+/// `BUILD_WORKSPACE_DIRECTORY` (set by `bazel run`); (4) those same two forms
+/// relative to the directory of `argv0` (the usual `bazel-bin/library/tests/dtest`
+/// layout). Absolute paths skip the bazel / argv0 relative retries.
 /// Directories are not accepted (avoids treating e.g. `-f hands` as a file).
 /// @return Resolved path, or empty if no regular file is found
 std::string resolve_dtest_input_file(

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -36,9 +36,10 @@ void print_options();
 /// `hands/list{arg}.txt` under cwd (list shorthand, intended for numeric
 /// ids such as `"100"`); the literal relative path, then that list form,
 /// under `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` (set by
-/// `bazel run`); then those same two forms relative to the directory of
-/// `argv0` (the usual `bazel-bin/library/tests/dtest` layout). Absolute
-/// paths only attempt the literal path as given.
+/// `bazel run`); then those same two forms under the workspace root inferred
+/// by climbing four parents from `argv0` (the usual
+/// `bazel-bin/library/tests/dtest` layout). Absolute paths only attempt the
+/// literal path as given.
 /// Directories are not accepted (avoids treating e.g. `-f hands` as a file).
 /// @return Resolved path, or empty if no regular file is found
 std::string resolve_dtest_input_file(

--- a/library/tests/args.hpp
+++ b/library/tests/args.hpp
@@ -38,8 +38,8 @@ void print_options();
 /// under `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` (set by
 /// `bazel run`); then those same two forms under the workspace root inferred
 /// by climbing four parents from `argv0` (the usual
-/// `bazel-bin/library/tests/dtest` layout). Absolute paths only attempt the
-/// literal path as given.
+/// `bazel-bin/library/tests/dtest` layout). Absolute paths, and Windows
+/// drive-relative forms like `C:foo`, only attempt the literal path as given.
 /// Directories are not accepted (avoids treating e.g. `-f hands` as a file).
 /// @return Resolved path, or empty if no regular file is found
 std::string resolve_dtest_input_file(

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -290,6 +290,32 @@ TEST_F(HandsLayoutFixture, ResolveNumericPrefersListOverLiteralUnderBazelWorking
     root_ + "hands/list42.txt"));
 }
 
+TEST_F(HandsLayoutFixture, ResolvePathLikeArgDoesNotUseListShorthand)
+{
+  // A path-like -f must not probe nonsense list-shorthand candidates such as
+  // hands/listhands/list42.txt.txt when the literal path is missing.
+  const std::string trap = root_ + "hands/listhands/list42.txt.txt";
+  ASSERT_TRUE(make_dir(root_ + "hands/listhands"));
+  {
+    std::ofstream out(trap);
+    out << "trap\n";
+  }
+  std::filesystem::remove(root_ + "hands/list42.txt");
+
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles_no_shorthand/";
+  ASSERT_TRUE(make_dir(runfiles));
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(root_.c_str());
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(
+    resolve_dtest_input_file("hands/list42.txt", "dtest").empty());
+}
+
 TEST_F(HandsLayoutFixture, ResolveLiteralRelativeUsesBazelWorkingDirectory)
 {
   // bazelisk run //library/tests:dtest -- -f hands/list42.txt must find the

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -266,6 +266,30 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
     root_ + "hands/list42.txt"));
 }
 
+TEST_F(HandsLayoutFixture, ResolveNumericPrefersListOverLiteralUnderBazelWorking)
+{
+  // A workspace-root file named "42" must not win over hands/list42.txt when
+  // resolving numeric -f under BUILD_WORKING_DIRECTORY.
+  {
+    std::ofstream out(root_ + "42");
+    out << "literal-trap\n";
+  }
+
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles_num_pref/";
+  ASSERT_TRUE(make_dir(runfiles));
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(root_.c_str());
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("42", "dtest"),
+    root_ + "hands/list42.txt"));
+}
+
 TEST_F(HandsLayoutFixture, ResolveLiteralRelativeUsesBazelWorkingDirectory)
 {
   // bazelisk run //library/tests:dtest -- -f hands/list42.txt must find the
@@ -331,6 +355,26 @@ TEST_F(HandsLayoutFixture, ResolveLiteralRelativeFallsBackRelativeToBinary)
 
   EXPECT_TRUE(same_path(
     resolve_dtest_input_file("hands/list42.txt", binary_path_),
+    root_ + "hands/list42.txt"));
+}
+
+TEST_F(HandsLayoutFixture, ResolveNumericPrefersListOverLiteralRelativeToBinary)
+{
+  // Workspace-root file "42" must not shadow hands/list42.txt for numeric -f
+  // when falling back via argv0.
+  {
+    std::ofstream out(root_ + "42");
+    out << "literal-trap\n";
+  }
+  ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("42", binary_path_),
     root_ + "hands/list42.txt"));
 }
 

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -3,7 +3,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -387,9 +389,32 @@ TEST_F(HandsLayoutFixture, ResolveAbsoluteMissingDoesNotUseListShorthand)
   // A missing absolute -f must not fall through to hands/list{arg}.txt
   // (list shorthand concatenates the absolute path into a nested name).
   ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
-  ASSERT_TRUE(make_dir(root_ + "hands/list"));
+
+  // Pick a unique absolute path that is not present on this machine.
+  const std::string token =
+    "no_such_dtest_abs_" +
+    std::to_string(static_cast<unsigned long long>(
+      reinterpret_cast<uintptr_t>(this)));
+#ifdef _WIN32
+  const std::string missing_abs = "\\" + token;
+#else
+  const std::string missing_abs = "/" + token;
+#endif
+  ASSERT_FALSE(std::filesystem::exists(missing_abs));
+
+  // Trap file at the binary-relative list-shorthand location that a buggy
+  // fallthrough would incorrectly accept.
+  const std::filesystem::path trap =
+    std::filesystem::path(root_) / "hands" /
+    ("list" + missing_abs + ".txt");
   {
-    std::ofstream out(root_ + "hands/list/no_such_dtest_abs.txt");
+    std::error_code ec;
+    std::filesystem::create_directories(trap.parent_path(), ec);
+    ASSERT_FALSE(ec) << ec.message();
+  }
+  {
+    std::ofstream out(trap);
+    ASSERT_TRUE(out) << trap.string();
     out << "trap\n";
   }
 
@@ -399,7 +424,7 @@ TEST_F(HandsLayoutFixture, ResolveAbsoluteMissingDoesNotUseListShorthand)
   workspace.set(nullptr);
 
   EXPECT_TRUE(
-    resolve_dtest_input_file("/no_such_dtest_abs", binary_path_).empty());
+    resolve_dtest_input_file(missing_abs, binary_path_).empty());
 }
 
 TEST(Args, AbsolutePathDetection)

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -300,7 +300,11 @@ TEST_F(HandsLayoutFixture, ResolvePathLikeArgDoesNotUseListShorthand)
     std::ofstream out(trap);
     out << "trap\n";
   }
-  std::filesystem::remove(root_ + "hands/list42.txt");
+  {
+    std::error_code ec;
+    std::filesystem::remove(root_ + "hands/list42.txt", ec);
+    ASSERT_FALSE(ec) << ec.message();
+  }
 
   const std::string runfiles =
     std::string(::testing::TempDir()) + "dtest_hands_runfiles_no_shorthand/";

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -268,7 +268,7 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
 
 TEST_F(HandsLayoutFixture, ResolveLiteralRelativeUsesBazelWorkingDirectory)
 {
-  // bazelisk run //library/tests:dtest -- -f hands/list1.txt must find the
+  // bazelisk run //library/tests:dtest -- -f hands/list42.txt must find the
   // path relative to the invoke-time shell cwd, not the runfiles tree.
   const std::string runfiles =
     std::string(::testing::TempDir()) + "dtest_hands_runfiles_lit/";

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -382,6 +382,26 @@ TEST_F(HandsLayoutFixture, ResolveRejectsDirectoryAsLiteralPath)
   EXPECT_TRUE(resolve_dtest_input_file(root_ + "hands", "dtest").empty());
 }
 
+TEST_F(HandsLayoutFixture, ResolveAbsoluteMissingDoesNotUseListShorthand)
+{
+  // A missing absolute -f must not fall through to hands/list{arg}.txt
+  // (list shorthand concatenates the absolute path into a nested name).
+  ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
+  ASSERT_TRUE(make_dir(root_ + "hands/list"));
+  {
+    std::ofstream out(root_ + "hands/list/no_such_dtest_abs.txt");
+    out << "trap\n";
+  }
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(
+    resolve_dtest_input_file("/no_such_dtest_abs", binary_path_).empty());
+}
+
 TEST(Args, AbsolutePathDetection)
 {
   EXPECT_FALSE(is_dtest_absolute_path("tmp/dtest"));

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -471,6 +471,38 @@ TEST_F(HandsLayoutFixture, ResolveAbsoluteMissingDoesNotUseListShorthand)
     resolve_dtest_input_file(missing_abs, binary_path_).empty());
 }
 
+#ifdef _WIN32
+TEST_F(HandsLayoutFixture, ResolveDriveRelativeMissingDoesNotJoinUnderBazelDirs)
+{
+  // Drive-relative "X:foo" is not absolute, but fs::path join can discard the
+  // BUILD_* base. Missing drive-relative -f must not resolve via env joins.
+  ASSERT_GE(root_.size(), 2u);
+  ASSERT_EQ(root_[1], ':');
+
+  const std::string token =
+    "no_such_dtest_drive_rel_" +
+    std::to_string(static_cast<unsigned long long>(
+      reinterpret_cast<uintptr_t>(this)));
+  const std::string missing_drive_rel =
+    std::string(1, root_[0]) + ":" + token;
+  ASSERT_FALSE(is_dtest_absolute_path(missing_drive_rel));
+  ASSERT_FALSE(std::filesystem::exists(missing_drive_rel));
+
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_drive_rel/";
+  ASSERT_TRUE(make_dir(runfiles));
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(root_.c_str());
+  workspace.set(root_.c_str());
+
+  EXPECT_TRUE(
+    resolve_dtest_input_file(missing_drive_rel, binary_path_).empty());
+}
+#endif
+
 TEST(Args, AbsolutePathDetection)
 {
   EXPECT_FALSE(is_dtest_absolute_path("tmp/dtest"));

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -264,6 +264,25 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkingDirectory)
     root_ + "hands/list42.txt"));
 }
 
+TEST_F(HandsLayoutFixture, ResolveLiteralRelativeUsesBazelWorkingDirectory)
+{
+  // bazelisk run //library/tests:dtest -- -f hands/list1.txt must find the
+  // path relative to the invoke-time shell cwd, not the runfiles tree.
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles_lit/";
+  ASSERT_TRUE(make_dir(runfiles));
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(root_.c_str());
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("hands/list42.txt", "dtest"),
+    root_ + "hands/list42.txt"));
+}
+
 TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
 {
   const std::string runfiles =
@@ -278,6 +297,38 @@ TEST_F(HandsLayoutFixture, ResolveNumericUsesBazelWorkspaceDirectory)
 
   EXPECT_TRUE(same_path(
     resolve_dtest_input_file("42", "dtest"),
+    root_ + "hands/list42.txt"));
+}
+
+TEST_F(HandsLayoutFixture, ResolveLiteralRelativeUsesBazelWorkspaceDirectory)
+{
+  const std::string runfiles =
+    std::string(::testing::TempDir()) + "dtest_hands_runfiles_ws_lit/";
+  ASSERT_TRUE(make_dir(runfiles));
+  ASSERT_EQ(change_dir(runfiles.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(root_.c_str());
+
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("hands/list42.txt", "dtest"),
+    root_ + "hands/list42.txt"));
+}
+
+TEST_F(HandsLayoutFixture, ResolveLiteralRelativeFallsBackRelativeToBinary)
+{
+  // Same layout as numeric binary-relative lookup, but with an explicit path.
+  ASSERT_EQ(change_dir(original_cwd_.c_str()), 0);
+
+  const EnvVarGuard working("BUILD_WORKING_DIRECTORY");
+  const EnvVarGuard workspace("BUILD_WORKSPACE_DIRECTORY");
+  working.set(nullptr);
+  workspace.set(nullptr);
+
+  EXPECT_TRUE(same_path(
+    resolve_dtest_input_file("hands/list42.txt", binary_path_),
     root_ + "hands/list42.txt"));
 }
 


### PR DESCRIPTION
## Summary
- Resolves literal relative `-f` paths (e.g. `hands/list1.txt`) via `BUILD_WORKING_DIRECTORY` / `BUILD_WORKSPACE_DIRECTORY` and relative to the dtest binary, so `bazelisk run //library/tests:dtest -- -f hands/list1.txt` works.
- Numeric list shorthand (`-f 1` → `hands/list1.txt`) behavior is unchanged; docs and error text updated to match.
- Adds unit coverage for literal relative resolution under bazel env dirs and binary-relative fallback.

Fixes #328

## Test plan
- [x] `bazelisk test //library/tests:args_test`
- [x] `bazelisk run //library/tests:dtest -- -f hands/list1.txt -s calc`
- [x] Confirm `bazel-bin/library/tests/dtest -f hands/list1.txt` still works from the repo root


Made with [Cursor](https://cursor.com)