### PR TITLE
Show DD-table solve time and debounce hand-edit solves

### DIFF
--- a/web/dds_web.css
+++ b/web/dds_web.css
@@ -110,6 +110,14 @@
   text-align: center;
 }
 
+#result {
+  font-size: 0.9rem;
+  line-height: 1.2;
+  margin: 0.45em 0 0;
+  min-height: 1.2em;
+  text-align: center;
+}
+
 .contract-status-panel {
   align-items: baseline;
   display: flex;

--- a/web/dds_web.html
+++ b/web/dds_web.html
@@ -129,11 +129,10 @@
                     <td valign="top"><br></td>
                 </tr>
             </table>
+            <p id="result" aria-live="polite"></p>
         </div>
     </div>
     </div>
-
-    <p id="result"></p>
 
     <script src="dds_web_wasm_bin.js"></script>
     <script src="dds_web_wasm.js"></script>

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -2085,9 +2085,11 @@ function updateActionButtons(activeElement) {
         inputIsValid(hands).length === 0;
 
     // Solve as soon as the deal first becomes complete (fourth-hand auto-fill
-    // or the final pip). Debounce only subsequent edits of a complete deal so
-    // typing does not sync-ccall on every keystroke.
-    if (dealComplete && !lastDealWasComplete) {
+    // or the final pip). Clear immediately when a complete deal becomes
+    // incomplete so stale DD numerals do not linger for the debounce window.
+    // Debounce only subsequent edits that stay in the same completeness state
+    // so typing does not sync-ccall on every keystroke.
+    if (dealComplete !== lastDealWasComplete) {
         void scheduleDealSolve();
     } else {
         void scheduleDealSolveDebounced();

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -26,7 +26,6 @@
             refreshOpeningLeadTricks
             scheduleDealSolve
             setDealSolveDebounceMs
-            scheduleDealSolveDebounced
             fourthHandFillState
             updateActionButtons
             sanitizeSuitHolding
@@ -119,15 +118,14 @@ function scheduleDealSolveDebounced() {
     }
 
     if (dealSolveDebounceMs <= 0) {
-        return scheduleDealSolve();
+        void scheduleDealSolve();
+        return;
     }
 
     dealSolveDebounceTimer = setTimeout(() => {
         dealSolveDebounceTimer = null;
         scheduleDealSolve();
     }, dealSolveDebounceMs);
-
-    return solveQueue;
 }
 
 // Coalesce DD-table + lead solves onto one queued job so rapid hand edits and

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -25,6 +25,8 @@
             refreshDdTable
             refreshOpeningLeadTricks
             scheduleDealSolve
+            setDealSolveDebounceMs
+            scheduleDealSolveDebounced
             fourthHandFillState
             updateActionButtons
             sanitizeSuitHolding
@@ -90,6 +92,13 @@ let lastDdTablePbn = null;
 let solveQueue = Promise.resolve();
 let dealSolveEpoch = 0;
 let dealSolveQueued = false;
+// Delay WASM work after hand edits so typing on a complete deal does not
+// freeze the UI on every keystroke (sync ccall). Contract clicks stay immediate.
+let dealSolveDebounceMs = 250;
+let dealSolveDebounceTimer = null;
+// Track completeness so the first transition to a full deal solves immediately
+// (auto-fill / final pip), while further edits of that deal stay debounced.
+let lastDealWasComplete = false;
 
 function enqueueSolve(task) {
     const run = solveQueue.then(task, task);
@@ -99,10 +108,39 @@ function enqueueSolve(task) {
     return run;
 }
 
+function setDealSolveDebounceMs(ms) {
+    dealSolveDebounceMs = ms;
+}
+
+function scheduleDealSolveDebounced() {
+    if (dealSolveDebounceTimer != null) {
+        clearTimeout(dealSolveDebounceTimer);
+        dealSolveDebounceTimer = null;
+    }
+
+    if (dealSolveDebounceMs <= 0) {
+        return scheduleDealSolve();
+    }
+
+    dealSolveDebounceTimer = setTimeout(() => {
+        dealSolveDebounceTimer = null;
+        scheduleDealSolve();
+    }, dealSolveDebounceMs);
+
+    return solveQueue;
+}
+
 // Coalesce DD-table + lead solves onto one queued job so rapid hand edits and
 // contract clicks cannot interleave CalcDDtable with SolveBoard, and so
 // intermediate schedules do not each add a stale promise-chain callback.
 function scheduleDealSolve() {
+    // A direct schedule (contract click, etc.) supersedes a pending debounced
+    // hand-edit solve so we do not fire a redundant trailing job afterward.
+    if (dealSolveDebounceTimer != null) {
+        clearTimeout(dealSolveDebounceTimer);
+        dealSolveDebounceTimer = null;
+    }
+
     dealSolveEpoch += 1;
 
     if (dealSolveQueued) {
@@ -2043,7 +2081,19 @@ function updateActionButtons(activeElement) {
 
     updateHandCardDisplays(hands);
 
-    void scheduleDealSolve();
+    const dealComplete = allHandsHaveThirteenCards(hands) &&
+        inputIsValid(hands).length === 0;
+
+    // Solve as soon as the deal first becomes complete (fourth-hand auto-fill
+    // or the final pip). Debounce only subsequent edits of a complete deal so
+    // typing does not sync-ccall on every keystroke.
+    if (dealComplete && !lastDealWasComplete) {
+        void scheduleDealSolve();
+    } else {
+        void scheduleDealSolveDebounced();
+    }
+
+    lastDealWasComplete = dealComplete;
 }
 
 function collectHands() {

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -65,6 +65,7 @@
             pipFromDdsRank
             leadTricksMapFromSolverOutput
             wasmSolveEnvironmentError
+            formatSolveTimeMs
             */
 
 // It's also useful to pass the code through
@@ -2156,6 +2157,11 @@ function clear_results() {
     }
 }
 
+/** Format wall elapsed time for the status line (whole milliseconds). */
+function formatSolveTimeMs(elapsedMs) {
+    return "Solved in " + Math.round(elapsedMs) + " ms.";
+}
+
 async function refreshDdTable() {
     const requestId = ++ddTableRequestId;
     const result = document.getElementById("result");
@@ -2203,12 +2209,14 @@ async function refreshDdTable() {
         const outPtr = module._malloc(20 * 4);
 
         try {
+            const startedAt = performance.now();
             const rc = module.ccall(
                 "dds_web_calc_table",
                 "number",
                 ["string", "number"],
                 [pbn, outPtr]
             );
+            const elapsedMs = performance.now() - startedAt;
 
             if (requestId !== ddTableRequestId) {
                 return;
@@ -2240,7 +2248,7 @@ async function refreshDdTable() {
             lastDdTablePbn = pbn;
 
             if (result) {
-                result.innerHTML = "";
+                result.innerHTML = formatSolveTimeMs(elapsedMs);
             }
         } finally {
             module._free(outPtr);

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -124,7 +124,7 @@ function scheduleDealSolveDebounced() {
 
     dealSolveDebounceTimer = setTimeout(() => {
         dealSolveDebounceTimer = null;
-        scheduleDealSolve();
+        void scheduleDealSolve();
     }, dealSolveDebounceMs);
 }
 

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -2089,15 +2089,14 @@ function updateActionButtons(activeElement) {
     const dealComplete = allHandsHaveThirteenCards(hands) &&
         inputIsValid(hands).length === 0;
 
-    // Solve as soon as the deal first becomes complete (fourth-hand auto-fill
-    // or the final pip). Clear immediately when a complete deal becomes
-    // incomplete so stale DD numerals do not linger for the debounce window.
-    // Debounce only subsequent edits that stay in the same completeness state
-    // so typing does not sync-ccall on every keystroke.
-    if (dealComplete !== lastDealWasComplete) {
-        void scheduleDealSolve();
-    } else {
+    // Debounce only while the deal stays solvable so typing on a complete deal
+    // does not sync-ccall on every keystroke. Incomplete/invalid edits (and the
+    // first transition to a complete deal) schedule immediately: clear/error
+    // updates are cheap, and first completion should feel instant.
+    if (dealComplete && lastDealWasComplete) {
         void scheduleDealSolveDebounced();
+    } else {
+        void scheduleDealSolve();
     }
 
     lastDealWasComplete = dealComplete;

--- a/web/dds_web.js
+++ b/web/dds_web.js
@@ -109,6 +109,13 @@ function enqueueSolve(task) {
 
 function setDealSolveDebounceMs(ms) {
     dealSolveDebounceMs = ms;
+
+    // Disabling debounce must not leave a previously scheduled trailing solve
+    // to fire later with the old delay.
+    if (ms <= 0 && dealSolveDebounceTimer != null) {
+        clearTimeout(dealSolveDebounceTimer);
+        dealSolveDebounceTimer = null;
+    }
 }
 
 function scheduleDealSolveDebounced() {

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -745,6 +745,32 @@ test("scheduleDealSolveDebounced does not return an awaitable for the trailing s
     assert.equal(returned, undefined);
 });
 
+test("disabling debounce cancels a pending debounced solve", async () => {
+    // Arrange: complete deal with a pending trailing hand-edit solve.
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(100);
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+    ctx.fillFormWithPartScoreTestData();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ddRuns, 1);
+    ddRuns = 0;
+
+    document.setValue("south_spades", "927");
+    ctx.updateActionButtons(document.element("south_spades"));
+    assert.equal(ddRuns, 0);
+
+    // Act: disable debounce while the timer is still pending.
+    ctx.setDealSolveDebounceMs(0);
+
+    // Assert: the previously scheduled trailing solve must not fire.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(ddRuns, 0);
+});
+
 test("contract selection still schedules a deal solve immediately", async () => {
     const document = createMockDocument();
     const ctx = loadDdsWeb(document);

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -700,8 +700,9 @@ test("rapid scheduleDealSolve does not enqueue one queue job per call", async ()
     assert.ok(ddRuns >= 2);
 });
 
-test("hand-edit solves are debounced so rapid typing does not start WASM immediately", async () => {
-    // Arrange: complete deal; each keystroke would otherwise sync-ccall and freeze.
+test("subsequent edits of a still-complete deal are debounced", async () => {
+    // Arrange: complete deal; reordering pips keeps the deal complete so each
+    // keystroke would otherwise schedule a solve immediately.
     const document = createMockDocument();
     const ctx = loadDdsWeb(document);
     ctx.setDealSolveDebounceMs(50);
@@ -714,10 +715,10 @@ test("hand-edit solves are debounced so rapid typing does not start WASM immedia
     assert.equal(ddRuns, 1);
     ddRuns = 0;
 
-    // Act: burst of hand edits (as when typing into South on a full deal).
-    document.setValue("south_spades", "972A");
+    // Act: burst of still-complete edits (reorder South's spade holding).
+    document.setValue("south_spades", "927");
     ctx.updateActionButtons(document.element("south_spades"));
-    document.setValue("south_spades", "972AK");
+    document.setValue("south_spades", "279");
     ctx.updateActionButtons(document.element("south_spades"));
     document.setValue("south_spades", "972");
     ctx.updateActionButtons(document.element("south_spades"));
@@ -799,6 +800,38 @@ test("completing the fourth hand manually schedules a solve immediately", async 
 
     // Assert
     assert.equal(ddRuns, 1);
+});
+
+test("breaking a complete deal clears DD results immediately despite debounce", async () => {
+    // Arrange: complete deal with populated results; deleting a card must not
+    // leave stale DD numerals visible for the debounce window.
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    ctx.fillFormWithPartScoreTestData();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    document.element("result").innerHTML = "Solved in 12 ms.";
+    document.element("result-table").innerHTML =
+        "<tr><td>N</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>";
+
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+        // Mirror production: incomplete deals clear immediately.
+        document.element("result").innerHTML = "";
+        document.element("result-table").innerHTML = "";
+    };
+
+    // Act: remove a card so the deal is no longer complete.
+    document.setValue("south_spades", "97");
+    ctx.updateActionButtons(document.element("south_spades"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Assert: clear path runs now, not after the debounce delay.
+    assert.equal(ddRuns, 1);
+    assert.equal(document.element("result").innerHTML, "");
+    assert.equal(document.element("result-table").innerHTML, "");
 });
 
 test("pageLoad shows valid pips", () => {

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -225,7 +225,7 @@ function createMockDocument(initialValues = {}) {
     return documentRef;
 }
 
-function loadDdsWeb(document) {
+function loadDdsWeb(document, extras = {}) {
     const code = readFileSync(findDdsWebJsPath(), "utf8");
     const sandbox = {
         document,
@@ -233,6 +233,12 @@ function loadDdsWeb(document) {
         Promise,
         Error,
         setTimeout,
+        performance: {
+            now() {
+                return 0;
+            },
+        },
+        ...extras,
     };
     const context = createContext(sandbox);
     runInContext(code, context, { filename: "dds_web.js" });
@@ -1293,6 +1299,51 @@ test("refreshDdTable clears the results table when the deal is incomplete", () =
     // Assert
     assert.equal(cell.innerHTML, "");
     assert.equal(document.element("result").innerHTML, "");
+});
+
+test("formatSolveTimeMs rounds wall time to whole milliseconds", () => {
+    const ctx = loadDdsWeb(createMockDocument());
+
+    assert.equal(ctx.formatSolveTimeMs(0), "Solved in 0 ms.");
+    assert.equal(ctx.formatSolveTimeMs(0.4), "Solved in 0 ms.");
+    assert.equal(ctx.formatSolveTimeMs(0.5), "Solved in 1 ms.");
+    assert.equal(ctx.formatSolveTimeMs(12.3), "Solved in 12 ms.");
+    assert.equal(ctx.formatSolveTimeMs(41.9), "Solved in 42 ms.");
+});
+
+test("refreshDdTable shows wall solve time in ms after a successful solve", async () => {
+    // Arrange: full part-score deal; mock WASM and a clock that advances 12.4 ms.
+    let clock = 1000;
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document, {
+        performance: {
+            now() {
+                return clock;
+            },
+        },
+    });
+    ctx.fillFormWithPartScoreTestData();
+    ctx.loadDdsModule = async () => ({
+        _malloc: () => 0,
+        _free() {},
+        ccall() {
+            clock += 12.4;
+            return 1;
+        },
+        getValue() {
+            return 7;
+        },
+    });
+
+    // Act
+    await ctx.refreshDdTable();
+
+    // Assert
+    assert.equal(document.element("result").innerHTML, "Solved in 12 ms.");
+    assert.equal(
+        String(document.element("result-table").rows[1].cells[1].innerHTML),
+        "7"
+    );
 });
 
 test("updateActionButtons displays all 52 cards in the deck status", () => {
@@ -3060,11 +3111,28 @@ test("result table lives in the hand diagram southeast corner", () => {
         /result-table-hint[\s\S]*?id="result-table"/
     );
     assert.match(afterSe, /id="result-table"/);
+    // Solve status (Computing… / wall time / errors) sits under the table in
+    // the SE cell so it is visible next to the results users are watching.
+    assert.match(
+        afterSe,
+        /id="result-table"[\s\S]*?<p\b[^>]*\bid="result"[^>]*>/
+    );
+    assert.match(
+        afterSe,
+        /<p\b[^>]*\bid="result"[^>]*\baria-live="polite"/
+    );
+    // Only one #result, and it is not left below the diagram.
+    assert.equal((html.match(/\bid="result"/g) || []).length, 1);
+    assert.doesNotMatch(
+        html.slice(html.indexOf("</div>\n    </div>\n    </div>")),
+        /id="result"/
+    );
     // SE cell must be readable (not aria-hidden) and sized for the table.
     assert.doesNotMatch(seOpen[0], /aria-hidden="true"/);
     assert.match(css, /\.grid-item\.grid-filler-se\s*\{[^}]*font-size:/s);
     assert.match(css, /\.grid-item\.grid-filler-se\s*\{[^}]*flex-direction:\s*column/s);
     assert.match(css, /\.result-table-hint\s*\{/s);
+    assert.match(css, /#result\s*\{/s);
 });
 
 test("contract status lives in the hand diagram northeast corner", () => {

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -731,6 +731,20 @@ test("subsequent edits of a still-complete deal are debounced", async () => {
     assert.equal(ddRuns, 1);
 });
 
+test("scheduleDealSolveDebounced does not return an awaitable for the trailing solve", () => {
+    // Arrange: non-zero debounce so the timer path is used (not the sync fallback).
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    ctx.refreshDdTable = async () => {};
+
+    // Act
+    const returned = ctx.scheduleDealSolveDebounced();
+
+    // Assert: callers must not treat the return as "debounced work finished".
+    assert.equal(returned, undefined);
+});
+
 test("contract selection still schedules a deal solve immediately", async () => {
     const document = createMockDocument();
     const ctx = loadDdsWeb(document);
@@ -740,8 +754,9 @@ test("contract selection still schedules a deal solve immediately", async () => 
         ddRuns += 1;
     };
     ctx.fillFormWithPartScoreTestData();
-    // Let the debounced fillForm solve fire, then reset.
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    // fillForm completes the deal, which schedules immediately (not debounced).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ddRuns, 1);
     ddRuns = 0;
 
     ctx.handleResultTableClick({

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -233,6 +233,7 @@ function loadDdsWeb(document, extras = {}) {
         Promise,
         Error,
         setTimeout,
+        clearTimeout,
         performance: {
             now() {
                 return 0;
@@ -242,6 +243,11 @@ function loadDdsWeb(document, extras = {}) {
     };
     const context = createContext(sandbox);
     runInContext(code, context, { filename: "dds_web.js" });
+    // Existing tests expect hand edits to schedule immediately; debounce is
+    // covered by dedicated tests that opt into a non-zero delay.
+    if (typeof context.setDealSolveDebounceMs === "function") {
+        context.setDealSolveDebounceMs(0);
+    }
     return context;
 }
 
@@ -692,6 +698,107 @@ test("rapid scheduleDealSolve does not enqueue one queue job per call", async ()
     // Trailing epoch may re-run work inside the same job, but still one enqueue.
     assert.equal(enqueued, enqueuedWhileBlocked);
     assert.ok(ddRuns >= 2);
+});
+
+test("hand-edit solves are debounced so rapid typing does not start WASM immediately", async () => {
+    // Arrange: complete deal; each keystroke would otherwise sync-ccall and freeze.
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(50);
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+    ctx.fillFormWithPartScoreTestData();
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(ddRuns, 1);
+    ddRuns = 0;
+
+    // Act: burst of hand edits (as when typing into South on a full deal).
+    document.setValue("south_spades", "972A");
+    ctx.updateActionButtons(document.element("south_spades"));
+    document.setValue("south_spades", "972AK");
+    ctx.updateActionButtons(document.element("south_spades"));
+    document.setValue("south_spades", "972");
+    ctx.updateActionButtons(document.element("south_spades"));
+
+    // Assert: no solve until the debounce window elapses, then one trailing run.
+    assert.equal(ddRuns, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(ddRuns, 0);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(ddRuns, 1);
+});
+
+test("contract selection still schedules a deal solve immediately", async () => {
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+    ctx.fillFormWithPartScoreTestData();
+    // Let the debounced fillForm solve fire, then reset.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    ddRuns = 0;
+
+    ctx.handleResultTableClick({
+        target: {
+            closest() {
+                return document.element("result-table").rows[3].cells[5];
+            },
+        },
+    });
+
+    // Contract click must not wait for the hand-edit debounce.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ddRuns, 1);
+});
+
+test("fourth-hand auto-fill schedules a solve immediately despite debounce", async () => {
+    // Arrange: three complete hands; completing the third triggers auto-fill.
+    const document = threeHandsPartScoreDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+
+    // Act
+    ctx.updateActionButtons();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Assert: West is filled and the DD solve does not wait for debounce.
+    assert.equal(document.element("west_spades").value, "K643");
+    assert.equal(ddRuns, 1);
+});
+
+test("completing the fourth hand manually schedules a solve immediately", async () => {
+    // Arrange: South is one card short of a complete deal.
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    ctx.fillFormWithPartScoreTestData();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    document.setValue("south_spades", "97"); // was 972; now 12 cards in South
+    ctx.updateActionButtons(document.element("south_spades"));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+
+    // Act: type the final pip that restores 13 cards.
+    document.setValue("south_spades", "972");
+    ctx.updateActionButtons(document.element("south_spades"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Assert
+    assert.equal(ddRuns, 1);
 });
 
 test("pageLoad shows valid pips", () => {

--- a/web/tests/dds_web_test.mjs
+++ b/web/tests/dds_web_test.mjs
@@ -875,6 +875,32 @@ test("breaking a complete deal clears DD results immediately despite debounce", 
     assert.equal(document.element("result-table").innerHTML, "");
 });
 
+test("edits that keep the deal incomplete refresh immediately despite debounce", async () => {
+    // Arrange: incomplete deal; clear/error updates are cheap (no WASM) and
+    // must stay responsive so validation/status does not linger.
+    const document = createMockDocument();
+    const ctx = loadDdsWeb(document);
+    ctx.setDealSolveDebounceMs(200);
+    let ddRuns = 0;
+    ctx.refreshDdTable = async () => {
+        ddRuns += 1;
+    };
+
+    document.setValue("north_spades", "A");
+    ctx.updateActionButtons(document.element("north_spades"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(ddRuns, 1);
+    ddRuns = 0;
+
+    // Act: another still-incomplete edit.
+    document.setValue("north_spades", "AK");
+    ctx.updateActionButtons(document.element("north_spades"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Assert: not deferred by the hand-edit debounce window.
+    assert.equal(ddRuns, 1);
+});
+
 test("pageLoad shows valid pips", () => {
     const document = createMockDocument();
     const ctx = loadDdsWeb(document);

--- a/web/tests/test_web_e2e.py
+++ b/web/tests/test_web_e2e.py
@@ -147,8 +147,8 @@ class DdsWebHtmlE2eTest(unittest.TestCase):
                     expected,
                     msg=f"{direction}/{denomination}",
                 )
-        result_text = page.locator("#result").inner_text()
-        self.assertEqual(result_text.strip(), "")
+        result_text = page.locator("#result").inner_text().strip()
+        self.assertRegex(result_text, r"^Solved in \d+ ms\.$")
 
     def test_page_load_shows_valid_pips(self) -> None:
         page, errors = self._open_page(self.site_dir.joinpath("dds_web.html").as_uri())


### PR DESCRIPTION
## Summary
- Display wall-clock DD-table solve time under the result table as `Solved in X ms.`
- Debounce WASM solves while editing an already-complete deal so sync `ccall` does not freeze typing
- Still solve immediately when the deal first becomes complete (fourth-hand auto-fill or final pip) and on contract selection

## Test plan
- [ ] `bazelisk test //web:dds_web_js_test`
- [ ] Load a part-score test deal and confirm `#result` shows `Solved in N ms.` under the DD table
- [ ] Fill three hands and confirm auto-fill of the fourth triggers an immediate solve
- [ ] Edit a suit on a complete deal rapidly and confirm the UI stays responsive, then one trailing solve runs after typing pauses
- [ ] Select a contract cell and confirm lead analysis still runs without waiting for the hand-edit debounce


Made with [Cursor](https://cursor.com)