### PR TITLE
fix: restore dll.h include broken by header-split / deprecate-c-api merge

### DIFF
--- a/library/src/api/dds_c_api.cpp
+++ b/library/src/api/dds_c_api.cpp
@@ -18,6 +18,7 @@
 
 #include <api/dds_c_api.h>
 #include <api/dds_api.hpp>
+#include <api/dll.h>   /* legacy Par/SidesPar/DealerPar/.../GetDDSInfo/ErrorMessage */
 
 /* This shim is the boundary between the C++ implementation and pure-C FFI
    consumers (JVM/FFM, .NET, ctypes). Two things must never cross it:

--- a/library/tests/dds_c_api_test.cpp
+++ b/library/tests/dds_c_api_test.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <api/dds_c_api.h>
+#include <api/dll.h>  // full definitions for DealPBN, ParResults{Dealer,Master}, ParTextResults, DDSInfo
 
 namespace {
 


### PR DESCRIPTION
## Summary
- PR #355 (`reorganise_headers`) replaced the transitive `<api/dll.h>` include in `dds_c_api.h` with `<api/dds_c_data_types.h>`; PR #354 (`deprecate_old_c_api`) added context-free wrappers that call legacy `dll.h` functions (`Par`, `SidesPar`, `DealerPar`, `GetDDSInfo`, `ErrorMessage`, ...).
- The two merged without a textual conflict, leaving `dds_c_api.cpp` with no declarations for those functions and `dds_c_api_test.cpp` with incomplete legacy struct types (`DealPBN`, `ParResultsDealer`, `ParResultsMaster`, `ParTextResults`, `DDSInfo`).
- Fix: `#include <api/dll.h>` directly in the two translation units that use the legacy symbols, rather than re-adding it to the now C-consumable public header.

## Test plan
- [x] `bazel build //...`
- [x] `bazel test //library/tests:dds_c_api_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #360 
Closes #359 