### PR TITLE
Add explicit includes for transitively-used std headers

### DIFF
--- a/benchmarks/dds_replay_main.cpp
+++ b/benchmarks/dds_replay_main.cpp
@@ -19,10 +19,13 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <map>
 #include <set>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "recording.hpp"

--- a/benchmarks/recording.cpp
+++ b/benchmarks/recording.cpp
@@ -9,8 +9,12 @@
 #include "recording.hpp"
 
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace dds_replay {
 

--- a/benchmarks/replay.cpp
+++ b/benchmarks/replay.cpp
@@ -11,12 +11,15 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 
 #include <api/dds_c_api.h>
 #include <api/dll.h>
+#include <vector>
 
 namespace dds_replay {
 

--- a/benchmarks/warm_tt_benchmark.cpp
+++ b/benchmarks/warm_tt_benchmark.cpp
@@ -36,6 +36,8 @@
 #include <chrono>
 #include <cstdio>
 #include <random>
+#include <ratio>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/library/src/ab_search.cpp
+++ b/library/src/ab_search.cpp
@@ -11,6 +11,7 @@
 
 #include "ab_search.hpp"
 #include <ab_stats.hpp>
+#include <cstddef>
 #include <dump.hpp>
 #include <later_tricks.hpp>
 #include <quick_tricks.hpp>

--- a/library/src/ab_stats.cpp
+++ b/library/src/ab_stats.cpp
@@ -11,8 +11,10 @@
    ABstats is a simple object for AB statistics and return values.
 */
 
+#include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <string>
 
 #include "ab_stats.hpp"
 

--- a/library/src/dds_api.cpp
+++ b/library/src/dds_api.cpp
@@ -7,6 +7,7 @@
 
 #include <api/dds_api.hpp>
 #include <api/calc_par.hpp>
+#include <string>
 
 // Creation
 DLLEXPORT DDS_SOLVER_CTX dds_create_solvercontext_default()

--- a/library/src/dump.cpp
+++ b/library/src/dump.cpp
@@ -10,12 +10,15 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "dump.hpp"
 #include <solver_context/solver_context.hpp>
+#include <string>
 #include <trans_table/trans_table.hpp>
 #include <utility/debug.h>
+#include <vector>
 
 
 std::string PrintSuit(const unsigned short suitCode);

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -7,9 +7,12 @@
    See LICENSE and README.
 */
 
+#include <algorithm>
 #include <cstring>
 #include <cstdio>
 #include <iomanip>
+#include <ios>
+#include <memory>
 #include <sstream>
 
 #include <calc_tables.hpp>
@@ -18,6 +21,7 @@
 #include <solve_board.hpp>
 #include <lookup_tables/lookup_tables.hpp>
 #include <solver_context/solver_context.hpp>
+#include <string>
 #include <system/scheduler.hpp>
 #include <system/system.hpp>
 #include <system/thread_mgr.hpp>

--- a/library/src/later_tricks.cpp
+++ b/library/src/later_tricks.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 
 #include "later_tricks.hpp"
+#include <cstdio>
 #include <solver_context/solver_context.hpp>
 
 

--- a/library/src/play_analyser.cpp
+++ b/library/src/play_analyser.cpp
@@ -13,6 +13,7 @@
 #include <solver_context/solver_context.hpp>
 #include <system/scheduler.hpp>
 #include <system/system.hpp>
+#include <vector>
 
 using namespace std;
 

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -18,6 +18,7 @@
 #include <system/scheduler.hpp>
 #include <system/system.hpp>
 #include <utility/debug.h>
+#include <vector>
 
 
 extern Scheduler scheduler;

--- a/library/src/solver_context/solver_context.cpp
+++ b/library/src/solver_context/solver_context.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/library/src/solver_if.cpp
+++ b/library/src/solver_if.cpp
@@ -13,6 +13,7 @@
 #include "solver_if.hpp"
 #include <api/solve_board.hpp>
 #include <lookup_tables/lookup_tables.hpp>
+#include <memory>
 #include <solver_context/solver_context.hpp>
 #include <system/scheduler.hpp>
 #include <system/system.hpp>

--- a/library/src/system/file.cpp
+++ b/library/src/system/file.cpp
@@ -8,6 +8,7 @@
 */
 
 #include "file.hpp"
+#include <fstream>
 
 dds::File::~File()
 {

--- a/library/src/system/memory.cpp
+++ b/library/src/system/memory.cpp
@@ -10,6 +10,7 @@
 
 #include "memory.hpp"
 #include <cstdlib>
+#include <string>
 #include <trans_table/trans_table.hpp>
 
 // After moving ThreadData ownership into SolverContext, Memory no longer

--- a/library/src/system/parallel_boards.cpp
+++ b/library/src/system/parallel_boards.cpp
@@ -12,10 +12,13 @@
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #if defined(__EMSCRIPTEN__)

--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -15,6 +15,8 @@
 #include "scheduler.hpp"
 #include <fstream>
 #include <iomanip>
+#include <utility>
+#include <vector>
 #ifdef DDS_SCHEDULER
 #include <system/time_stat_list.hpp>
 

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -7,8 +7,11 @@
    See LICENSE and README.
 */
 
+#include <cstdio>
 #include <cstring>
+#include <string>
 #include <thread>
+#include <vector>
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__unix__)
   #include <unistd.h>

--- a/library/src/system/thread_data.cpp
+++ b/library/src/system/thread_data.cpp
@@ -1,5 +1,6 @@
 // ThreadData instance methods implementation
 #include "thread_data.hpp"
+#include <string>
 #include <utility/debug.h>
 
 using std::string;

--- a/library/src/system/thread_mgr.cpp
+++ b/library/src/system/thread_mgr.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <mutex>
 #include <chrono>
+#include <string>
 #include <thread>
 
 #include "thread_mgr.hpp"

--- a/library/src/system/time_stat.cpp
+++ b/library/src/system/time_stat.cpp
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <sstream>
 #include <cmath>
+#include <string>
 
 #include "time_stat.hpp"
 

--- a/library/src/system/timer.cpp
+++ b/library/src/system/timer.cpp
@@ -8,8 +8,11 @@
 */
 
 
+#include <chrono>
+#include <ctime>
 #include <iostream>
 #include <iomanip>
+#include <ratio>
 #include <sstream>
 
 #include "timer.hpp"

--- a/library/src/system/timer_group.cpp
+++ b/library/src/system/timer_group.cpp
@@ -7,6 +7,8 @@
    See LICENSE and README.
 */
 
+#include <cstddef>
+#include <string>
 #define TIMER_DEPTH 50
 
 #include <iostream>

--- a/library/src/system/timer_list.cpp
+++ b/library/src/system/timer_list.cpp
@@ -13,6 +13,8 @@
 */
 
 #include "timer_list.hpp"
+#include <fstream>
+#include <ostream>
 
 
 TimerList::TimerList()

--- a/library/src/trans_table/trans_table_l.cpp
+++ b/library/src/trans_table/trans_table_l.cpp
@@ -82,12 +82,16 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <fstream>
 #include <iomanip>
+#include <ios>
 #include <new>
 
 #include "trans_table_l.hpp"
 
+#include <string>
 #include <utility/constants.h>
+#include <vector>
 
 namespace
 {

--- a/library/src/trans_table/trans_table_s.cpp
+++ b/library/src/trans_table/trans_table_s.cpp
@@ -9,10 +9,12 @@
 
 #include <array>
 #include <cstdlib>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <new>
 #include <api/dds.h>
+#include <string>
 
 #include "trans_table_s.hpp"
 

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -8,9 +8,12 @@
 */
 
 
+#include <chrono>
 #include <ctime>
 #include <iostream>
 #include <iomanip>
+#include <ratio>
+#include <string>
 
 #include "TestTimer.hpp"
 

--- a/library/tests/ab_search/make3_test.cpp
+++ b/library/tests/ab_search/make3_test.cpp
@@ -11,6 +11,7 @@
 #include <ab_search.hpp>
 #include <api/dds.h>
 #include <api/dll.h>
+#include <memory>
 #include <solver_context/solver_context.hpp>
 #include <system/memory.hpp>
 #include <utility/constants.h>

--- a/library/tests/ab_search/tt_lookup_test.cpp
+++ b/library/tests/ab_search/tt_lookup_test.cpp
@@ -11,6 +11,7 @@
 #include <ab_search.hpp>
 #include <api/dds.h>
 #include <api/dll.h>
+#include <memory>
 #include <solver_context/solver_context.hpp>
 #include <system/memory.hpp>
 #include <trans_table/trans_table.hpp>

--- a/library/tests/args.cpp
+++ b/library/tests/args.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <string>
 #include <vector>
 #include <algorithm>
 #include <cctype>

--- a/library/tests/args_test.cpp
+++ b/library/tests/args_test.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #ifdef _WIN32

--- a/library/tests/dds_c_api_test.cpp
+++ b/library/tests/dds_c_api_test.cpp
@@ -15,6 +15,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <cstring>
 
 #include <api/dds_c_api.h>

--- a/library/tests/dtest.cpp
+++ b/library/tests/dtest.cpp
@@ -8,6 +8,7 @@
 */
 
 
+#include <cstdlib>
 #include <iostream>
 #if defined(__linux__) || defined(__APPLE__) || defined(__unix__)
   #include <unistd.h>

--- a/library/tests/dtest_parallel.cpp
+++ b/library/tests/dtest_parallel.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <functional>
 #include <thread>
 #include <vector>
 

--- a/library/tests/heuristic_sorting/minimal_weight_test.cpp
+++ b/library/tests/heuristic_sorting/minimal_weight_test.cpp
@@ -6,6 +6,7 @@
  * without segmentation faults on minimal input data.
  */
 
+#include <cstring>
 #include <gtest/gtest.h>
 #include <iostream>
 #include "heuristic_sorting/heuristic_sorting.hpp"

--- a/library/tests/heuristic_sorting/test_utils.cpp
+++ b/library/tests/heuristic_sorting/test_utils.cpp
@@ -6,6 +6,7 @@
 #include "test_utils.hpp"
 #include <sstream>
 #include <cstring>
+#include <string>
 #include <vector>
 #include <algorithm>
 

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -8,6 +8,8 @@
 */
 
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <iostream>

--- a/library/tests/loop_par_test.cpp
+++ b/library/tests/loop_par_test.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <ios>
 #include <regex>
 #include <sstream>
 #include <string>

--- a/library/tests/moves/moves_test.cpp
+++ b/library/tests/moves/moves_test.cpp
@@ -10,7 +10,9 @@
  * - Edge cases and invariant violations
  */
 
+#include <cctype>
 #include <gtest/gtest.h>
+#include <memory>
 #include <vector>
 #include <cstring>
 #include <chrono>

--- a/library/tests/parse.cpp
+++ b/library/tests/parse.cpp
@@ -7,6 +7,7 @@
    See LICENSE and README.
 */
 
+#include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/library/tests/print.cpp
+++ b/library/tests/print.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
+#include <string>
 
 #include "print.hpp"
 

--- a/library/tests/regression/heuristic_sorting/heuristic_sorting_test.cpp
+++ b/library/tests/regression/heuristic_sorting/heuristic_sorting_test.cpp
@@ -5,6 +5,7 @@
 /// heuristics maintain expected priority and consistency across scenarios.
 
 #include <algorithm>
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/library/tests/report_board_timings.cpp
+++ b/library/tests/report_board_timings.cpp
@@ -7,7 +7,11 @@
 #include <cmath>
 #include <cstdlib>
 #include <iomanip>
+#include <ios>
+#include <ostream>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 namespace
 {

--- a/library/tests/report_board_timings_test.cpp
+++ b/library/tests/report_board_timings_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <iomanip>
+#include <ios>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/library/tests/solve_board/analyse_play_consistency.cpp
+++ b/library/tests/solve_board/analyse_play_consistency.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <random>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Third-party headers

--- a/library/tests/system/parallel_boards_test.cpp
+++ b/library/tests/system/parallel_boards_test.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <future>
@@ -8,6 +9,7 @@
 #include <new>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -5,6 +5,7 @@
 #include <ctime>
 #include <gtest/gtest.h>
 #include <iomanip>
+#include <ios>
 #include <limits>
 #include <regex>
 #include <sstream>

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -8,8 +8,11 @@
 */
 
 
+#include <cstddef>
+#include <cstdlib>
 #include <iostream>
 #include <iomanip>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/library/tests/trans_table/mock_data_generators.cpp
+++ b/library/tests/trans_table/mock_data_generators.cpp
@@ -6,7 +6,11 @@
 
 // C++ standard library headers
 #include <algorithm>
+#include <array>
 #include <iostream>
+#include <random>
+#include <utility>
+#include <vector>
 
 namespace dds_test {
 

--- a/library/tests/trans_table/test_utilities.cpp
+++ b/library/tests/trans_table/test_utilities.cpp
@@ -6,10 +6,12 @@
 
 // C++ standard library headers
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 namespace dds_test {
 

--- a/library/tests/trans_table/trans_table_base_test.cpp
+++ b/library/tests/trans_table/trans_table_base_test.cpp
@@ -3,6 +3,8 @@
 /// @details Tests virtual methods, polymorphism, and base class interface.
 
 // C++ standard library headers
+#include <cstdio>
+#include <fstream>
 #include <memory>
 
 // Third-party headers

--- a/library/tests/trans_table/trans_table_l_test.cpp
+++ b/library/tests/trans_table/trans_table_l_test.cpp
@@ -1,5 +1,9 @@
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <cstring>
+#include <ios>
 
 // Include DDS types first
 #include <api/dll.h>

--- a/library/tests/trans_table/trans_table_s_test.cpp
+++ b/library/tests/trans_table/trans_table_s_test.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <cstring>
 

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/python/src/converters.cpp
+++ b/python/src/converters.cpp
@@ -4,6 +4,8 @@
 #include <cstring>
 
 #include <pybind11/pybind11.h>
+#include <string>
+#include <vector>
 
 namespace py = pybind11;
 

--- a/utilities/src/dd_table_for_deal/dd_table_for_deal_lib.cpp
+++ b/utilities/src/dd_table_for_deal/dd_table_for_deal_lib.cpp
@@ -17,9 +17,12 @@
 #include <iostream>
 #include <istream>
 #include <limits>
+#include <optional>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <unordered_set>
+#include <vector>
 
 namespace dd_table_for_deal {
 namespace {

--- a/utilities/tests/dd_table_for_deal_test.cpp
+++ b/utilities/tests/dd_table_for_deal_test.cpp
@@ -11,6 +11,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <ios>
 #include <sstream>
 
 #include <api/dll.h>


### PR DESCRIPTION
## Summary
- A Copilot review on `dds_c_api_test.cpp` flagged `std::snprintf` used without including `<cstdio>` (only `<cstring>` was present) — fixed.
- Swept the rest of the project's own sources with `clang-tidy`'s `misc-include-cleaner` check (via the repo's `compile_commands.json`) to find other symbols relied on only through transitive includes.
- Findings were filtered to genuine standard-library headers only, excluding project facade headers (e.g. `api/dll.h`, `utility/constants.h`) that are intentionally re-exported by `dds_c_api.h` and friends.
- Purely additive; no behavior changes — 58 files touched, 107 lines added, 0 removed.

## Test plan
- [x] `bazel build //...` — all 186 targets build clean
- [x] `bazel test //...` — all 86 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #329 