### PR TITLE
Remove `using namespace std` / using-declarations from headers

### DIFF
--- a/.github/instructions/cpp.instructions.md
+++ b/.github/instructions/cpp.instructions.md
@@ -140,13 +140,32 @@ auto result = compute_area(
 - **RAII** – manage resources via destructors.
 - **Smart pointers** – prefer `std::unique_ptr` / `std::shared_ptr`.
 - **Const-correctness** – mark data/functions const where possible.
-- **No `using namespace` in headers.**
+- **Namespace `using`** – see [Namespace `using`](#namespace-using) below.
 - **C++ Core Guidelines** – [Style Guide](https://isocpp.github.io/CppCoreGuidelines/) follow naming, formatting, and layout.
 - **Enums** – use `enum class`.
 - **Functions** – keep short; extract helpers if > 20 lines.
 - **Variables** – snake_case; classes – PascalCase.
 - **Header guards** – `#pragma once` or traditional guards.
 - **Include paths** – use `<target/header.hpp>` (angle brackets) for headers from other Bazel targets; use `"header.hpp"` (quotes) only for the paired header of the current translation unit.
+
+### Namespace `using`
+- **Headers:** no namespace-scope `using namespace` (using-directives) and no
+  namespace-scope `using X::name;` (using-declarations). Fully qualify names in
+  header code (`std::string`, not `string`). Rationale: either form at namespace
+  scope leaks names into every translation unit that includes the header,
+  directly or transitively, and a later cleanup then breaks every includer that
+  had come to rely on it.
+  - A `using` inside a class or function body (e.g. inheriting constructors
+    `using Base::Base;`) is fine — it does not leak.
+  - Alias-declarations (`using Clock = std::chrono::steady_clock;`) are not
+    using-directives/declarations and are allowed; prefer placing them inside a
+    namespace rather than at global scope.
+- **`.cpp` files:** `using X::name;` for specific names is allowed and preferred
+  where it improves readability. A file-scope `using namespace` is permitted but
+  discouraged — prefer specific using-declarations, a qualified sub-namespace
+  (`using namespace std::chrono;`), or scoping the directive to a function body.
+- **Never rely on a `using` supplied by an included header.** Qualify the name,
+  or add your own using-declaration in the `.cpp`.
 
 ### Safety
 - Initialize all variables.

--- a/library/src/calc_tables.cpp
+++ b/library/src/calc_tables.cpp
@@ -776,8 +776,8 @@ int STDCALL CalcDDtablePBN(
 
 void detect_calc_duplicates(
   const Boards& bds,
-  vector<int>& uniques,
-  vector<int>& crossrefs)
+  std::vector<int>& uniques,
+  std::vector<int>& crossrefs)
 {
   // Could save a little bit of time with a dedicated checker that
   // only looks at the cards.

--- a/library/src/init.cpp
+++ b/library/src/init.cpp
@@ -30,6 +30,14 @@
 #include <api/dll.h>
 #include <utility/debug.h>
 
+using std::left;
+using std::min;
+using std::right;
+using std::setw;
+using std::string;
+using std::stringstream;
+using std::to_string;
+
 System sysdep;
 Memory memory;
 Scheduler scheduler;

--- a/library/src/solve_board.cpp
+++ b/library/src/solve_board.cpp
@@ -307,8 +307,8 @@ auto solve_all_boards_n_seq(
 
 auto detect_solve_duplicates(
   const Boards& bds,
-  vector<int>& uniques,
-  vector<int>& crossrefs) -> void
+  std::vector<int>& uniques,
+  std::vector<int>& crossrefs) -> void
 {
   const unsigned nu = static_cast<unsigned>(bds.no_of_boards);
 

--- a/library/src/system/scheduler.cpp
+++ b/library/src/system/scheduler.cpp
@@ -927,6 +927,12 @@ void Scheduler::EndBlockTimer()
 
 void Scheduler::PrintTiming() const
 {
+  using std::fixed;
+  using std::ofstream;
+  using std::setprecision;
+  using std::setw;
+  using std::string;
+
   const string fname = string(DDS_SCHEDULER_PREFIX) + DDS_DEBUG_SUFFIX;
   ofstream fout;
   fout.open(fname);

--- a/library/src/system/system.cpp
+++ b/library/src/system/system.cpp
@@ -26,6 +26,10 @@
 
 #include "system.hpp"
 
+using std::string;
+using std::to_string;
+using std::vector;
+
 // Boost: Disable some header warnings.
 
 #ifdef DDS_THREADS_BOOST

--- a/library/src/system/system.hpp
+++ b/library/src/system/system.hpp
@@ -20,11 +20,9 @@
 
 #include <api/dds_data_types.hpp>
 
-using namespace std;
-
 typedef void (*FduplType)(
-  const Boards& bds, vector<int>& uniques, vector<int>& crossrefs);
-typedef void (*FcopyType)(const vector<int>& crossrefs);
+  const Boards& bds, std::vector<int>& uniques, std::vector<int>& crossrefs);
+typedef void (*FcopyType)(const std::vector<int>& crossrefs);
 
 
 /**
@@ -44,20 +42,20 @@ class System
 
     unsigned preferred_system_;
 
-    vector<bool> available_system_;
-  
+    std::vector<bool> available_system_;
+
     public:
 
-    string get_version(
+    std::string get_version(
       int& major,
       int& minor,
       int& patch) const;
-    string get_system(int& sys) const;
-    string get_bits(int& bits) const;
-    string get_compiler(int& comp) const;
+    std::string get_system(int& sys) const;
+    std::string get_bits(int& bits) const;
+    std::string get_compiler(int& comp) const;
     int get_cores() const;
-    string get_constructor(int& cons) const;
-    string get_threading(int& thr) const;
+    std::string get_constructor(int& cons) const;
+    std::string get_threading(int& thr) const;
     int get_memory_max() const { return sys_mem_mb_; }
     int get_num_threads() const { return num_threads_; }
 

--- a/library/src/system/thread_mgr.cpp
+++ b/library/src/system/thread_mgr.cpp
@@ -18,6 +18,12 @@
 
 #include "thread_mgr.hpp"
 
+using std::endl;
+using std::left;
+using std::ofstream;
+using std::setw;
+using std::string;
+
 namespace {
 
 std::mutex mtx;

--- a/library/src/system/thread_mgr.hpp
+++ b/library/src/system/thread_mgr.hpp
@@ -13,8 +13,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 
 /**
  * @brief Thread manager for bridge double dummy solver.
@@ -28,8 +26,8 @@ class ThreadMgr
 {
   private:
 
-    vector<bool> realThreads;
-    vector<int> machineThreads;
+    std::vector<bool> realThreads;
+    std::vector<int> machineThreads;
     unsigned numRealThreads;
     unsigned numMachineThreads;
 
@@ -64,8 +62,8 @@ class ThreadMgr
     bool Release(const int MachineThrId);
 
     void Print(
-      const string& fname,
-      const string& tag) const;
+      const std::string& fname,
+      const std::string& tag) const;
 };
 
 #endif

--- a/library/src/system/time_stat.cpp
+++ b/library/src/system/time_stat.cpp
@@ -16,6 +16,13 @@
 
 #include "time_stat.hpp"
 
+using std::fixed;
+using std::right;
+using std::setprecision;
+using std::setw;
+using std::string;
+using std::stringstream;
+
 
 TimeStat::TimeStat()
 {

--- a/library/src/system/time_stat.hpp
+++ b/library/src/system/time_stat.hpp
@@ -12,8 +12,6 @@
 
 #include <string>
 
-using namespace std;
-
 
 /**
  * @brief Timing statistics accumulator for bridge double dummy solver.
@@ -57,8 +55,8 @@ class TimeStat
 
     bool Used() const;
 
-    string Header() const;
-    string Line() const;
+    std::string Header() const;
+    std::string Line() const;
 };
 
 #endif

--- a/library/src/system/time_stat_list.cpp
+++ b/library/src/system/time_stat_list.cpp
@@ -14,6 +14,11 @@
 
 #include "time_stat_list.hpp"
 
+using std::right;
+using std::setw;
+using std::string;
+using std::stringstream;
+
 
 TimeStatList::TimeStatList()
 {

--- a/library/src/system/timer.cpp
+++ b/library/src/system/timer.cpp
@@ -55,14 +55,14 @@ void Timer::SetName(const string& nameIn)
 void Timer::Start()
 {
   user0 = Clock::now();
-  syst0 = clock();
+  syst0 = std::clock();
 }
 
 
 void Timer::End()
 {
   std::chrono::time_point<Clock> user1 = Clock::now();
-  clock_t syst1 = clock();
+  std::clock_t syst1 = std::clock();
 
   std::chrono::duration<double, std::micro> d = user1 - user0;
   int tuser = static_cast<int>(d.count());

--- a/library/src/system/timer.cpp
+++ b/library/src/system/timer.cpp
@@ -17,8 +17,13 @@
 
 #include "timer.hpp"
 
-using std::chrono::duration_cast;
-using std::chrono::microseconds;
+using std::fixed;
+using std::left;
+using std::right;
+using std::setprecision;
+using std::setw;
+using std::string;
+using std::stringstream;
 
 
 Timer::Timer()
@@ -56,10 +61,10 @@ void Timer::Start()
 
 void Timer::End()
 {
-  time_point<Clock> user1 = Clock::now();
+  std::chrono::time_point<Clock> user1 = Clock::now();
   clock_t syst1 = clock();
 
-  chrono::duration<double, micro> d = user1 - user0;
+  std::chrono::duration<double, std::micro> d = user1 - user0;
   int tuser = static_cast<int>(d.count());
 
   count++;

--- a/library/src/system/timer.hpp
+++ b/library/src/system/timer.hpp
@@ -14,9 +14,6 @@
 #include <chrono>
 
 using Clock = std::chrono::steady_clock;
-using std::chrono::time_point;
-
-using namespace std;
 
 
 /**
@@ -31,12 +28,12 @@ class Timer
 {
   private:
 
-    string name;
+    std::string name;
     unsigned int count;
     long userCum;
     long systCum;
 
-    time_point<Clock> user0;
+    std::chrono::time_point<Clock> user0;
     clock_t syst0;
 
   public:
@@ -57,7 +54,7 @@ class Timer
 
     void Reset();
 
-    void SetName(const string& nameIn);
+    void SetName(const std::string& nameIn);
 
     void Start();
 
@@ -71,11 +68,11 @@ class Timer
 
     void operator -= (const Timer& deduct);
 
-    string SumLine(
+    std::string SumLine(
       const Timer& divisor,
-      const string& bname = "") const;
+      const std::string& bname = "") const;
 
-    string DetailLine() const;
+    std::string DetailLine() const;
 };
 
 #endif

--- a/library/src/system/timer.hpp
+++ b/library/src/system/timer.hpp
@@ -35,7 +35,7 @@ class Timer
     long systCum;
 
     std::chrono::time_point<Clock> user0;
-    clock_t syst0;
+    std::clock_t syst0;
 
   public:
 

--- a/library/src/system/timer.hpp
+++ b/library/src/system/timer.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <chrono>
+#include <ctime>
 
 using Clock = std::chrono::steady_clock;
 

--- a/library/src/system/timer_group.cpp
+++ b/library/src/system/timer_group.cpp
@@ -16,6 +16,13 @@
 
 #include "timer_group.hpp"
 
+using std::left;
+using std::right;
+using std::setw;
+using std::string;
+using std::stringstream;
+using std::to_string;
+
 // Number of per-depth timer slots reserved by TimerGroup::Reset().
 constexpr int TIMER_DEPTH = 50;
 

--- a/library/src/system/timer_list.cpp
+++ b/library/src/system/timer_list.cpp
@@ -16,6 +16,9 @@
 #include <fstream>
 #include <ostream>
 
+using std::endl;
+using std::ofstream;
+
 
 TimerList::TimerList()
 {

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -90,7 +90,7 @@ void TestTimer::start(const int number)
 
 void TestTimer::end()
 {
-  time_point<Clock> user1 = Clock::now();
+  std::chrono::time_point<Clock> user1 = Clock::now();
   clock_t sys1 = clock();
 
   duration<double, std::milli> d = user1 - user0_;

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -70,7 +70,7 @@ void TestTimer::set_name(const string& s)
 }
 
 
-long clock_delta_to_ms(clock_t delta)
+long clock_delta_to_ms(std::clock_t delta)
 {
   return static_cast<long>(
     (1000.0 * static_cast<double>(delta)) /
@@ -82,8 +82,8 @@ void TestTimer::start(const int number)
 {
   pending_hands_ = number;
   user0_ = Clock::now();
-  sys0_ = clock();
-  if (sys0_ == static_cast<clock_t>(-1))
+  sys0_ = std::clock();
+  if (sys0_ == static_cast<std::clock_t>(-1))
     sys_time_known_ = false;
 }
 
@@ -91,14 +91,14 @@ void TestTimer::start(const int number)
 void TestTimer::end()
 {
   std::chrono::time_point<Clock> user1 = Clock::now();
-  clock_t sys1 = clock();
+  std::clock_t sys1 = std::clock();
 
   duration<double, std::milli> d = user1 - user0_;
   const long tuser = static_cast<long>(d.count());
   long tsys = 0;
   if (sys_time_known_)
   {
-    if (sys1 == static_cast<clock_t>(-1))
+    if (sys1 == static_cast<std::clock_t>(-1))
       sys_time_known_ = false;
     else
       tsys = clock_delta_to_ms(sys1 - sys0_);

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -17,7 +17,6 @@
 #include <iostream>
 
 using Clock = std::chrono::steady_clock;
-using std::chrono::time_point;
 
 /// @file TestTimer.hpp
 /// @brief High-resolution performance timing utility for tests.
@@ -44,7 +43,7 @@ class TestTimer
     int pending_hands_;     ///< Hands counted into the open start()/end() batch
     bool sys_time_known_;   ///< False when clock() is unusable (e.g. wasm32)
 
-    time_point<Clock> user0_;  ///< Wall-clock start time
+    std::chrono::time_point<Clock> user0_;  ///< Wall-clock start time
     clock_t sys0_;             ///< CPU start time
 
   public:

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -28,7 +28,7 @@ using Clock = std::chrono::steady_clock;
 /// Convert a `clock()` tick delta to milliseconds.
 /// Uses floating-point so `1000 * ticks` cannot overflow 32-bit `long`
 /// (wasm32 batches longer than ~2.15s when CLOCKS_PER_SEC is 1e6).
-long clock_delta_to_ms(clock_t delta);
+long clock_delta_to_ms(std::clock_t delta);
 
 /// Timer for measuring test performance.
 /// Tracks both wall-clock (user) and CPU (system) time for test execution.
@@ -44,7 +44,7 @@ class TestTimer
     bool sys_time_known_;   ///< False when clock() is unusable (e.g. wasm32)
 
     std::chrono::time_point<Clock> user0_;  ///< Wall-clock start time
-    clock_t sys0_;             ///< CPU start time
+    std::clock_t sys0_;        ///< CPU start time
 
   public:
 

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -39,7 +39,7 @@ std::int32_t wrap_i64_to_i32(const std::int64_t value)
 }
 
 /// What the old `1000 * delta` path produces when `long` is 32-bit (wasm32).
-long wrapped_i32_clock_delta_to_ms(const clock_t delta)
+long wrapped_i32_clock_delta_to_ms(const std::clock_t delta)
 {
   const auto prod =
     wrap_i64_to_i32(1000 * static_cast<std::int64_t>(delta));
@@ -48,10 +48,10 @@ long wrapped_i32_clock_delta_to_ms(const clock_t delta)
 
 /// Smallest tick count where `1000 * ticks` no longer fits in int32.
 /// Independent of CLOCKS_PER_SEC (1000 on Windows, 1e6 on POSIX/wasm).
-clock_t ticks_that_overflow_i32_multiply()
+std::clock_t ticks_that_overflow_i32_multiply()
 {
   constexpr auto kMaxI32 = std::numeric_limits<std::int32_t>::max();
-  return static_cast<clock_t>(
+  return static_cast<std::clock_t>(
     static_cast<std::int64_t>(kMaxI32) / 1000 + 1);
 }
 
@@ -78,7 +78,7 @@ TEST(TestTimer, WrapI64ToI32UsesDefinedTwosComplement)
 
 TEST(TestTimer, ClockDeltaToMsAvoids32BitOverflowForMultiSecondBatches)
 {
-  const clock_t ticks = ticks_that_overflow_i32_multiply();
+  const std::clock_t ticks = ticks_that_overflow_i32_multiply();
   const long expected_ms = static_cast<long>(
     (1000.0 * static_cast<double>(ticks)) /
     static_cast<double>(CLOCKS_PER_SEC));

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -29,6 +29,8 @@
 
 using std::cout;
 using std::endl;
+using std::left;
+using std::right;
 using std::setw;
 using std::string;
 using std::vector;


### PR DESCRIPTION
## What

`using namespace std;` (and one namespace-scope `using std::chrono::time_point;`) appeared at file scope in several headers. That injects names into every translation unit that includes the header, directly or transitively — bad style and a maintenance hazard.

### Headers cleaned (declarations now fully qualified)

- `library/src/system/system.hpp`
- `library/src/system/thread_mgr.hpp`
- `library/src/system/time_stat.hpp`
- `library/src/system/timer.hpp`
- `library/tests/TestTimer.hpp`

The `using Clock = std::chrono::steady_clock;` alias-declarations are left as-is (they are type aliases, not using-directives/declarations).

### Translation units updated

Several `.cpp` files had been leaning on those headers' transitive `using`. They now declare what they need locally:

- Specific `using std::...;` declarations added to `init.cpp` and the `system/*.cpp` printing/formatting code.
- Point qualification (`std::vector`, `std::chrono::time_point`) in `calc_tables.cpp`, `solve_board.cpp`, `timer.cpp`, `TestTimer.cpp`.
- `testcommon.cpp` gains `using std::left; using std::right;` alongside its existing `using std::` block.

### Coding standard

`.github/instructions/cpp.instructions.md` gains a dedicated **Namespace `using`** section replacing the terse "No `using namespace` in headers" bullet: headers ban namespace-scope using-directives *and* using-declarations (class/function-body `using` and alias-declarations still fine); `.cpp` files prefer specific using-declarations, with file-scope `using namespace` permitted but discouraged; never rely on a `using` supplied by an included header.

## Testing

- `bazel build //...` — passes
- `bazel test //...` — 93/93 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #357