### PR TITLE
Improve dtest mismatch handling, TABLE compare, and progress UX

### DIFF
--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
             "calc_par_test.cpp",  # Uses GoogleTest, compiled separately
             "test_timer_test.cpp",  # Uses GoogleTest, compiled separately
             "args_test.cpp",  # Uses GoogleTest, compiled separately
+            "compare_test.cpp",  # Uses GoogleTest, compiled separately
             "report_board_timings_test.cpp",  # Uses GoogleTest, compiled separately
             "parse_par_test.cpp",  # Uses GoogleTest, compiled separately
             "loop_par_test.cpp",  # Uses GoogleTest, compiled separately
@@ -165,6 +166,23 @@ cc_test(
     linkopts = DDS_LINKOPTS,
     local_defines = DDS_LOCAL_DEFINES,
     deps = [
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "compare_test",
+    srcs = [
+        "compare_test.cpp",
+        "compare.cpp",
+        "compare.hpp",
+    ],
+    size = "small",
+    copts = DDS_CPPOPTS,
+    linkopts = DDS_LINKOPTS,
+    local_defines = DDS_LOCAL_DEFINES,
+    deps = [
+        "//library/src/api:api_definitions",
         "@googletest//:gtest_main",
     ],
 )

--- a/library/tests/BUILD.bazel
+++ b/library/tests/BUILD.bazel
@@ -246,6 +246,17 @@ py_test(
     ],
 )
 
+# Integration: real_main/main must exit non-zero after the first mismatch.
+py_test(
+    name = "dtest_mismatch_exit_test",
+    size = "small",
+    srcs = ["test_dtest_mismatch_exit.py"],
+    main = "test_dtest_mismatch_exit.py",
+    data = [
+        ":dtest",
+    ],
+)
+
 cc_test(
     name = "loop_par_test",
     srcs = [

--- a/library/tests/TestTimer.cpp
+++ b/library/tests/TestTimer.cpp
@@ -49,6 +49,7 @@ void TestTimer::reset()
   sys_cum_ = 0;
   pending_hands_ = 0;
   sys_time_known_ = true;
+  running_line_active_ = false;
 }
 
 
@@ -127,14 +128,26 @@ void TestTimer::print_running(
   if (count_ == 0)
     return;
 
-  cout << setw(8) << reached << " (" <<
+  // Overwrite a single terminal line: clear, return to column 0, rewrite, flush.
+  cout << "\033[2K\r" << setw(8) << reached << " (" <<
     setw(6) << setprecision(1) << right << fixed <<
-      100. * reached / 
+      100. * reached /
         static_cast<float>(divisor) << "%)" <<
-    setw(15) << right << fixed << setprecision(0) << 
-      (user_cum_ - user_cum_old_) << endl;
-  
+    setw(15) << right << fixed << setprecision(0) <<
+      (user_cum_ - user_cum_old_) << std::flush;
+
   user_cum_old_ = user_cum_;
+  running_line_active_ = true;
+}
+
+
+void TestTimer::finish_running()
+{
+  if (!running_line_active_)
+    return;
+  // Erase the in-place progress line so it does not remain after the run.
+  cout << "\033[2K\r" << std::flush;
+  running_line_active_ = false;
 }
 
 

--- a/library/tests/TestTimer.hpp
+++ b/library/tests/TestTimer.hpp
@@ -42,6 +42,7 @@ class TestTimer
     long sys_cum_;          ///< Cumulative system time (milliseconds)
     int pending_hands_;     ///< Hands counted into the open start()/end() batch
     bool sys_time_known_;   ///< False when clock() is unusable (e.g. wasm32)
+    bool running_line_active_;  ///< True after print_running until finish_running
 
     std::chrono::time_point<Clock> user0_;  ///< Wall-clock start time
     std::clock_t sys0_;        ///< CPU start time
@@ -82,12 +83,15 @@ class TestTimer
     /// @param sys_ms Batch system (CPU) time in milliseconds
     void record(const int hands, const long user_ms, const long sys_ms);
 
-    /// Print timer status while running.
+    /// Print/overwrite a single in-place progress line (ANSI clear + CR).
     /// @param reached Number of iterations completed so far
     /// @param number Total number of iterations
     void print_running(
         const int reached,
         const int number);
+
+    /// End an in-place progress line by clearing it (no leftover 100% row).
+    void finish_running();
     
     /// Print basic timer summary.
     void print_basic() const;

--- a/library/tests/compare.cpp
+++ b/library/tests/compare.cpp
@@ -58,10 +58,10 @@ bool compare_TABLE(
   const DdTableResults& table1, 
   const DdTableResults& table2)
 {
-  for (int suit = 0; suit < DDS_SUITS; suit++)
+  for (int strain = 0; strain < DDS_STRAINS; strain++)
   {
     for (int pl = 0; pl < DDS_HANDS; pl++)
-      if (table1.res_table[suit][pl] != table2.res_table[suit][pl])
+      if (table1.res_table[strain][pl] != table2.res_table[strain][pl])
         return false;
   }
 

--- a/library/tests/compare_test.cpp
+++ b/library/tests/compare_test.cpp
@@ -1,0 +1,45 @@
+/// @file compare_test.cpp
+/// @brief Unit tests for dtest result comparison helpers.
+
+#include <gtest/gtest.h>
+
+#include "compare.hpp"
+
+namespace
+{
+
+auto filled_table(const int value) -> DdTableResults
+{
+  DdTableResults table{};
+  for (int strain = 0; strain < DDS_STRAINS; ++strain)
+  {
+    for (int hand = 0; hand < DDS_HANDS; ++hand)
+      table.res_table[strain][hand] = value;
+  }
+  return table;
+}
+
+}  // namespace
+
+TEST(CompareTable, EqualTablesMatchIncludingNt)
+{
+  const DdTableResults a = filled_table(7);
+  const DdTableResults b = filled_table(7);
+  EXPECT_TRUE(compare_TABLE(a, b));
+}
+
+TEST(CompareTable, DetectsNtOnlyMismatch)
+{
+  DdTableResults a = filled_table(7);
+  DdTableResults b = filled_table(7);
+  b.res_table[4][0] = 8;  // NT / North
+  EXPECT_FALSE(compare_TABLE(a, b));
+}
+
+TEST(CompareTable, DetectsSuitMismatch)
+{
+  DdTableResults a = filled_table(7);
+  DdTableResults b = filled_table(7);
+  b.res_table[0][1] = 3;  // Spades / East
+  EXPECT_FALSE(compare_TABLE(a, b));
+}

--- a/library/tests/dtest.cpp
+++ b/library/tests/dtest.cpp
@@ -82,12 +82,12 @@ int main(int argc, char * argv[])
   else
     cout << "dtest worker threads: " << options.num_threads_ << "\n";
 
-  real_main(argc, argv);
+  const int status = real_main(argc, argv);
 
 #if defined(__EMSCRIPTEN__)
-  dtest_emscripten_clean_exit(0);
+  dtest_emscripten_clean_exit(status);
 #else
   // Restore normal termination so destructors / atexit handlers run.
-  exit(0);
+  exit(status);
 #endif
 }

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -60,11 +60,6 @@ auto loop_solve(
   const int stepsize,
   std::vector<std::pair<int, int>>* board_times) -> bool
 {
-#ifdef BATCHTIMES
-  cout << setw(8) << left << "Hand no." <<
-    setw(25) << right << "Time" << "\n";
-#endif
-
   for (int i = 0; i < number; i += stepsize)
   {
     int count = (i + stepsize > number ? number - i : stepsize);
@@ -92,6 +87,7 @@ auto loop_solve(
     }
     if (ret != RETURN_NO_FAULT)
     {
+      timer.finish_running();
       report_dds_error("loop_solve", ret);
       cout << "loop_solve: i " << i << "\n";
       return false;
@@ -114,6 +110,7 @@ auto loop_solve(
       if (compare_FUT(solvedbdp->solved_board[j], fut_list[i + j]))
         continue;
 
+      timer.finish_running();
       cout << "loop_solve: i " << i << ", j " << j << ": " <<
         "Difference\n\n";
       print_FUT(solvedbdp->solved_board[j]);
@@ -125,7 +122,7 @@ auto loop_solve(
   }
 
 #ifdef BATCHTIMES
-  cout << "\n";
+  timer.finish_running();
 #endif
 
   return true;
@@ -137,11 +134,6 @@ auto loop_calc(
   DdTableResults * table_list,
   const int number) -> bool
 {
-#ifdef BATCHTIMES
-  cout << setw(8) << left << "Hand no." <<
-    setw(25) << right << "Time" << "\n";
-#endif
-
   // One CalcAllTablesPBNX call for the whole file: expands to number×strains
   // boards and solves them in a single parallel job (ddss large-batch shape).
   int filter[DDS_STRAINS] = {0, 0, 0, 0, 0};
@@ -180,6 +172,7 @@ auto loop_calc(
     if (compare_TABLE(results[static_cast<unsigned>(j)], table_list[j]))
       continue;
 
+    timer.finish_running();
     cout << "loop_calc: j " << j << ": Difference\n\n";
     print_TABLE(results[static_cast<unsigned>(j)]);
     cout << "\n";
@@ -189,7 +182,7 @@ auto loop_calc(
   }
 
 #ifdef BATCHTIMES
-  cout << "\n";
+  timer.finish_running();
 #endif
 
   return true;
@@ -238,6 +231,7 @@ auto loop_par(
 
 #ifdef BATCHTIMES
   timer.print_running(number, number);
+  timer.finish_running();
 #endif
 
   return true;
@@ -286,6 +280,7 @@ auto loop_dealerpar(
 
 #ifdef BATCHTIMES
   timer.print_running(number, number);
+  timer.finish_running();
 #endif
 
   return true;
@@ -302,11 +297,6 @@ auto loop_play(
   const int number,
   const int stepsize) -> bool
 {
-#ifdef BATCHTIMES
-  cout << setw(8) << left << "Hand no." <<
-    setw(25) << right << "Time" << "\n";
-#endif
-
   for (int i = 0; i < number; i += stepsize)
   {
     int count = (i + stepsize > number ? number - i : stepsize);
@@ -341,6 +331,7 @@ auto loop_play(
     }
     if (ret != RETURN_NO_FAULT)
     {
+      timer.finish_running();
       report_dds_error("loop_play", ret);
       cout << "loop_play: i " << i << "\n";
       return false;
@@ -356,6 +347,7 @@ auto loop_play(
       if (compare_TRACE(solvedplp->solved[j], trace_list[i+j]))
         continue;
 
+      timer.finish_running();
       printf("loop_play i %d, j %d: Difference\n", i, j);
       cout << "loop_play: i " << i << ", j " << j << ": " <<
         "Difference\n\n";
@@ -366,7 +358,7 @@ auto loop_play(
   }
 
 #ifdef BATCHTIMES
-  printf("\n");
+  timer.finish_running();
 #endif
 
   return true;

--- a/library/tests/loop.cpp
+++ b/library/tests/loop.cpp
@@ -39,17 +39,29 @@ extern OptionsType options;
 extern Scheduler scheduler;
 
 
-void loop_solve(
+namespace {
+
+auto report_dds_error(const char* where, const int code) -> void
+{
+  char line[80];
+  ErrorMessage(code, line);
+  cout << where << ": " << line << " (" << code << ")\n";
+}
+
+}  // namespace
+
+
+auto loop_solve(
   BoardsPBN * bop,
   SolvedBoards * solvedbdp,
   DealPBN * deal_list,
   FutureTricks * fut_list,
   const int number,
   const int stepsize,
-  std::vector<std::pair<int, int>>* board_times)
+  std::vector<std::pair<int, int>>* board_times) -> bool
 {
 #ifdef BATCHTIMES
-  cout << setw(8) << left << "Hand no." << 
+  cout << setw(8) << left << "Hand no." <<
     setw(25) << right << "Time" << "\n";
 #endif
 
@@ -80,8 +92,9 @@ void loop_solve(
     }
     if (ret != RETURN_NO_FAULT)
     {
-      cout << "loop_solve: i " << i << ", return " << ret << "\n";
-      exit(0);
+      report_dds_error("loop_solve", ret);
+      cout << "loop_solve: i " << i << "\n";
+      return false;
     }
     timer.end();
 
@@ -107,6 +120,7 @@ void loop_solve(
       cout << "\n";
       print_FUT(fut_list[i+j]);
       cout << "\n";
+      return false;
     }
   }
 
@@ -114,13 +128,14 @@ void loop_solve(
   cout << "\n";
 #endif
 
+  return true;
 }
 
 
-bool loop_calc(
+auto loop_calc(
   DealPBN * deal_list,
   DdTableResults * table_list,
-  const int number)
+  const int number) -> bool
 {
 #ifdef BATCHTIMES
   cout << setw(8) << left << "Hand no." <<
@@ -152,8 +167,8 @@ bool loop_calc(
   timer.end();
   if (ret != RETURN_NO_FAULT)
   {
-    cout << "loop_calc: CalcAllTablesPBNX return " << ret << "\n";
-    exit(0);
+    report_dds_error("loop_calc", ret);
+    return false;
   }
 
 #ifdef BATCHTIMES
@@ -170,6 +185,7 @@ bool loop_calc(
     cout << "\n";
     print_TABLE(table_list[j]);
     cout << "\n";
+    return false;
   }
 
 #ifdef BATCHTIMES
@@ -181,12 +197,12 @@ bool loop_calc(
 
 
 
-bool loop_par(
+auto loop_par(
   int * vul_list,
   DdTableResults * table_list,
   ParResults * par_list,
   const int number,
-  const int stepsize)
+  const int stepsize) -> bool
 {
   // This is so fast that there is no batch or multi-threaded
   // version. We run it many times just to get meaningful times.
@@ -202,9 +218,9 @@ bool loop_par(
       if ((ret = Par(&table_list[i], &presp, vul_list[i]))
           != RETURN_NO_FAULT)
       {
-        cout << "loop_par: i " << i << ", j " << j << ": " <<
-          "return " << ret << "\n";
-        exit(0);
+        report_dds_error("loop_par", ret);
+        cout << "loop_par: i " << i << ", j " << j << "\n";
+        return false;
       }
     }
 
@@ -216,6 +232,7 @@ bool loop_par(
     cout << "\n";
     print_PAR(par_list[i]);
     cout << "\n";
+    return false;
   }
   timer.end();
 
@@ -227,13 +244,13 @@ bool loop_par(
 }
 
 
-bool loop_dealerpar(
+auto loop_dealerpar(
   int * dealer_list,
   int * vul_list,
   DdTableResults * table_list,
   ParResultsDealer * dealerpar_list,
   const int number,
-  const int stepsize)
+  const int stepsize) -> bool
 {
   // This is so fast that there is no batch or multi-threaded
   // version. We run it many times just to get meaningful times.
@@ -249,9 +266,9 @@ bool loop_dealerpar(
       if ((ret = DealerPar(&table_list[i], &presp,
           dealer_list[i], vul_list[i])) != RETURN_NO_FAULT)
       {
-        cout << "loop_dealerpar: i " << i << ", j " << j << ": " <<
-          "return " << ret << "\n";
-        exit(0);
+        report_dds_error("loop_dealerpar", ret);
+        cout << "loop_dealerpar: i " << i << ", j " << j << "\n";
+        return false;
       }
     }
 
@@ -263,6 +280,7 @@ bool loop_dealerpar(
     cout << "\n";
     print_DEALERPAR(dealerpar_list[i]);
     cout << "\n";
+    return false;
   }
   timer.end();
 
@@ -274,7 +292,7 @@ bool loop_dealerpar(
 }
 
 
-bool loop_play(
+auto loop_play(
   BoardsPBN * bop,
   PlayTracesPBN * playsp,
   SolvedPlays * solvedplp,
@@ -282,10 +300,10 @@ bool loop_play(
   PlayTracePBN * play_list,
   SolvedPlay * trace_list,
   const int number,
-  const int stepsize)
+  const int stepsize) -> bool
 {
 #ifdef BATCHTIMES
-  cout << setw(8) << left << "Hand no." << 
+  cout << setw(8) << left << "Hand no." <<
     setw(25) << right << "Time" << "\n";
 #endif
 
@@ -323,9 +341,9 @@ bool loop_play(
     }
     if (ret != RETURN_NO_FAULT)
     {
-      printf("loop_play i %i: Return %d\n", i, ret);
-      cout << "loop_play: i " << i << ": " << "return " << ret << "\n";
-      exit(0);
+      report_dds_error("loop_play", ret);
+      cout << "loop_play: i " << i << "\n";
+      return false;
     }
     timer.end();
 
@@ -343,6 +361,7 @@ bool loop_play(
         "Difference\n\n";
       print_double_TRACE(solvedplp->solved[j], trace_list[i+j]);
       cout << "\n";
+      return false;
     }
   }
 
@@ -352,4 +371,3 @@ bool loop_play(
 
   return true;
 }
-

--- a/library/tests/loop.hpp
+++ b/library/tests/loop.hpp
@@ -16,7 +16,7 @@
 
 /// @file loop.hpp
 /// @brief Main test loop implementations for DDS solver testing.
-/// 
+///
 /// Executes test loops for various solver operations (solve, calc,
 /// par score, play tracing) over sets of deals.
 
@@ -29,14 +29,15 @@
 /// @param stepsize Boards per solve batch (typically `MAXNOOFBOARDS`)
 /// @param board_times When non-null, appends per-deal timings for every batch
 ///        with file-relative board indices (for `dtest -r`)
-void loop_solve(
+/// @return false on DDS API fault or first expected-result mismatch
+auto loop_solve(
     BoardsPBN * bop,
     SolvedBoards * solvedbdp,
     DealPBN * deal_list,
     FutureTricks * fut_list,
     const int number,
     const int stepsize,
-    std::vector<std::pair<int, int>>* board_times = nullptr);
+    std::vector<std::pair<int, int>>* board_times = nullptr) -> bool;
 
 /// Calculate loop: CalcAllTablesPBNX for the full deal list in one parallel job.
 /// Allocates its own flat deal/result buffers (unbounded X API); no legacy
@@ -44,30 +45,34 @@ void loop_solve(
 /// @param deal_list Input deals in PBN format
 /// @param table_list Expected DD table results
 /// @param number Number of deals in the test set
-bool loop_calc(
+/// @return false on DDS API fault or first expected-result mismatch
+auto loop_calc(
     DealPBN * deal_list,
     DdTableResults * table_list,
-    const int number);
+    const int number) -> bool;
 
 /// PAR loop: calculate PAR scores for multiple deals.
-bool loop_par(
+/// @return false on DDS API fault or first expected-result mismatch
+auto loop_par(
     int * vul_list,
     DdTableResults * table_list,
     ParResults * par_list,
     const int number,
-    const int stepsize);
+    const int stepsize) -> bool;
 
 /// Dealer PAR loop: calculate dealer PAR scores.
-bool loop_dealerpar(
+/// @return false on DDS API fault or first expected-result mismatch
+auto loop_dealerpar(
     int * dealer_list,
     int * vul_list,
     DdTableResults * table_list,
     ParResultsDealer * dealerpar_list,
     const int number,
-    const int stepsize);
+    const int stepsize) -> bool;
 
 /// Play loop: execute play_trace for multiple deals.
-bool loop_play(
+/// @return false on DDS API fault or first expected-result mismatch
+auto loop_play(
     BoardsPBN * bop,
     PlayTracesPBN * playsp,
     SolvedPlays * solvedplp,
@@ -75,4 +80,4 @@ bool loop_play(
     PlayTracePBN * play_list,
     SolvedPlay * trace_list,
     const int number,
-    const int stepsize);
+    const int stepsize) -> bool;

--- a/library/tests/loop_par_test.cpp
+++ b/library/tests/loop_par_test.cpp
@@ -106,3 +106,78 @@ TEST(LoopPar, RecordsHandCountInTimer)
   free(trace_list);
   cleanup(path);
 }
+
+
+TEST(LoopPar, StopsAndReportsOnExpectedMismatch)
+{
+  // Two mismatched deals: stopping on the first must skip the second report.
+  const std::string path =
+    std::string(::testing::TempDir()) + "loop_par_test_mismatch.txt";
+  {
+    std::ofstream out(path, std::ios::out | std::ios::trunc);
+    out << "NUMBER 2 \n"
+        << "PBN 0 0 0 0 \"N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 "
+           "AT942.AQ4.32.KJ3\" \n"
+        << "FUT 0 \n"
+        << "TABLE 5 8 5 8 6 6 6 6 5 7 5 7 7 5 7 5 6 6 6 6 \n"
+        << "PAR \"NS -999\" \"EW 999\" \"NS:EW 7N\" \"EW:EW 7N\" \n"
+        << "PAR2 \"-999\" \"7N-EW\" \n"
+        << "PLAY 0 \"\" \n"
+        << "TRACE 1 0 \n"
+        << "PBN 0 0 0 0 \"N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 "
+           "AT942.AQ4.32.KJ3\" \n"
+        << "FUT 0 \n"
+        << "TABLE 5 8 5 8 6 6 6 6 5 7 5 7 7 5 7 5 6 6 6 6 \n"
+        << "PAR \"NS -888\" \"EW 888\" \"NS:EW 6N\" \"EW:EW 6N\" \n"
+        << "PAR2 \"-888\" \"6N-EW\" \n"
+        << "PLAY 0 \"\" \n"
+        << "TRACE 1 0 \n";
+  }
+
+  int number = 0;
+  bool gib_mode = false;
+  int* dealer_list = nullptr;
+  int* vul_list = nullptr;
+  DealPBN* deal_list = nullptr;
+  FutureTricks* fut_list = nullptr;
+  DdTableResults* table_list = nullptr;
+  ParResults* par_list = nullptr;
+  ParResultsDealer* dealerpar_list = nullptr;
+  PlayTracePBN* play_list = nullptr;
+  SolvedPlay* trace_list = nullptr;
+
+  ASSERT_TRUE(read_file(
+      path,
+      number,
+      gib_mode,
+      &dealer_list,
+      &vul_list,
+      &deal_list,
+      &fut_list,
+      &table_list,
+      &par_list,
+      &dealerpar_list,
+      &play_list,
+      &trace_list));
+  ASSERT_EQ(number, 2);
+
+  timer.reset();
+  testing::internal::CaptureStdout();
+  const bool ok = loop_par(vul_list, table_list, par_list, number, 1);
+  const std::string stdout_text = testing::internal::GetCapturedStdout();
+
+  EXPECT_FALSE(ok);
+  EXPECT_NE(stdout_text.find("loop_par i 0: Difference"), std::string::npos);
+  EXPECT_EQ(stdout_text.find("loop_par i 1:"), std::string::npos);
+
+  free(dealer_list);
+  free(vul_list);
+  free(deal_list);
+  free(fut_list);
+  free(table_list);
+  free(par_list);
+  free(dealerpar_list);
+  free(play_list);
+  free(trace_list);
+  cleanup(path);
+}

--- a/library/tests/test_dtest_mismatch_exit.py
+++ b/library/tests/test_dtest_mismatch_exit.py
@@ -1,0 +1,111 @@
+"""CI coverage: dtest must exit non-zero on the first expected-result mismatch."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _runfiles_root() -> Path | None:
+    for key in ("RUNFILES_DIR", "TEST_SRCDIR"):
+        if key in os.environ:
+            return Path(os.environ[key])
+    return None
+
+
+def _rlocation_from_manifest(relpath: str) -> Path | None:
+    manifest = os.environ.get("RUNFILES_MANIFEST_FILE")
+    if not manifest:
+        return None
+    keys = {relpath, f"_main/{relpath}"}
+    try:
+        with open(manifest, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.rstrip("\n")
+                if not line or line.startswith("[") or line.startswith(" "):
+                    continue
+                space = line.find(" ")
+                if space < 0:
+                    continue
+                key, value = line[:space], line[space + 1 :]
+                if key in keys and value:
+                    path = Path(value)
+                    if path.exists():
+                        return path
+    except OSError:
+        return None
+    return None
+
+
+def rlocation(relpath: str) -> Path:
+    root = _runfiles_root()
+    if root is not None:
+        for candidate in (root / relpath, root / "_main" / relpath):
+            if candidate.exists():
+                return candidate
+
+    from_manifest = _rlocation_from_manifest(relpath)
+    if from_manifest is not None:
+        return from_manifest
+
+    raise FileNotFoundError(relpath)
+
+
+def _dtest_binary() -> Path:
+    for name in ("library/tests/dtest", "library/tests/dtest.exe"):
+        try:
+            return rlocation(name)
+        except FileNotFoundError:
+            continue
+    raise FileNotFoundError("library/tests/dtest[.exe]")
+
+
+# Same deal twice; intentional wrong PAR goldens so both would mismatch if
+# dtest kept going past the first difference.
+_MISMATCH_HANDS = """\
+NUMBER 2 
+PBN 0 0 0 0 "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3" 
+FUT 0 
+TABLE 5 8 5 8 6 6 6 6 5 7 5 7 7 5 7 5 6 6 6 6 
+PAR "NS -999" "EW 999" "NS:EW 7N" "EW:EW 7N" 
+PAR2 "-999" "7N-EW" 
+PLAY 0 "" 
+TRACE 1 0 
+PBN 0 0 0 0 "N:QJ6.K652.J85.T98 873.J97.AT764.Q4 K5.T83.KQ9.A7652 AT942.AQ4.32.KJ3" 
+FUT 0 
+TABLE 5 8 5 8 6 6 6 6 5 7 5 7 7 5 7 5 6 6 6 6 
+PAR "NS -888" "EW 888" "NS:EW 6N" "EW:EW 6N" 
+PAR2 "-888" "6N-EW" 
+PLAY 0 "" 
+TRACE 1 0 
+"""
+
+
+class DtestMismatchExitTest(unittest.TestCase):
+    def test_dtest_exits_nonzero_on_first_par_mismatch(self) -> None:
+        dtest = _dtest_binary()
+        with tempfile.TemporaryDirectory() as tmp:
+            hands = Path(tmp) / "mismatch.txt"
+            hands.write_text(_MISMATCH_HANDS, encoding="utf-8")
+            proc = subprocess.run(
+                [str(dtest), "-f", str(hands), "-s", "par", "-n", "1"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+
+        self.assertNotEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+        self.assertIn("loop_par i 0: Difference", proc.stdout)
+        self.assertNotIn("loop_par i 1:", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/library/tests/test_timer_test.cpp
+++ b/library/tests/test_timer_test.cpp
@@ -170,3 +170,46 @@ TEST(TestTimer, PrintHandsRestoresStreamFormatState)
   EXPECT_EQ(out.flags(), flags_before);
   EXPECT_EQ(out.precision(), precision_before);
 }
+
+TEST(TestTimer, PrintRunningOverwritesSingleLineWithAnsi)
+{
+  TestTimer timer;
+  timer.record(1, 10, 0);
+  testing::internal::CaptureStdout();
+  timer.print_running(1, 10);
+  timer.record(1, 20, 0);
+  timer.print_running(2, 10);
+  const std::string out = testing::internal::GetCapturedStdout();
+
+  EXPECT_NE(out.find("\033[2K"), std::string::npos);
+  EXPECT_NE(out.find('\r'), std::string::npos);
+  EXPECT_NE(out.find("2 ("), std::string::npos);
+  // In-place updates must not end each progress tick with a newline.
+  EXPECT_EQ(out.find('\n'), std::string::npos);
+}
+
+TEST(TestTimer, FinishRunningClearsProgressLine)
+{
+  TestTimer timer;
+  timer.record(1, 5, 0);
+  testing::internal::CaptureStdout();
+  timer.print_running(1, 1);
+  timer.finish_running();
+  const std::string out = testing::internal::GetCapturedStdout();
+
+  // After finish, the progress line is erased (clear + CR), not kept as a
+  // finalized "100%" row above the summary.
+  ASSERT_FALSE(out.empty());
+  EXPECT_NE(out.find("\033[2K"), std::string::npos);
+  EXPECT_EQ(out.back(), '\r');
+  EXPECT_EQ(out.find('\n'), std::string::npos);
+}
+
+TEST(TestTimer, FinishRunningIsNoOpWithoutPrintRunning)
+{
+  TestTimer timer;
+  testing::internal::CaptureStdout();
+  timer.finish_running();
+  const std::string out = testing::internal::GetCapturedStdout();
+  EXPECT_TRUE(out.empty());
+}

--- a/library/tests/testcommon.cpp
+++ b/library/tests/testcommon.cpp
@@ -101,13 +101,13 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
         &play_list, &trace_list) == false)
   {
     cout << "read_file failed\n";
-    exit(0);
+    return 1;
   }
 
   if (GIBmode && options.solver_ != Solver::DTEST_SOLVER_CALC)
   {
     cout << "GIB file only works with calc\n";
-    exit(0);
+    return 1;
   }
 
   timer.reset();
@@ -122,9 +122,10 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
   if (options.report_slow_boards_)
     board_times.reserve(static_cast<std::size_t>(number));
 
+  bool ok = true;
   if (options.solver_ == Solver::DTEST_SOLVER_SOLVE)
   {
-    loop_solve(
+    ok = loop_solve(
       &bop,
       &solvedbdp,
       deal_list,
@@ -135,27 +136,27 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
   }
   else if (options.solver_ == Solver::DTEST_SOLVER_CALC)
   {
-    loop_calc(deal_list, table_list, number);
+    ok = loop_calc(deal_list, table_list, number);
   }
   else if (options.solver_ == Solver::DTEST_SOLVER_PLAY)
   {
-    loop_play(&bop, &playsp, &solvedplp, deal_list, play_list, trace_list, 
+    ok = loop_play(&bop, &playsp, &solvedplp, deal_list, play_list, trace_list,
       number, stepsize);
   }
   else if (options.solver_ == Solver::DTEST_SOLVER_PAR)
   {
-    loop_par(vul_list, table_list, par_list, number, stepsize);
+    ok = loop_par(vul_list, table_list, par_list, number, stepsize);
   }
   else if (options.solver_ == Solver::DTEST_SOLVER_DEALERPAR)
   {
-    loop_dealerpar(dealer_list, vul_list, table_list, dealerpar_list, 
+    ok = loop_dealerpar(dealer_list, vul_list, table_list, dealerpar_list,
       number, stepsize);
   }
   else
   {
-    cout << "Unknown type " << 
+    cout << "Unknown type " <<
       static_cast<unsigned>(options.solver_) << "\n";
-    exit(0);
+    return 1;
   }
 
   timer.print_hands(cout);
@@ -193,7 +194,7 @@ int real_main([[maybe_unused]] int argc, [[maybe_unused]] char * argv[])
   // Release heavy timing storage before program exit to avoid long destructor work.
   scheduler.ClearTiming();
 
-  return (0);
+  return ok ? 0 : 1;
 }
 
 


### PR DESCRIPTION
## Summary
- Stop dtest on the first API fault or expected-result mismatch and exit non-zero instead of always 0.
- Make `compare_TABLE` verify all `DDS_STRAINS`, including NT.
- Show batch progress on a single ANSI-overwritten line and clear it when the run finishes.
- Show batch progress on `-s calc` runs, including GIB-produced `solXXX.txt` files.

## Test plan
- [x] `bazelisk test //library/tests:loop_par_test //library/tests:compare_test //library/tests:test_timer_test`
- [x] `bazelisk run //library/tests:dtest -- -f hands/list100.txt -s calc` succeeds and leaves no leftover 100% progress row above the timer summary
- [ ] Force a TABLE/PAR mismatch and confirm dtest exits non-zero after reporting only the first difference

## Addresses Issue https://github.com/dds-bridge/dds/issues/334


Made with [Cursor](https://cursor.com)