### PR TITLE
Use American spelling for initialize and initialization

### DIFF
--- a/library/src/api/dll.h
+++ b/library/src/api/dll.h
@@ -429,10 +429,10 @@ struct DDSInfo
 
 
 /**
- * @brief Initialise the solver's static memory.
+ * @brief Initialize the solver's static memory.
  *
  * Allocates the transposition-table memory pools, registers scheduler and
- * thread-manager state, and performs one-time lookup-table initialisation.
+ * thread-manager state, and performs one-time lookup-table initialization.
  * This does NOT control the number of worker threads — use the
  * SolveAllBoardsN / CalcAllTablesN family for per-call thread caps.
  */

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -36,7 +36,7 @@ int _initialized = 0;
 
 
 /*
- * Initialise the solver's static memory: TT memory pools, scheduler /
+ * Initialize the solver's static memory: TT memory pools, scheduler /
  * thread-manager state, and one-time lookup-table setup.
  *
  * Public API documentation is maintained in the API headers.

--- a/library/tests/system/BUILD.bazel
+++ b/library/tests/system/BUILD.bazel
@@ -113,7 +113,7 @@ filegroup(
     visibility = ["//python:__pkg__"],
 )
 
-# max_threads override equivalence + rename/alias initialisation test
+# max_threads override equivalence + rename/alias initialization test
 cc_test(
     name = "max_threads_equivalence_test",
     size = "small",

--- a/library/tests/system/max_threads_equivalence_test.cpp
+++ b/library/tests/system/max_threads_equivalence_test.cpp
@@ -1,6 +1,6 @@
 /// @file max_threads_equivalence_test.cpp
 /// @brief Tests that the *N batch APIs honour maxThreads and stay equivalent to
-///        the auto path, plus that the rename/alias both initialise the library.
+///        the auto path, plus that the rename/alias both initialize the library.
 
 #include <gtest/gtest.h>
 #include <cstring>
@@ -102,7 +102,7 @@ TEST(MaxThreadsEquivalence, SolveAllBoardsBinNMatchesAuto)
     const FutureTricks& fa = solved_auto.solved_board[b];
     const FutureTricks& fo = solved_one.solved_board[b];
     ASSERT_EQ(fa.cards, fo.cards) << "card count differs at board=" << b;
-    // Only the first `cards` entries are meaningful; the tail is uninitialised.
+    // Only the first `cards` entries are meaningful; the tail is uninitialized.
     for (int c = 0; c < fa.cards; c++)
     {
       EXPECT_EQ(fa.suit[c], fo.suit[c]) << "suit at board=" << b << " c=" << c;
@@ -122,7 +122,7 @@ TEST(MaxThreadsEquivalence, InitializeStaticMemoryThenSolve)
   EXPECT_EQ(CalcDDtable(deal, &table), RETURN_NO_FAULT);
 }
 
-// The deprecated SetMaxThreads alias still initialises the library.
+// The deprecated SetMaxThreads alias still initializes the library.
 TEST(MaxThreadsEquivalence, DeprecatedSetMaxThreadsAliasStillWorks)
 {
   SetMaxThreads(1);

--- a/python/dds3/__init__.py
+++ b/python/dds3/__init__.py
@@ -7,7 +7,7 @@ try:
     from ._dds3 import calc_par
     from ._dds3 import calc_par_from_table
     from ._dds3 import dealer_par
-    from ._dds3 import initialise_static_memory
+    from ._dds3 import initialize_static_memory
     from ._dds3 import module_name
     from ._dds3 import par
     from ._dds3 import set_max_threads
@@ -26,7 +26,7 @@ except ImportError:
     from _dds3 import calc_par
     from _dds3 import calc_par_from_table
     from _dds3 import dealer_par
-    from _dds3 import initialise_static_memory
+    from _dds3 import initialize_static_memory
     from _dds3 import module_name
     from _dds3 import par
     from _dds3 import set_max_threads
@@ -45,7 +45,7 @@ __all__ = [
     "calc_par",
     "calc_par_from_table",
     "dealer_par",
-    "initialise_static_memory",
+    "initialize_static_memory",
     "module_name",
     "par",
     "set_max_threads",

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -609,33 +609,33 @@ auto register_calc_par_bindings(py::module_& module) -> void
 
 auto register_analysis_bindings(py::module_& module) -> void
 {
-    // initialise_static_memory: allocate the solver's static memory pools and
-    // perform one-time lookup-table initialisation. This does NOT control the
+    // initialize_static_memory: allocate the solver's static memory pools and
+    // perform one-time lookup-table initialization. This does NOT control the
     // worker-thread count; use solve_all_boards_* (which parallelise across the
     // machine's hardware threads automatically) or one SolverContext per worker
     // thread for per-board concurrency.
     module.def(
-        "initialise_static_memory",
+        "initialize_static_memory",
         []() {
             py::gil_scoped_release release;
             InitializeStaticMemory();
         },
-        "Initialise the solver's static memory.\n\n"
+        "Initialize the solver's static memory.\n\n"
         "Allocates the transposition-table memory pools and performs one-time\n"
-        "lookup-table initialisation. This does NOT control the number of worker\n"
+        "lookup-table initialization. This does NOT control the number of worker\n"
         "threads: solve_all_boards_* parallelise across the machine's hardware\n"
         "threads automatically, and for per-board concurrency from Python you\n"
         "create one SolverContext per worker thread and pass it to solve_board /\n"
         "solve_board_pbn.");
 
-    // set_max_threads: DEPRECATED alias of initialise_static_memory. The thread
+    // set_max_threads: DEPRECATED alias of initialize_static_memory. The thread
     // count argument is ignored; retained only for backward compatibility.
     module.def(
         "set_max_threads",
         [](const int user_threads) {
             if (PyErr_WarnEx(
                     PyExc_DeprecationWarning,
-                    "set_max_threads() is deprecated; use initialise_static_memory(). "
+                    "set_max_threads() is deprecated; use initialize_static_memory(). "
                     "The user_threads argument is ignored.",
                     1) != 0) {
                 throw py::error_already_set();
@@ -644,7 +644,7 @@ auto register_analysis_bindings(py::module_& module) -> void
             SetMaxThreads(user_threads);
         },
         py::arg("user_threads") = 0,
-        "DEPRECATED: use initialise_static_memory() instead.\n\n"
+        "DEPRECATED: use initialize_static_memory() instead.\n\n"
         "Legacy thread-resource hook (wraps the deprecated SetMaxThreads C API,\n"
         "now a thin alias of InitializeStaticMemory). Calling this emits a\n"
         "DeprecationWarning.\n\n"

--- a/python/tests/test_import.py
+++ b/python/tests/test_import.py
@@ -5,6 +5,7 @@ from dds3 import calc_all_tables_pbn
 from dds3 import calc_dd_table
 from dds3 import calc_par
 from dds3 import calc_par_from_table
+from dds3 import initialize_static_memory
 from dds3 import module_name
 from dds3 import par
 from dds3 import SolverContext
@@ -27,6 +28,7 @@ class TestImport(unittest.TestCase):
         self.assertTrue(callable(par))
         self.assertTrue(callable(calc_par))
         self.assertTrue(callable(calc_par_from_table))
+        self.assertTrue(callable(initialize_static_memory))
         self.assertIsNotNone(SolverContext)
 
         # Verify SolverContext can be instantiated.

--- a/specs/lookup-tables.md
+++ b/specs/lookup-tables.md
@@ -8,7 +8,7 @@ last-updated: 2026-07-18
 
 > **Specs vs. doxygen.** Each table's exact indexing and return encoding is
 > documented inline in `lookup_tables.hpp`. This spec records what the tables are
-> collectively, their initialisation/immutability contract, and who depends on
+> collectively, their initialization/immutability contract, and who depends on
 > them.
 
 ## Purpose
@@ -34,14 +34,14 @@ inner loops of [move-generation](move-generation.md) and the search index these 
   `win_ranks[8192][14]` (bitmask of the top-N cards), and `group_data[8192]`
   (`MoveGroupType` run decomposition — up to 7 runs of adjacent ranks with their
   top card, tail sequence, full sequence, and inter-run gaps).
-- **Initialised once, eagerly, at startup.** `init_lookup_tables()` fills the
-  storage via static initialisation (`DdsLutInitGuard`), guarded by
+- **Initialized once, eagerly, at startup.** `init_lookup_tables()` fills the
+  storage via static initialization (`DdsLutInitGuard`), guarded by
   `std::call_once`. It is **thread-safe, idempotent, and a no-op after startup** —
-  explicit calls are safe but redundant. No consumer needs to initialise them.
+  explicit calls are safe but redundant. No consumer needs to initialize them.
 - **Read-only and immutable after init.** The tables are exposed as `const`
   references to fixed-size arrays, giving zero-overhead direct indexing
   (`highest_rank[aggr]`, `rel_rank[aggr][rank]`). Any thread may read them
-  concurrently; nothing mutates them post-initialisation.
+  concurrently; nothing mutates them post-initialization.
 - **`MoveGroupType` is the run-decomposition contract** consumed by move
   generation: `last_group_` (−1 for empty, up to 6), and per-group `rank_`,
   `sequence_`, `fullseq_`, and `gap_` arrays. `rank_`, `sequence_` and

--- a/specs/move-generation.md
+++ b/specs/move-generation.md
@@ -47,7 +47,7 @@ and transposition-table hits. `Moves` is an internal component — it is not par
   void situation (0–3 hands void), 13 categories total. It indexes the statistics
   tables and the heuristic's per-situation tracking.
 - **Invariants are assertion-checked.** Public methods assume valid input and
-  prior initialisation; violations trip asserts in debug builds. The move-finding
+  prior initialization; violations trip asserts in debug builds. The move-finding
   methods signal "no move" by returning `nullptr`, not by throwing.
 - **Statistics/printing are diagnostic-only** and emit under `DDS_MOVES` /
   `DDS_MOVES_DETAILS` (see [constants-and-debug](constants-and-debug.md)); they are off the hot path in

--- a/specs/python-binding.md
+++ b/specs/python-binding.md
@@ -32,9 +32,9 @@ context API and the flat API from [dds-public-api](dds-public-api.md).
 - **Public surface is the package `__all__`.** `python/dds3/__init__.py` re-exports
   the extension symbols; see that list and `docs/python_interface.md` rather than
   duplicating names here. Notable capability-wide pieces: a Python `SolverContext`
-  for TT reuse, and `initialise_static_memory` for lookup-table setup. Note
+  for TT reuse, and `initialize_static_memory` for lookup-table setup. Note
   `set_max_threads` is exported but **deprecated** — it is an alias of
-  `initialise_static_memory` that ignores its argument and warns; it does not set
+  `initialize_static_memory` that ignores its argument and warns; it does not set
   a worker count.
 - **In-package native staging is platform-specific.** `_dds3_in_package` copies
   the built extension into `dds3/` under the filename Python expects —


### PR DESCRIPTION
## Summary
- Standardize on American `initialize` / `initialization` spelling in comments, specs, and the Python API.
- Rename the Python export `initialise_static_memory` to `initialize_static_memory` so it matches C++ `InitializeStaticMemory`. `set_max_threads` remains a deprecated alias and now points at the new name.

## Test plan
- [x] `bazelisk test //python:python_interface_smoke_test`
- [x] `bazelisk test //library/tests/system:max_threads_equivalence_test`


Made with [Cursor](https://cursor.com)